### PR TITLE
Embed frontend into the Go binary for single-file deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,21 +18,20 @@ COPY backend/go.mod backend/go.sum ./
 RUN go mod download
 
 COPY backend/ ./
+COPY --from=ui-build /src/ui/dist ./internal/static/dist
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/comichero .
 
 FROM alpine:3.22
 RUN adduser -D -H comichero \
-    && mkdir -p /app/public /data \
-    && chown -R comichero /app /data
+    && mkdir -p /data \
+    && chown -R comichero /data
 
 WORKDIR /app
 COPY --from=backend-build /out/comichero /app/comichero
-COPY --from=ui-build /src/ui/dist /app/public
 
 ENV PORT=8080
 ENV DB_PATH=/data/comicorder.db
 ENV COVER_CACHE_DIR=/data/covers
-ENV STATIC_DIR=/app/public
 
 EXPOSE 8080
 VOLUME ["/data"]

--- a/backend/internal/static/.gitignore
+++ b/backend/internal/static/.gitignore
@@ -1,0 +1,4 @@
+# Populated by `npm run build` in ui/ + copy step before `go build`.
+# See static.go for details.
+dist/*
+!dist/.gitkeep

--- a/backend/internal/static/static.go
+++ b/backend/internal/static/static.go
@@ -1,0 +1,21 @@
+// Package static embeds the built frontend (ui/dist) into the compiled
+// binary so the server can run standalone with no external asset directory.
+//
+// The dist/ subdirectory here is populated by the build (see Makefile /
+// Dockerfile: `npm run build` in ui/, then copy ui/dist -> this dist/
+// before `go build`). It is gitignored and empty in source control.
+package static
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed all:dist
+var embedded embed.FS
+
+// FS returns the embedded frontend files rooted at dist/, ready to be
+// served directly (e.g. via http.FS).
+func FS() (fs.FS, error) {
+	return fs.Sub(embedded, "dist")
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"bufio"
+	"bytes"
+	"fmt"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/go-chi/chi/v5"
@@ -15,6 +19,7 @@ import (
 	"github.com/Lofter1/ComicHero/backend/internal/api"
 	"github.com/Lofter1/ComicHero/backend/internal/db"
 	"github.com/Lofter1/ComicHero/backend/internal/metron"
+	"github.com/Lofter1/ComicHero/backend/internal/static"
 )
 
 func main() {
@@ -55,7 +60,9 @@ func main() {
 	api.RegisterCharacterRoutes(humaAPI, database)
 	api.RegisterMetronRoutes(humaAPI, database, metronClient, covers, metronImportJobs)
 	serveCovers(router, "/covers", covers.Dir())
-	serveStatic(router, env("STATIC_DIR", "./public"))
+	if err := serveStatic(router, os.Getenv("STATIC_DIR")); err != nil {
+		log.Fatalf("failed to prepare static assets: %v", err)
+	}
 
 	addr := ":" + env("PORT", "8080")
 	log.Printf("listening on %s", addr)
@@ -79,24 +86,45 @@ func serveCovers(router chi.Router, publicPath, dir string) {
 	}))
 }
 
-func serveStatic(router chi.Router, dir string) {
-	info, err := os.Stat(dir)
-	if err != nil || !info.IsDir() {
-		log.Printf("static dir %q not found; serving API only", dir)
-		return
+// serveStatic serves the frontend. If diskDir is non-empty and exists, it's
+// served straight off disk (handy for local frontend dev). Otherwise it
+// falls back to the frontend embedded into the binary at build time.
+func serveStatic(router chi.Router, diskDir string) error {
+	var fsys fs.FS
+
+	if diskDir != "" {
+		if info, err := os.Stat(diskDir); err == nil && info.IsDir() {
+			log.Printf("serving frontend from disk: %s", diskDir)
+			fsys = os.DirFS(diskDir)
+		} else {
+			log.Printf("STATIC_DIR %q not found; falling back to embedded frontend", diskDir)
+		}
 	}
 
-	files := http.FileServer(http.Dir(dir))
+	if fsys == nil {
+		embedded, err := static.FS()
+		if err != nil {
+			return fmt.Errorf("embedded frontend: %w", err)
+		}
+		fsys = embedded
+	}
+
+	files := http.FileServer(http.FS(fsys))
 	router.Handle("/*", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requestPath := strings.TrimPrefix(filepath.Clean(r.URL.Path), string(filepath.Separator))
-		path := filepath.Join(dir, requestPath)
-		if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		if info, err := fs.Stat(fsys, requestPath); err == nil && !info.IsDir() {
 			files.ServeHTTP(w, r)
 			return
 		}
 
-		http.ServeFile(w, r, filepath.Join(dir, "index.html"))
+		index, err := fs.ReadFile(fsys, "index.html")
+		if err != nil {
+			http.NotFound(w, r)
+			return
+		}
+		http.ServeContent(w, r, "index.html", time.Time{}, bytes.NewReader(index))
 	}))
+	return nil
 }
 
 func env(key, fallback string) string {

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Builds a single, self-contained ComicHero binary: compiles the frontend,
+# copies it into the backend's embed package, then compiles a static Go
+# binary. The result (dist/comichero) needs no other files at runtime
+# besides a writable directory for the SQLite DB and cover cache.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+echo "==> building frontend"
+(cd ui && npm ci && npm run build)
+
+echo "==> embedding frontend into backend"
+rm -rf backend/internal/static/dist
+mkdir -p backend/internal/static/dist
+cp -r ui/dist/. backend/internal/static/dist/
+
+echo "==> building binary"
+mkdir -p dist
+(cd backend && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o ../dist/comichero .)
+
+echo "==> done: dist/comichero"
+echo "    run with: DB_PATH=./data/comicorder.db COVER_CACHE_DIR=./data/covers ./dist/comichero"


### PR DESCRIPTION
- Add backend/internal/static package that //go:embed's the built
  frontend (ui/dist) into the compiled binary.
- serveStatic now serves from the embedded FS by default, falling
  back to STATIC_DIR on disk when set (useful for local frontend dev).
- Dockerfile copies ui/dist into the embed package before go build,
  and the final image no longer needs /app/public or STATIC_DIR.
- Add build.sh to produce a standalone dist/comichero binary outside
  Docker (e.g. for direct deployment to a VPS).
