### PR TITLE
Add release pipeline: cross-platform binaries + GHCR image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,122 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  binaries:
+    name: Build binary (${{ matrix.goos }}/${{ matrix.goarch }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Set up Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          cache: npm
+          cache-dependency-path: ui/package-lock.json
+
+      - name: Install frontend dependencies
+        run: npm ci --prefix ui
+
+      - name: Build standalone binary
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          VERSION: ${{ github.ref_name }}
+          BINARY_NAME: comichero
+        run: make build-standalone
+
+      - name: Package archive
+        run: |
+          set -euo pipefail
+          name="comichero_${{ github.ref_name }}_${{ matrix.goos }}_${{ matrix.goarch }}"
+          mkdir "$name"
+          cp dist/comichero "$name/"
+          cp README.md LICENSE "$name/"
+          tar -czf "$name.tar.gz" "$name"
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: comichero_${{ matrix.goos }}_${{ matrix.goarch }}
+          path: comichero_${{ github.ref_name }}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
+          retention-days: 1
+
+  release:
+    name: Publish GitHub release
+    needs: binaries
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download binary archives
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Publish release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/*/*.tar.gz
+          generate_release_notes: true
+
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v7
+
+      - name: Set image name (lowercase)
+        id: image
+        run: |
+          echo "name=ghcr.io/$(echo '${{ github.repository }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            VERSION=${{ github.ref_name }}
+          tags: |
+            ${{ steps.image.outputs.name }}:${{ github.ref_name }}
+            ${{ steps.image.outputs.name }}:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           name="comichero_${{ github.ref_name }}_${{ matrix.goos }}_${{ matrix.goarch }}"
           mkdir "$name"
           cp dist/comichero "$name/"
-          cp README.md LICENSE "$name/"
+          cp README.md LICENSE .env.example "$name/"
           tar -czf "$name.tar.gz" "$name"
 
       - name: Upload archive

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ RUN go mod download
 
 COPY backend/ ./
 COPY --from=ui-build /src/ui/dist ./internal/static/dist
-RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o /out/comichero .
+ARG VERSION="dev"
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=$VERSION" -o /out/comichero .
 
 FROM alpine:3.22
 RUN adduser -D -H comichero \

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: dev dev-backend dev-ui test test-backend test-ui build build-backend build-ui install-ui embed-ui build-standalone docker-build docker-run compose-up compose-down
+.PHONY: dev dev-backend dev-ui test test-backend test-ui build build-backend build-ui install-ui build-standalone docker-build docker-run compose-up compose-down
 
 GOCACHE ?= $(CURDIR)/tmp/go-build
 export GOCACHE
@@ -11,6 +11,8 @@ IMAGE ?= comichero:latest
 VITE_API_BASE ?= /api
 export VITE_API_BASE
 DIST_DIR ?= dist
+VERSION ?= dev
+BINARY_NAME ?= comichero
 
 dev:
 	@set -e; \
@@ -47,15 +49,13 @@ build-ui:
 install-ui:
 	npm --prefix ui install
 
-embed-ui: build-ui
+build-standalone: build-ui
 	rm -rf backend/internal/static/dist
 	mkdir -p backend/internal/static/dist
 	cp -r ui/dist/. backend/internal/static/dist/
-
-build-standalone: embed-ui
 	mkdir -p $(DIST_DIR)
-	cd backend && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w" -o ../$(DIST_DIR)/comichero .
-	@echo "==> built $(DIST_DIR)/comichero (standalone binary, frontend embedded, no other files needed)"
+	cd backend && CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=$(VERSION)" -o ../$(DIST_DIR)/$(BINARY_NAME) .
+	@echo "==> built $(DIST_DIR)/$(BINARY_NAME) (standalone binary, frontend embedded, no other files needed)"
 
 docker-build:
 	docker build --build-arg VITE_API_BASE=$(VITE_API_BASE) -t $(IMAGE) .

--- a/README.md
+++ b/README.md
@@ -16,25 +16,66 @@ ComicHero is a self-hosted reading-order tracker for comics. It helps you build 
 - Frontend: Vue 3 and Vite.
 - Packaging: Docker and Docker Compose.
 
-## Quick Start With Docker Compose
+## Installation
 
-1. Copy the example environment file:
+### Option 1: Docker (recommended)
+
+Pull the published image and run it directly:
+
+```sh
+docker run -d \
+  --name comichero \
+  -p 8080:8080 \
+  -v comichero-data:/data \
+  ghcr.io/lofter1/comichero:latest
+```
+
+Open `http://localhost:8080`. SQLite data and cached covers live in the `comichero-data` volume.
+
+Images are published on every tagged release (`ghcr.io/lofter1/comichero:v1.2.3`) and `latest` always points at the most recent release. See the [Releases page](https://github.com/Lofter1/ComicHero/releases) for available tags.
+
+### Option 2: Docker Compose
+
+1. Copy the example environment file and optionally add Metron credentials:
 
    ```sh
    cp .env.example .env
    ```
 
-2. Optionally add Metron credentials to `.env`.
-
-3. Start the app:
+2. Start the app:
 
    ```sh
-   docker compose up --build
+   docker compose up
    ```
 
-4. Open `http://localhost:8080`.
+   This pulls `ghcr.io/lofter1/comichero:latest` as defined in `compose.yaml`. To build from a local checkout instead, run `docker compose up --build` (see the commented-out `build: .` line in `compose.yaml`).
 
-SQLite data is stored in the `comichero-data` Docker volume.
+3. Open `http://localhost:8080`.
+
+### Option 3: Prebuilt binary
+
+Each [release](https://github.com/Lofter1/ComicHero/releases) includes standalone binaries for Linux and macOS (amd64 and arm64), with the frontend already embedded. No Docker, Node, or Go required.
+
+```sh
+curl -LO https://github.com/Lofter1/ComicHero/releases/latest/download/comichero_<version>_linux_amd64.tar.gz
+tar -xzf comichero_<version>_linux_amd64.tar.gz
+cd comichero_<version>_linux_amd64
+./comichero
+```
+
+Replace `linux_amd64` with `linux_arm64`, `darwin_amd64`, or `darwin_arm64` as needed. Configure via environment variables (see [Configuration](#configuration)) or a `.env` file next to the binary.
+
+### Option 4: Build from source
+
+Requirements: Go matching `backend/go.mod`, Node.js 24 LTS, npm.
+
+```sh
+make install-ui
+make build-standalone
+./dist/comichero
+```
+
+This builds the frontend, embeds it into the Go binary, and produces a single standalone executable at `dist/comichero` — the same artifact published in releases.
 
 ## Local Development
 
@@ -85,7 +126,7 @@ The backend reads environment variables from the process environment and, when p
 | ----------------- | -------------------------- | --------------------------------------------------- |
 | `PORT`            | `8080`                     | HTTP port for the Go server.                        |
 | `DB_PATH`         | `./data/comicorder.db`     | SQLite database path.                               |
-| `STATIC_DIR`      | `./public`                 | Directory for built frontend assets.                |
+| `STATIC_DIR`      | _(embedded)_                | Optional: serve the frontend from this directory instead of the copy embedded in the binary. Useful for local frontend development. |
 | `COVER_CACHE_DIR` | `./public/covers`          | Directory where downloaded cover images are cached. |
 | `METRON_BASE_URL` | `https://metron.cloud/api` | Metron API base URL.                                |
 | `METRON_USERNAME` | empty                      | Optional Metron username.                           |

--- a/README.md
+++ b/README.md
@@ -18,31 +18,42 @@ ComicHero is a self-hosted reading-order tracker for comics. It helps you build 
 
 ## Installation
 
+Metron credentials are optional and only needed if you want to import comics, reading lists, and series from [Metron](https://metron.cloud/). Every install option below supports setting them either as environment variables (`METRON_USERNAME` / `METRON_PASSWORD`) or via a `.env` file — pick whichever fits the option you're using.
+
 ### Option 1: Docker (recommended)
 
-Pull the published image and run it directly:
+Pull the published image and run it, passing Metron credentials as environment variables if you want them:
 
 ```sh
 docker run -d \
   --name comichero \
   -p 8080:8080 \
   -v comichero-data:/data \
+  -e METRON_USERNAME=your-metron-username \
+  -e METRON_PASSWORD=your-metron-password \
   ghcr.io/lofter1/comichero:latest
 ```
 
-Open `http://localhost:8080`. SQLite data and cached covers live in the `comichero-data` volume.
+Omit the two `-e` lines if you don't need Metron import. Open `http://localhost:8080`. SQLite data and cached covers live in the `comichero-data` volume.
 
 Images are published on every tagged release (`ghcr.io/lofter1/comichero:v1.2.3`) and `latest` always points at the most recent release. See the [Releases page](https://github.com/Lofter1/ComicHero/releases) for available tags.
 
 ### Option 2: Docker Compose
 
-1. Copy the example environment file and optionally add Metron credentials:
+1. Copy the example environment file:
 
    ```sh
    cp .env.example .env
    ```
 
-2. Start the app:
+2. Open `.env` and, if you want Metron import, fill in:
+
+   ```
+   METRON_USERNAME=your-metron-username
+   METRON_PASSWORD=your-metron-password
+   ```
+
+3. Start the app:
 
    ```sh
    docker compose up
@@ -50,26 +61,28 @@ Images are published on every tagged release (`ghcr.io/lofter1/comichero:v1.2.3`
 
    This pulls `ghcr.io/lofter1/comichero:latest` as defined in `compose.yaml`. To build from a local checkout instead, run `docker compose up --build` (see the commented-out `build: .` line in `compose.yaml`).
 
-3. Open `http://localhost:8080`.
+4. Open `http://localhost:8080`.
 
 ### Option 3: Prebuilt binary
 
-Each [release](https://github.com/Lofter1/ComicHero/releases) includes standalone binaries for Linux and macOS (amd64 and arm64), with the frontend already embedded. No Docker, Node, or Go required.
+Each [release](https://github.com/Lofter1/ComicHero/releases) includes standalone binaries for Linux and macOS (amd64 and arm64), with the frontend already embedded, plus a `.env.example` template. No Docker, Node, or Go required.
 
 ```sh
 curl -LO https://github.com/Lofter1/ComicHero/releases/latest/download/comichero_<version>_linux_amd64.tar.gz
 tar -xzf comichero_<version>_linux_amd64.tar.gz
 cd comichero_<version>_linux_amd64
+cp .env.example .env   # optional: fill in METRON_USERNAME / METRON_PASSWORD
 ./comichero
 ```
 
-Replace `linux_amd64` with `linux_arm64`, `darwin_amd64`, or `darwin_arm64` as needed. Configure via environment variables (see [Configuration](#configuration)) or a `.env` file next to the binary.
+Replace `linux_amd64` with `linux_arm64`, `darwin_amd64`, or `darwin_arm64` as needed. The binary reads `.env` from its own directory automatically; see [Configuration](#configuration) for all available variables.
 
 ### Option 4: Build from source
 
 Requirements: Go matching `backend/go.mod`, Node.js 24 LTS, npm.
 
 ```sh
+cp .env.example .env   # optional: fill in METRON_USERNAME / METRON_PASSWORD
 make install-ui
 make build-standalone
 ./dist/comichero

--- a/backend/main.go
+++ b/backend/main.go
@@ -22,6 +22,8 @@ import (
 	"github.com/Lofter1/ComicHero/backend/internal/static"
 )
 
+var version = "dev"
+
 func main() {
 	loadEnvFiles(".env", "../.env")
 
@@ -65,7 +67,7 @@ func main() {
 	}
 
 	addr := ":" + env("PORT", "8080")
-	log.Printf("listening on %s", addr)
+	log.Printf("ComicHero %s listening on %s", version, addr)
 	if err := http.ListenAndServe(addr, router); err != nil {
 		log.Fatalf("server stopped: %v", err)
 	}

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,9 @@
 services:
   comichero:
-    build: .
-    image: comichero:latest
+    image: ghcr.io/lofter1/comichero:latest
+    # Uncomment to build from a local checkout instead of pulling the
+    # published image (`docker compose up --build`):
+    # build: .
     ports:
       - "8080:8080"
     volumes:
@@ -10,7 +12,6 @@ services:
       PORT: "8080"
       DB_PATH: /data/comicorder.db
       COVER_CACHE_DIR: /data/covers
-      STATIC_DIR: /app/public
       METRON_BASE_URL: https://metron.cloud/api
       METRON_USERNAME: ${METRON_USERNAME:-}
       METRON_PASSWORD: ${METRON_PASSWORD:-}


### PR DESCRIPTION
- New workflow (.github/workflows/release.yml), triggered on v*.*.*
  tags:
  - builds standalone binaries for linux/amd64, linux/arm64,
    darwin/amd64, darwin/arm64 via 'make build-standalone' and
    attaches them as .tar.gz archives to a GitHub release.
  - builds and pushes a multi-arch (linux/amd64, linux/arm64) Docker
    image to ghcr.io/lofter1/comichero, tagged with the release
    version and 'latest'.
- Stamp a real version into the binary: main.go now has a 'version'
  var (default 'dev'), set via -X main.version=... in both the
  Makefile (build-standalone) and the Dockerfile, and logged on
  startup.
- Fix compose.yaml: drop the stale STATIC_DIR=/app/public env var
  (no longer valid now that the frontend is embedded in the binary),
  and default to pulling the published image instead of building
  locally, with 'build: .' left available but commented out.
- Update README with install instructions covering all four ways to
  run ComicHero: pull the Docker image, Docker Compose, download a
  prebuilt binary from Releases, or build from source with 'make
  build-standalone'. Also corrects the STATIC_DIR row in the
  configuration table to reflect the embedded-by-default behavior.
