### PR TITLE
Fix user management security issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ The backend reads environment variables from the process environment and, when p
 | `DB_PATH`         | `./data/comicorder.db`     | SQLite database path.                               |
 | `STATIC_DIR`      | _(embedded)_                | Optional: serve the frontend from this directory instead of the copy embedded in the binary. Useful for local frontend development. |
 | `COVER_CACHE_DIR` | `./public/covers`          | Directory where downloaded cover images are cached. |
+| `COOKIE_SECURE`   | `true`                     | Sets the `Secure` flag on session cookies. Set to `false` only when serving ComicHero over plain HTTP in a trusted local setup. |
 | `METRON_BASE_URL` | `https://metron.cloud/api` | Metron API base URL.                                |
 | `METRON_USERNAME` | empty                      | Optional Metron username.                           |
 | `METRON_PASSWORD` | empty                      | Optional Metron password.                           |

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -1031,6 +1031,28 @@ func TestRegisterUserRequiresValidInvite(t *testing.T) {
 	}
 }
 
+func TestExpiredSessionTokenIsRejected(t *testing.T) {
+	db := setupMountedAuthTestDB(t)
+	if _, err := db.Exec(`
+		INSERT INTO user_sessions (token, user_id, expires_at)
+		VALUES ('expired-session', 1, ?)
+	`, time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)); err != nil {
+		t.Fatalf("seed expired session: %v", err)
+	}
+
+	if userID, err := userIDFromSessionToken(context.Background(), db, "expired-session"); err == nil {
+		t.Fatalf("expired session returned user %d, nil error; want error", userID)
+	}
+
+	var count int
+	if err := db.Get(&count, `SELECT COUNT(*) FROM user_sessions WHERE token = 'expired-session'`); err != nil {
+		t.Fatalf("count expired sessions: %v", err)
+	}
+	if count != 0 {
+		t.Fatalf("expired session count = %d; want 0", count)
+	}
+}
+
 func setupMountedAuthTestDB(t *testing.T) *sqlx.DB {
 	t.Helper()
 	db, err := sqlx.Open("sqlite", ":memory:")
@@ -1073,7 +1095,8 @@ func setupMountedAuthTestDB(t *testing.T) *sqlx.DB {
 		CREATE TABLE user_sessions (
 			token TEXT PRIMARY KEY,
 			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			expires_at TEXT NOT NULL DEFAULT ''
 		);
 		CREATE TABLE user_invites (
 			token TEXT PRIMARY KEY,

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -52,6 +52,10 @@ func TestPaginationHelpers(t *testing.T) {
 	}
 }
 
+func testUserContext() context.Context {
+	return context.WithValue(context.Background(), contextUserIDKey{}, 1)
+}
+
 func TestComicListQuery(t *testing.T) {
 	query, args, err := comicListQuery(&ComicListInput{
 		Query:          "bat",
@@ -109,7 +113,7 @@ func TestReadingOrderHelpers(t *testing.T) {
 }
 
 func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db, err := sqlx.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -224,7 +228,7 @@ func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
 
 func TestReadingOrderWritesRequireAuthor(t *testing.T) {
 	db := setupReadingOrderCBLTestDB(t)
-	ctx := context.Background()
+	ctx := testUserContext()
 	ownerCtx := context.WithValue(ctx, contextUserIDKey{}, 2)
 	otherCtx := context.WithValue(ctx, contextUserIDKey{}, 1)
 	if _, err := db.ExecContext(ctx, `INSERT INTO users (id, name, is_default) VALUES (2, 'Owner', 0)`); err != nil {
@@ -269,7 +273,7 @@ func TestReadingOrderWritesRequireAuthor(t *testing.T) {
 }
 
 func TestReadingOrderCBLImportMatchesLocalComicsAndReportsUnmatched(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := setupReadingOrderCBLTestDB(t)
 
 	if _, err := db.Exec(`
@@ -317,7 +321,7 @@ func TestReadingOrderCBLImportMatchesLocalComicsAndReportsUnmatched(t *testing.T
 }
 
 func TestReadingOrderCBLExportBuildsFlatCBLXML(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := setupReadingOrderCBLTestDB(t)
 
 	metronID := 98765
@@ -431,7 +435,7 @@ func setupReadingOrderCBLTestDB(t *testing.T) *sqlx.DB {
 }
 
 func TestArcCreateEntriesFavoriteAndProgress(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db, err := sqlx.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -530,7 +534,7 @@ func TestArcCreateEntriesFavoriteAndProgress(t *testing.T) {
 }
 
 func TestSeriesFavoriteAndProgress(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db, err := sqlx.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -613,7 +617,7 @@ func TestSeriesFavoriteAndProgress(t *testing.T) {
 }
 
 func TestSeriesSyncDoesNotFailWhenPruneFails(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db, err := sqlx.Open("sqlite", ":memory:")
 	if err != nil {
 		t.Fatalf("open db: %v", err)
@@ -776,6 +780,34 @@ func TestMultiUserSetupSetsSessionCookieForProtectedRoutes(t *testing.T) {
 	}
 	if !strings.Contains(withCookie.Body.String(), `"series":"Amazing Spider-Man"`) {
 		t.Fatalf("comics body = %s; want seeded comic", withCookie.Body.String())
+	}
+}
+
+func TestRequireAdminUserFailsWithoutUserContext(t *testing.T) {
+	db := setupMountedAuthTestDB(t)
+
+	if userID, err := requireAdminUser(context.Background(), db); err == nil {
+		t.Fatalf("requireAdminUser without user context = %d, nil; want error", userID)
+	}
+}
+
+func TestPerUserEndpointFailsWithoutUserContext(t *testing.T) {
+	db := setupMountedAuthTestDB(t)
+
+	router := chi.NewRouter()
+	apiRouter := chi.NewRouter()
+	router.Mount("/api", apiRouter)
+	api := humachi.New(apiRouter, DocsConfig())
+	RegisterComicRoutes(api, db, nil)
+
+	recorder := httptest.NewRecorder()
+	body := strings.NewReader(`{"read":true}`)
+	req := httptest.NewRequest(http.MethodPatch, "/api/comic/1/read", body)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(recorder, req)
+
+	if recorder.Code != http.StatusUnauthorized {
+		t.Fatalf("read-status without user context status = %d; want 401: %s", recorder.Code, recorder.Body.String())
 	}
 }
 

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/go-chi/chi/v5"
@@ -978,6 +979,58 @@ func TestAdminCanPromoteOtherUsers(t *testing.T) {
 	}
 }
 
+func TestRegisterUserRequiresValidInvite(t *testing.T) {
+	db := setupMountedAuthTestDB(t)
+	if _, err := db.Exec(`INSERT INTO app_settings (key, value) VALUES ('user_mode', 'multi')`); err != nil {
+		t.Fatalf("seed multi-user mode: %v", err)
+	}
+
+	if _, err := registerUser(context.Background(), db, UserCredentialsPayload{
+		Name:     "No Invite",
+		Password: "secret1",
+	}); err == nil {
+		t.Fatal("registerUser without invite returned nil error")
+	}
+
+	adminCtx := context.WithValue(context.Background(), contextUserIDKey{}, 1)
+	invite, err := createUserInvite(adminCtx, db)
+	if err != nil {
+		t.Fatalf("createUserInvite: %v", err)
+	}
+	if invite.Body.Token == "" || invite.Body.ExpiresAt == "" {
+		t.Fatalf("invite = %#v; want token and expiry", invite.Body)
+	}
+
+	if _, err := registerUser(context.Background(), db, UserCredentialsPayload{
+		Name:        "Invited",
+		Password:    "secret1",
+		InviteToken: invite.Body.Token,
+	}); err != nil {
+		t.Fatalf("registerUser with invite: %v", err)
+	}
+	if _, err := registerUser(context.Background(), db, UserCredentialsPayload{
+		Name:        "Reuse",
+		Password:    "secret1",
+		InviteToken: invite.Body.Token,
+	}); err == nil {
+		t.Fatal("registerUser accepted a used invite")
+	}
+
+	if _, err := db.Exec(`
+		INSERT INTO user_invites (token, expires_at)
+		VALUES ('expired-token', ?)
+	`, time.Now().UTC().Add(-time.Hour).Format(time.RFC3339)); err != nil {
+		t.Fatalf("seed expired invite: %v", err)
+	}
+	if _, err := registerUser(context.Background(), db, UserCredentialsPayload{
+		Name:        "Expired",
+		Password:    "secret1",
+		InviteToken: "expired-token",
+	}); err == nil {
+		t.Fatal("registerUser accepted an expired invite")
+	}
+}
+
 func setupMountedAuthTestDB(t *testing.T) *sqlx.DB {
 	t.Helper()
 	db, err := sqlx.Open("sqlite", ":memory:")
@@ -1020,6 +1073,13 @@ func setupMountedAuthTestDB(t *testing.T) *sqlx.DB {
 		CREATE TABLE user_sessions (
 			token TEXT PRIMARY KEY,
 			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+		);
+		CREATE TABLE user_invites (
+			token TEXT PRIMARY KEY,
+			created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+			expires_at TEXT NOT NULL DEFAULT '',
+			used_at TEXT NOT NULL DEFAULT '',
 			created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
 		);
 		CREATE TABLE user_comics (

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -1053,6 +1053,34 @@ func TestExpiredSessionTokenIsRejected(t *testing.T) {
 	}
 }
 
+func TestSessionCookiesAreSecureByDefaultAndConfigurable(t *testing.T) {
+	db := setupMountedAuthTestDB(t)
+	t.Setenv("COOKIE_SECURE", "")
+
+	cookie, err := createSession(context.Background(), db, 1)
+	if err != nil {
+		t.Fatalf("createSession: %v", err)
+	}
+	if !cookie.Secure {
+		t.Fatal("session cookie Secure = false; want true by default")
+	}
+	if expired := expiredSessionCookie(); !expired.Secure {
+		t.Fatal("expired session cookie Secure = false; want true by default")
+	}
+
+	t.Setenv("COOKIE_SECURE", "false")
+	cookie, err = createSession(context.Background(), db, 1)
+	if err != nil {
+		t.Fatalf("createSession with COOKIE_SECURE=false: %v", err)
+	}
+	if cookie.Secure {
+		t.Fatal("session cookie Secure = true; want false when COOKIE_SECURE=false")
+	}
+	if expired := expiredSessionCookie(); expired.Secure {
+		t.Fatal("expired session cookie Secure = true; want false when COOKIE_SECURE=false")
+	}
+}
+
 func setupMountedAuthTestDB(t *testing.T) *sqlx.DB {
 	t.Helper()
 	db, err := sqlx.Open("sqlite", ":memory:")

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"encoding/base64"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -1125,6 +1126,32 @@ func TestSessionCookiesAreSecureByDefaultAndConfigurable(t *testing.T) {
 	}
 	if expired := expiredSessionCookie(); expired.Secure {
 		t.Fatal("expired session cookie Secure = true; want false when COOKIE_SECURE=false")
+	}
+}
+
+func TestPasswordHashUsesCurrentIterationsAndVerifiesOldHashes(t *testing.T) {
+	hash, err := hashPassword("secret1")
+	if err != nil {
+		t.Fatalf("hashPassword: %v", err)
+	}
+	parts := strings.Split(hash, "$")
+	if len(parts) != 4 || parts[1] != "600000" {
+		t.Fatalf("hash = %q; want current iteration count encoded", hash)
+	}
+	if !checkPassword("secret1", hash) {
+		t.Fatal("checkPassword rejected current hash")
+	}
+
+	salt := []byte("0123456789abcdef")
+	key := derivePasswordKey([]byte("secret1"), salt, 120000, 32)
+	oldHash := "pbkdf2_sha256$120000$" +
+		base64.RawStdEncoding.EncodeToString(salt) + "$" +
+		base64.RawStdEncoding.EncodeToString(key)
+	if !checkPassword("secret1", oldHash) {
+		t.Fatal("checkPassword rejected old iteration count")
+	}
+	if !passwordHashNeedsUpgrade(oldHash) {
+		t.Fatal("passwordHashNeedsUpgrade returned false for old hash")
 	}
 }
 

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -784,6 +784,53 @@ func TestMultiUserSetupSetsSessionCookieForProtectedRoutes(t *testing.T) {
 	}
 }
 
+func TestLoginRateLimitReturnsTooManyRequests(t *testing.T) {
+	previousLimiter := authLoginLimiter
+	authLoginLimiter = newLoginRateLimiter(loginRateLimitMaxAttempts, loginRateLimitWindow)
+	t.Cleanup(func() {
+		authLoginLimiter = previousLimiter
+	})
+
+	db := setupMountedAuthTestDB(t)
+	hash, err := hashPassword("secret1")
+	if err != nil {
+		t.Fatalf("hash password: %v", err)
+	}
+	if _, err := db.Exec(`
+		INSERT INTO app_settings (key, value) VALUES ('user_mode', 'multi');
+		UPDATE users SET name = 'Test', password_hash = ? WHERE id = 1;
+	`, hash); err != nil {
+		t.Fatalf("seed login user: %v", err)
+	}
+
+	router := chi.NewRouter()
+	apiRouter := chi.NewRouter()
+	apiRouter.Use(UserMiddleware(db))
+	router.Mount("/api", apiRouter)
+	api := humachi.New(apiRouter, DocsConfig())
+	RegisterUserRoutes(api, db)
+
+	for i := 0; i < loginRateLimitMaxAttempts; i++ {
+		recorder := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"name":"Test","password":"wrong"}`))
+		req.Header.Set("Content-Type", "application/json")
+		req.RemoteAddr = "203.0.113.44:1234"
+		router.ServeHTTP(recorder, req)
+		if recorder.Code == http.StatusTooManyRequests {
+			t.Fatalf("attempt %d status = 429; want not rate-limited yet", i+1)
+		}
+	}
+
+	recorder := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/login", strings.NewReader(`{"name":"Test","password":"wrong"}`))
+	req.Header.Set("Content-Type", "application/json")
+	req.RemoteAddr = "203.0.113.44:1234"
+	router.ServeHTTP(recorder, req)
+	if recorder.Code != http.StatusTooManyRequests {
+		t.Fatalf("rate-limited login status = %d; want 429: %s", recorder.Code, recorder.Body.String())
+	}
+}
+
 func TestRequireAdminUserFailsWithoutUserContext(t *testing.T) {
 	db := setupMountedAuthTestDB(t)
 

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -144,7 +144,8 @@ func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			name TEXT NOT NULL UNIQUE,
 			password_hash TEXT NOT NULL DEFAULT '',
-			is_default INTEGER NOT NULL DEFAULT 0
+			is_default INTEGER NOT NULL DEFAULT 0,
+			is_admin INTEGER NOT NULL DEFAULT 0
 		);
 		CREATE TABLE user_comics (
 			comic_id INTEGER NOT NULL REFERENCES comics(id) ON DELETE CASCADE,
@@ -248,6 +249,19 @@ func TestReadingOrderWritesRequireAuthor(t *testing.T) {
 
 	if _, err := updateReadingOrder(otherCtx, db, created.Body.ID, ReadingOrderPayload{Name: "Nope"}); err == nil {
 		t.Fatalf("updateReadingOrder as non-author succeeded; want error")
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE users SET is_admin = 1 WHERE id = 1`); err != nil {
+		t.Fatalf("promote admin: %v", err)
+	}
+	adminView, err := getReadingOrder(otherCtx, db, created.Body.ID)
+	if err != nil {
+		t.Fatalf("getReadingOrder as admin: %v", err)
+	}
+	if !adminView.Body.CanEdit {
+		t.Fatalf("admin canEdit = false; want true")
+	}
+	if _, err := updateReadingOrder(otherCtx, db, created.Body.ID, ReadingOrderPayload{Name: "Admin update"}); err != nil {
+		t.Fatalf("updateReadingOrder as admin: %v", err)
 	}
 	if _, err := updateReadingOrder(ownerCtx, db, created.Body.ID, ReadingOrderPayload{Name: "Updated"}); err != nil {
 		t.Fatalf("updateReadingOrder as author: %v", err)
@@ -385,7 +399,8 @@ func setupReadingOrderCBLTestDB(t *testing.T) *sqlx.DB {
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			name TEXT NOT NULL UNIQUE,
 			password_hash TEXT NOT NULL DEFAULT '',
-			is_default INTEGER NOT NULL DEFAULT 0
+			is_default INTEGER NOT NULL DEFAULT 0,
+			is_admin INTEGER NOT NULL DEFAULT 0
 		);
 		CREATE TABLE user_comics (
 			comic_id INTEGER NOT NULL REFERENCES comics(id) ON DELETE CASCADE,
@@ -902,6 +917,32 @@ func TestMetronPermissionsControlScopesAndHourlyLimit(t *testing.T) {
 	}
 	if err := authorizeMetron(readerCtx, db, metronScopeSearch, "GET /metron/series"); err == nil {
 		t.Fatal("authorize search returned nil after hourly limit was reached")
+	}
+}
+
+func TestAdminCanPromoteOtherUsers(t *testing.T) {
+	db := setupMountedAuthTestDB(t)
+	if _, err := db.Exec(`
+		INSERT INTO users (id, name, is_admin) VALUES (2, 'Reader', 0)
+	`); err != nil {
+		t.Fatalf("create reader user: %v", err)
+	}
+
+	adminCtx := context.WithValue(context.Background(), contextUserIDKey{}, 1)
+	output, err := updateUserAdmin(adminCtx, db, 2, UpdateUserAdminPayload{IsAdmin: true})
+	if err != nil {
+		t.Fatalf("updateUserAdmin promote: %v", err)
+	}
+	if !output.Body.User.IsAdmin {
+		t.Fatalf("promoted user isAdmin = false; want true")
+	}
+
+	readerCtx := context.WithValue(context.Background(), contextUserIDKey{}, 2)
+	if _, err := updateUserAdmin(readerCtx, db, 1, UpdateUserAdminPayload{IsAdmin: false}); err != nil {
+		t.Fatalf("promoted user should be able to update admin roles: %v", err)
+	}
+	if _, err := updateUserAdmin(readerCtx, db, 2, UpdateUserAdminPayload{IsAdmin: false}); err == nil {
+		t.Fatal("updateUserAdmin allowed current user to remove own admin role")
 	}
 }
 

--- a/backend/internal/api/cover_cache_test.go
+++ b/backend/internal/api/cover_cache_test.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"bytes"
-	"context"
 	"image"
 	"image/color"
 	"image/jpeg"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestCreateComicDownloadsRemoteCover(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/png")
@@ -66,7 +65,7 @@ func TestCreateComicDownloadsRemoteCover(t *testing.T) {
 }
 
 func TestImportMetronComicDownloadsRemoteCover(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/jpeg")
@@ -89,7 +88,7 @@ func TestImportMetronComicDownloadsRemoteCover(t *testing.T) {
 }
 
 func TestSyncMetronCharactersDownloadsRemoteImage(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "image/png")

--- a/backend/internal/api/metron.go
+++ b/backend/internal/api/metron.go
@@ -176,7 +176,7 @@ func RegisterMetronRoutes(api huma.API, db *sqlx.DB, client *metron.Client, cove
 		if err := authorizeMetron(ctx, db, metronScopeImport, "POST /metron/comics/{id}/import"); err != nil {
 			return nil, err
 		}
-		job := startMetronComicImportWithOptions(importJobs, db, client, covers, input.ID, input.Body)
+		job := startMetronComicImportWithOptions(ctx, importJobs, db, client, covers, input.ID, input.Body)
 		return &MetronImportJobOutput{Body: job}, nil
 	})
 
@@ -267,7 +267,7 @@ func RegisterMetronRoutes(api huma.API, db *sqlx.DB, client *metron.Client, cove
 		if err := authorizeMetron(ctx, db, metronScopeImport, "POST /metron/readingLists/{id}/import"); err != nil {
 			return nil, err
 		}
-		job := startMetronReadingListImportWithOptions(importJobs, db, client, covers, input.ID, input.Body)
+		job := startMetronReadingListImportWithOptions(ctx, importJobs, db, client, covers, input.ID, input.Body)
 		return &MetronImportJobOutput{Body: job}, nil
 	})
 
@@ -322,7 +322,7 @@ func RegisterMetronRoutes(api huma.API, db *sqlx.DB, client *metron.Client, cove
 		if err := authorizeMetron(ctx, db, metronScopeImport, "POST /metron/arcs/{id}/import"); err != nil {
 			return nil, err
 		}
-		job := startMetronArcImportWithOptions(importJobs, db, client, covers, input.ID, input.Body)
+		job := startMetronArcImportWithOptions(ctx, importJobs, db, client, covers, input.ID, input.Body)
 		return &MetronImportJobOutput{Body: job}, nil
 	})
 
@@ -381,7 +381,7 @@ func RegisterMetronRoutes(api huma.API, db *sqlx.DB, client *metron.Client, cove
 		if err := authorizeMetron(ctx, db, metronScopeImport, "POST /metron/characters/{id}/import"); err != nil {
 			return nil, err
 		}
-		job := startMetronCharacterAppearancesImportWithOptions(importJobs, db, client, covers, input.ID, input.Body)
+		job := startMetronCharacterAppearancesImportWithOptions(ctx, importJobs, db, client, covers, input.ID, input.Body)
 		return &MetronImportJobOutput{Body: job}, nil
 	})
 
@@ -398,7 +398,7 @@ func RegisterMetronRoutes(api huma.API, db *sqlx.DB, client *metron.Client, cove
 		if err := authorizeMetron(ctx, db, metronScopeImport, "POST /metron/series/{id}/import"); err != nil {
 			return nil, err
 		}
-		job := startMetronSeriesImportWithOptions(importJobs, db, client, covers, input.ID, input.Body)
+		job := startMetronSeriesImportWithOptions(ctx, importJobs, db, client, covers, input.ID, input.Body)
 		return &MetronImportJobOutput{Body: job}, nil
 	})
 
@@ -528,7 +528,7 @@ func RegisterMetronRoutes(api huma.API, db *sqlx.DB, client *metron.Client, cove
 		if err := authorizeMetron(ctx, db, metronScopeImport, "POST /metron/imports/{id}/continue"); err != nil {
 			return nil, err
 		}
-		return continueMetronImportJob(importJobs, db, client, covers, input.ID)
+		return continueMetronImportJob(ctx, importJobs, db, client, covers, input.ID)
 	})
 }
 

--- a/backend/internal/api/metron.go
+++ b/backend/internal/api/metron.go
@@ -625,7 +625,7 @@ func importMetronComicWithOptions(ctx context.Context, db *sqlx.DB, client *metr
 					return nil, err
 				}
 			}
-			return getComic(contextWithDefaultUser(ctx, db), db, id)
+			return getComic(ctx, db, id)
 		}
 	}
 
@@ -648,7 +648,7 @@ func importMetronComicWithOptions(ctx context.Context, db *sqlx.DB, client *metr
 				return nil, err
 			}
 		}
-		return getComic(contextWithDefaultUser(ctx, db), db, id)
+		return getComic(ctx, db, id)
 	}
 
 	return createMetronComicWithOptions(ctx, db, client, covers, issue, options)
@@ -667,7 +667,7 @@ func importMetronComicSweep(ctx context.Context, db *sqlx.DB, client *metron.Cli
 					return nil, err
 				}
 				if complete {
-					return getComic(contextWithDefaultUser(ctx, db), db, id)
+					return getComic(ctx, db, id)
 				}
 			}
 		}
@@ -696,7 +696,7 @@ func importMetronComicSweep(ctx context.Context, db *sqlx.DB, client *metron.Cli
 			if id, ok, err := existingComicIDByMetronIssueID(ctx, db, issue.ID); err != nil {
 				return nil, err
 			} else if ok {
-				return getComic(contextWithDefaultUser(ctx, db), db, id)
+				return getComic(ctx, db, id)
 			}
 			detail, issueInfo, err = fetchMetronIssue(ctx, db, client, issue.ID, true)
 			if err != nil {
@@ -860,7 +860,7 @@ func createMetronComicWithOptions(ctx context.Context, db *sqlx.DB, client *metr
 		return nil, huma.Error500InternalServerError("failed to get imported comic id")
 	}
 	if payload.Read {
-		if err := setComicReadStatusForCurrentUser(contextWithDefaultUser(ctx, db), db, int(id), payload.Read); err != nil {
+		if err := setComicReadStatusForCurrentUser(ctx, db, int(id), payload.Read); err != nil {
 			return nil, err
 		}
 	}
@@ -875,7 +875,7 @@ func createMetronComicWithOptions(ctx context.Context, db *sqlx.DB, client *metr
 			return nil, err
 		}
 	}
-	return getComic(contextWithDefaultUser(ctx, db), db, int(id))
+	return getComic(ctx, db, int(id))
 }
 
 func updateComicFromMetron(ctx context.Context, db *sqlx.DB, client *metron.Client, covers *CoverCache, comicID int, issue metron.Issue) (*ComicDetailOutput, error) {
@@ -916,7 +916,7 @@ func updateComicFromMetron(ctx context.Context, db *sqlx.DB, client *metron.Clie
 	if err := syncMetronIssueCharacters(ctx, db, covers, comicID, issue); err != nil {
 		return nil, err
 	}
-	return getComic(contextWithDefaultUser(ctx, db), db, comicID)
+	return getComic(ctx, db, comicID)
 }
 
 func importMetronReadingList(ctx context.Context, db *sqlx.DB, client *metron.Client, covers *CoverCache, list metron.ReadingList) (*ReadingOrderDetailOutput, error) {

--- a/backend/internal/api/metron_import_test.go
+++ b/backend/internal/api/metron_import_test.go
@@ -57,7 +57,8 @@ func newMetronImportTestDB(t *testing.T) *sqlx.DB {
 		CREATE TABLE users (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			name TEXT NOT NULL UNIQUE,
-			is_default INTEGER NOT NULL DEFAULT 0
+			is_default INTEGER NOT NULL DEFAULT 0,
+			is_admin INTEGER NOT NULL DEFAULT 0
 		);
 		CREATE TABLE user_comics (
 			comic_id INTEGER NOT NULL REFERENCES comics(id) ON DELETE CASCADE,

--- a/backend/internal/api/metron_import_test.go
+++ b/backend/internal/api/metron_import_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -170,7 +169,7 @@ func serverNextURL(r *http.Request, path string) string {
 }
 
 func TestImportMetronComicReusesExistingMetronComic(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 	issue := metron.Issue{
 		ID:         101,
@@ -202,7 +201,7 @@ func TestImportMetronComicReusesExistingMetronComic(t *testing.T) {
 }
 
 func TestMetronConditionalRequestRequiresFullSyncState(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 	if _, err := db.ExecContext(ctx, `
 		INSERT INTO comics (series, series_year, issue, publisher, metron_issue_id)
@@ -267,7 +266,7 @@ func TestMetronConditionalRequestRequiresFullSyncState(t *testing.T) {
 }
 
 func TestImportMetronComicPreservesIssueNumberSuffix(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	comic, err := importMetronComic(ctx, db, nil, nil, metron.Issue{
@@ -299,7 +298,7 @@ func TestImportMetronComicPreservesIssueNumberSuffix(t *testing.T) {
 }
 
 func TestImportMetronComicSavesCharacterAppearancesAndAliases(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 	issue := metron.Issue{
 		ID:         101,
@@ -344,7 +343,7 @@ func TestImportMetronComicSavesCharacterAppearancesAndAliases(t *testing.T) {
 }
 
 func TestQuickImportMetronComicSavesArcRelationshipWithoutFetchingArc(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	requests := map[string]int{}
@@ -383,7 +382,7 @@ func TestQuickImportMetronComicSavesArcRelationshipWithoutFetchingArc(t *testing
 }
 
 func TestFullImportMetronComicExpandsArcMetadataWithoutIssueList(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	requests := map[string]int{}
@@ -432,7 +431,7 @@ func TestFullImportMetronComicExpandsArcMetadataWithoutIssueList(t *testing.T) {
 }
 
 func TestListCharactersReturnsFavoriteAndProgress(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	if _, err := db.ExecContext(ctx, `
@@ -463,7 +462,7 @@ func TestListCharactersReturnsFavoriteAndProgress(t *testing.T) {
 }
 
 func TestImportMetronComicDoesNotFetchCharacterDetails(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	requests := map[string]int{}
@@ -494,7 +493,7 @@ func TestImportMetronComicDoesNotFetchCharacterDetails(t *testing.T) {
 }
 
 func TestImportMetronComicSkipsExistingCharacterImport(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	if _, err := db.ExecContext(ctx, `
@@ -548,7 +547,7 @@ func TestImportMetronComicSkipsExistingCharacterImport(t *testing.T) {
 }
 
 func TestImportCharacterAppearancesFromMetron(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	if _, err := db.ExecContext(ctx, `
@@ -659,7 +658,7 @@ func TestStartMetronCharacterAppearancesImport(t *testing.T) {
 
 	store := newMetronImportJobStore()
 	client := metron.New(metron.Config{BaseURL: server.URL})
-	job := startMetronCharacterAppearancesImport(store, db, client, nil, 301)
+	job := startMetronCharacterAppearancesImport(testUserContext(), store, db, client, nil, 301)
 
 	var current MetronImportJob
 	for range 100 {
@@ -685,7 +684,7 @@ func TestStartMetronCharacterAppearancesImport(t *testing.T) {
 }
 
 func TestImportMetronReadingListReusesExistingOrderAndComics(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 	list := metron.ReadingList{
 		ID:          501,
@@ -745,7 +744,7 @@ func TestImportMetronReadingListReusesExistingOrderAndComics(t *testing.T) {
 }
 
 func TestContinueMetronReadingListFillsExistingOrder(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	if _, err := db.ExecContext(ctx, `
@@ -799,7 +798,7 @@ func TestContinueMetronReadingListFillsExistingOrder(t *testing.T) {
 }
 
 func TestMetronReadingListLinksComicsDuringImportProgress(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	progressLinkedCounts := []int{}
@@ -850,7 +849,7 @@ func TestMetronReadingListLinksComicsDuringImportProgress(t *testing.T) {
 }
 
 func TestUpdateComicReadStatus(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	if _, err := db.ExecContext(ctx, `
@@ -885,7 +884,7 @@ func TestUpdateComicReadStatus(t *testing.T) {
 }
 
 func TestImportMetronSeriesSkipsDetailFetchForExistingComic(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	if _, err := db.ExecContext(ctx, `
@@ -928,7 +927,7 @@ func TestImportMetronSeriesSkipsDetailFetchForExistingComic(t *testing.T) {
 }
 
 func TestImportMetronSeriesOptionsControlDetailFetches(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 
 	requests := map[string]int{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -975,7 +974,7 @@ func TestImportMetronSeriesOptionsControlDetailFetches(t *testing.T) {
 }
 
 func TestImportLocalSeriesFromMetronUpdatesMetadataAndImportsMissingComics(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	if _, err := db.ExecContext(ctx, `
@@ -1062,7 +1061,7 @@ func TestImportLocalSeriesFromMetronUpdatesMetadataAndImportsMissingComics(t *te
 }
 
 func TestUpdateSeriesMetronMetadataKeepsLocalRowOnNameYearConflict(t *testing.T) {
-	ctx := context.Background()
+	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 
 	if _, err := db.ExecContext(ctx, `

--- a/backend/internal/api/metron_jobs.go
+++ b/backend/internal/api/metron_jobs.go
@@ -83,8 +83,12 @@ func (s *metronImportJobStore) start(jobType string, metronID int, message strin
 }
 
 func (s *metronImportJobStore) startWithOptions(jobType string, metronID int, options MetronImportOptions, message string, run func(context.Context, func(int, int, string)) error) MetronImportJob {
+	return s.startWithContextAndOptions(context.Background(), jobType, metronID, options, message, run)
+}
+
+func (s *metronImportJobStore) startWithContextAndOptions(parent context.Context, jobType string, metronID int, options MetronImportOptions, message string, run func(context.Context, func(int, int, string)) error) MetronImportJob {
 	id := fmt.Sprintf("metron-%d", s.nextID.Add(1))
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(context.WithoutCancel(parent))
 	job := &MetronImportJob{
 		ID:        id,
 		Type:      jobType,
@@ -412,9 +416,9 @@ func (o MetronImportOptions) needsIssueDetail() bool {
 	return o.includesComics() || o.includesSeries() || o.includesArcs() || o.includesCharacters()
 }
 
-func startMetronComicImportWithOptions(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
+func startMetronComicImportWithOptions(parent context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
 	options = resolveMetronImportOptions(options)
-	return store.startWithOptions("comic", metronID, options, "Importing comic from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
+	return store.startWithContextAndOptions(parent, "comic", metronID, options, "Importing comic from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
 		progress(0, 1, "Checking existing imports...")
 		if _, ok, err := existingComicIDByMetronIssueID(ctx, db, metronID); err != nil || ok {
 			if ok && options.Mode != "full" && !options.Force {
@@ -458,9 +462,9 @@ func startMetronComicImportWithOptions(store *metronImportJobStore, db *sqlx.DB,
 	})
 }
 
-func startMetronReadingListImportWithOptions(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
+func startMetronReadingListImportWithOptions(parent context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
 	options = resolveMetronImportOptions(options)
-	return store.startWithOptions("readingList", metronID, options, "Importing reading list and issues from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
+	return store.startWithContextAndOptions(parent, "readingList", metronID, options, "Importing reading list and issues from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
 		progress(0, 0, "Checking existing imports...")
 		existingID, existing, err := existingReadingOrderIDByMetronID(ctx, db, metronID)
 		if err != nil || existing {
@@ -509,9 +513,9 @@ func startMetronReadingListImportWithOptions(store *metronImportJobStore, db *sq
 	})
 }
 
-func startMetronArcImportWithOptions(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
+func startMetronArcImportWithOptions(parent context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
 	options = resolveMetronImportOptions(options)
-	return store.startWithOptions("arc", metronID, options, "Importing arc and issues from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
+	return store.startWithContextAndOptions(parent, "arc", metronID, options, "Importing arc and issues from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
 		progress(0, 0, "Checking existing imports...")
 		if _, ok, err := existingArcIDByMetronID(ctx, db, metronID); err != nil || ok {
 			if ok && options.Mode != "full" && !options.Force {
@@ -551,9 +555,9 @@ func startMetronArcImportWithOptions(store *metronImportJobStore, db *sqlx.DB, c
 	})
 }
 
-func startMetronSeriesImportWithOptions(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
+func startMetronSeriesImportWithOptions(parent context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
 	options = resolveMetronImportOptions(options)
-	return store.startWithOptions("series", metronID, options, "Importing series from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
+	return store.startWithContextAndOptions(parent, "series", metronID, options, "Importing series from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
 		progress(0, 0, "Fetching series metadata from Metron...")
 		metadata, info, err := fetchMetronSeries(ctx, db, client, metronID, options.Force)
 		if err != nil {
@@ -589,8 +593,8 @@ func startMetronSeriesImportWithOptions(store *metronImportJobStore, db *sqlx.DB
 	})
 }
 
-func startLocalSeriesMetronImport(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, localID, metronID int) MetronImportJob {
-	return store.startWithOptions("series", metronID, defaultMetronImportOptions(), "Importing series from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
+func startLocalSeriesMetronImport(parent context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, localID, metronID int) MetronImportJob {
+	return store.startWithContextAndOptions(parent, "series", metronID, defaultMetronImportOptions(), "Importing series from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
 		progress(0, 0, "Fetching series metadata from Metron...")
 		metadata, info, err := fetchMetronSeries(ctx, db, client, metronID, false)
 		if err != nil {
@@ -623,13 +627,13 @@ func startLocalSeriesMetronImport(store *metronImportJobStore, db *sqlx.DB, clie
 	})
 }
 
-func startMetronCharacterAppearancesImport(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int) MetronImportJob {
-	return startMetronCharacterAppearancesImportWithOptions(store, db, client, covers, metronID, defaultMetronImportOptions())
+func startMetronCharacterAppearancesImport(parent context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int) MetronImportJob {
+	return startMetronCharacterAppearancesImportWithOptions(parent, store, db, client, covers, metronID, defaultMetronImportOptions())
 }
 
-func startMetronCharacterAppearancesImportWithOptions(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
+func startMetronCharacterAppearancesImportWithOptions(parent context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
 	options = resolveMetronImportOptions(options)
-	return store.startWithOptions("character", metronID, options, "Importing character from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
+	return store.startWithContextAndOptions(parent, "character", metronID, options, "Importing character from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
 		progress(0, 0, "Preparing character appearance import...")
 		return importMetronCharacterAppearancesWithProgressOptions(ctx, db, client, covers, metronID, progress, options)
 	})
@@ -697,7 +701,7 @@ func cancelMetronImportJob(store *metronImportJobStore, id string) (*MetronImpor
 	return &MetronImportJobOutput{Body: job}, nil
 }
 
-func continueMetronImportJob(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, id string) (*MetronImportJobOutput, error) {
+func continueMetronImportJob(ctx context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, id string) (*MetronImportJobOutput, error) {
 	job, ok := store.get(id)
 	if !ok {
 		return nil, huma.Error404NotFound("import job not found")
@@ -709,24 +713,24 @@ func continueMetronImportJob(store *metronImportJobStore, db *sqlx.DB, client *m
 	var next MetronImportJob
 	switch job.Type {
 	case "comic":
-		next = startMetronComicImportWithOptions(store, db, client, covers, job.MetronID, job.Options)
+		next = startMetronComicImportWithOptions(ctx, store, db, client, covers, job.MetronID, job.Options)
 	case "readingList":
-		next = startMetronReadingListContinue(store, db, client, covers, job.MetronID, job.Options)
+		next = startMetronReadingListContinue(ctx, store, db, client, covers, job.MetronID, job.Options)
 	case "arc":
-		next = startMetronArcContinue(store, db, client, covers, job.MetronID, job.Options)
+		next = startMetronArcContinue(ctx, store, db, client, covers, job.MetronID, job.Options)
 	case "series":
-		next = startMetronSeriesImportWithOptions(store, db, client, covers, job.MetronID, job.Options)
+		next = startMetronSeriesImportWithOptions(ctx, store, db, client, covers, job.MetronID, job.Options)
 	case "character":
-		next = startMetronCharacterAppearancesImportWithOptions(store, db, client, covers, job.MetronID, job.Options)
+		next = startMetronCharacterAppearancesImportWithOptions(ctx, store, db, client, covers, job.MetronID, job.Options)
 	default:
 		return nil, huma.Error400BadRequest("unsupported import type")
 	}
 	return &MetronImportJobOutput{Body: next}, nil
 }
 
-func startMetronArcContinue(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
+func startMetronArcContinue(parent context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
 	options = resolveMetronImportOptions(options)
-	return store.startWithOptions("arc", metronID, options, "Continuing arc import from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
+	return store.startWithContextAndOptions(parent, "arc", metronID, options, "Continuing arc import from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
 		progress(0, 0, "Fetching arc from Metron...")
 		arc, info, err := fetchMetronArc(ctx, db, client, metronID, options.Force)
 		if err != nil {
@@ -755,9 +759,9 @@ func startMetronArcContinue(store *metronImportJobStore, db *sqlx.DB, client *me
 	})
 }
 
-func startMetronReadingListContinue(store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
+func startMetronReadingListContinue(parent context.Context, store *metronImportJobStore, db *sqlx.DB, client *metron.Client, covers *CoverCache, metronID int, options MetronImportOptions) MetronImportJob {
 	options = resolveMetronImportOptions(options)
-	return store.startWithOptions("readingList", metronID, options, "Continuing reading list import from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
+	return store.startWithContextAndOptions(parent, "readingList", metronID, options, "Continuing reading list import from Metron...", func(ctx context.Context, progress func(int, int, string)) error {
 		forceMetadata := options.Force
 		if existingID, ok, err := existingReadingOrderIDByMetronID(ctx, db, metronID); err != nil {
 			return err

--- a/backend/internal/api/metron_jobs_test.go
+++ b/backend/internal/api/metron_jobs_test.go
@@ -95,6 +95,32 @@ func TestMetronImportJobCancelingDoesNotBecomeSucceeded(t *testing.T) {
 	}
 }
 
+func TestMetronImportJobKeepsTriggeringUserContext(t *testing.T) {
+	store := newMetronImportJobStore()
+	parent, cancel := context.WithCancel(context.WithValue(context.Background(), contextUserIDKey{}, 42))
+	cancel()
+
+	seenUserID := make(chan int, 1)
+	job := store.startWithContextAndOptions(parent, "series", 123, defaultMetronImportOptions(), "Starting...", func(ctx context.Context, progress func(int, int, string)) error {
+		userID, err := currentUserID(ctx)
+		if err != nil {
+			return err
+		}
+		seenUserID <- userID
+		return nil
+	})
+
+	select {
+	case userID := <-seenUserID:
+		if userID != 42 {
+			t.Fatalf("job user id = %d; want 42", userID)
+		}
+	case <-time.After(time.Second):
+		current, _ := store.get(job.ID)
+		t.Fatalf("job did not report user id; status = %q message = %q", current.Status, current.Message)
+	}
+}
+
 func TestContextCanceledStringIsTreatedAsCancellation(t *testing.T) {
 	err := fmt.Errorf(`Get "https://metron.cloud/api/issue/335/": context canceled`)
 	if !isContextCanceledError(err) {

--- a/backend/internal/api/models.go
+++ b/backend/internal/api/models.go
@@ -54,6 +54,15 @@ type UpdateUserMetronPermissionsInput struct {
 	Body UserMetronPermissions
 }
 
+type UpdateUserAdminPayload struct {
+	IsAdmin bool `json:"isAdmin" doc:"Whether the user should be an admin." example:"true"`
+}
+
+type UpdateUserAdminInput struct {
+	ID   int `path:"id" doc:"Local user identifier." example:"2"`
+	Body UpdateUserAdminPayload
+}
+
 type UserAdminOutput struct {
 	Body UserAdminView
 }

--- a/backend/internal/api/models.go
+++ b/backend/internal/api/models.go
@@ -49,6 +49,15 @@ type UserListOutput struct {
 	Body []UserAdminView
 }
 
+type UserInvite struct {
+	Token     string `json:"token"     doc:"Single-use invite token."`
+	ExpiresAt string `json:"expiresAt" doc:"RFC3339 expiry time for this invite."`
+}
+
+type UserInviteOutput struct {
+	Body UserInvite
+}
+
 type UpdateUserMetronPermissionsInput struct {
 	ID   int `path:"id" doc:"Local user identifier." example:"2"`
 	Body UserMetronPermissions
@@ -102,8 +111,9 @@ type SetupUsersInput struct {
 }
 
 type UserCredentialsPayload struct {
-	Name     string `json:"name"     minLength:"1" doc:"User name." example:"Justin"`
-	Password string `json:"password" minLength:"6" doc:"Password." example:"correct horse battery staple"`
+	Name        string `json:"name"                  minLength:"1" doc:"User name." example:"Justin"`
+	Password    string `json:"password"              minLength:"6" doc:"Password." example:"correct horse battery staple"`
+	InviteToken string `json:"inviteToken,omitempty" doc:"Invite token required for registration in multi-user mode."`
 }
 
 type RegisterUserInput struct {

--- a/backend/internal/api/readingorders.go
+++ b/backend/internal/api/readingorders.go
@@ -162,7 +162,11 @@ func readingOrderListQuery(input *ReadingOrderListInput, userID int) (string, []
 			ro.image,
 			ro.favorite,
 			COALESCE(author.name, '') AS author_name,
-			CASE WHEN ro.author_user_id = ? THEN 1 ELSE 0 END AS can_edit,
+			CASE
+				WHEN ro.author_user_id = ?
+					OR EXISTS (SELECT 1 FROM users current_user WHERE current_user.id = ? AND current_user.is_admin = 1)
+				THEN 1 ELSE 0
+			END AS can_edit,
 			CASE
 				WHEN COUNT(c.id) = 0 THEN 0.0
 				ELSE CAST(SUM(CASE WHEN COALESCE(uc.read, 0) = 1 THEN 1 ELSE 0 END) AS REAL) / COUNT(c.id)
@@ -173,7 +177,7 @@ func readingOrderListQuery(input *ReadingOrderListInput, userID int) (string, []
 		LEFT JOIN comics c ON c.id = roc.comic_id
 		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
 	`)
-	query.args = append(query.args, userID, userID)
+	query.args = append(query.args, userID, userID, userID)
 
 	if input.Query != "" {
 		search := "%" + input.Query + "%"
@@ -235,11 +239,15 @@ func getReadingOrderRow(ctx context.Context, db *sqlx.DB, id int) (ReadingOrder,
 			ro.favorite,
 			0.0 AS progress,
 			COALESCE(author.name, '') AS author_name,
-			CASE WHEN ro.author_user_id = ? THEN 1 ELSE 0 END AS can_edit
+			CASE
+				WHEN ro.author_user_id = ?
+					OR EXISTS (SELECT 1 FROM users current_user WHERE current_user.id = ? AND current_user.is_admin = 1)
+				THEN 1 ELSE 0
+			END AS can_edit
 		FROM reading_orders ro
 		LEFT JOIN users author ON author.id = ro.author_user_id
 		WHERE ro.id = ?
-	`, userID, id); err != nil {
+	`, userID, userID, id); err != nil {
 		if err == sql.ErrNoRows {
 			return ReadingOrder{}, huma.Error404NotFound("reading order not found")
 		}
@@ -333,7 +341,11 @@ func fetchReadingOrderEntries(ctx context.Context, db *sqlx.DB, readingOrderID i
 			ro.favorite,
 			0.0 AS progress,
 			COALESCE(author.name, '') AS author_name,
-			CASE WHEN ro.author_user_id = ? THEN 1 ELSE 0 END AS can_edit,
+			CASE
+				WHEN ro.author_user_id = ?
+					OR EXISTS (SELECT 1 FROM users current_user WHERE current_user.id = ? AND current_user.is_admin = 1)
+				THEN 1 ELSE 0
+			END AS can_edit,
 			roc.position AS position,
 			roc.note AS comment
 		FROM reading_orders ro
@@ -341,7 +353,7 @@ func fetchReadingOrderEntries(ctx context.Context, db *sqlx.DB, readingOrderID i
 		JOIN reading_order_children roc ON roc.child_reading_order_id = ro.id
 		WHERE roc.parent_reading_order_id = ?
 		ORDER BY roc.position, ro.name
-	`, userID, readingOrderID); err != nil {
+	`, userID, userID, readingOrderID); err != nil {
 		return nil, huma.Error500InternalServerError("failed to fetch child reading orders")
 	}
 
@@ -433,7 +445,7 @@ func createReadingOrder(ctx context.Context, db *sqlx.DB, payload ReadingOrderPa
 }
 
 func updateReadingOrder(ctx context.Context, db *sqlx.DB, id int, payload ReadingOrderPayload) (*ReadingOrderDetailOutput, error) {
-	if err := requireReadingOrderAuthor(ctx, db, id); err != nil {
+	if err := requireReadingOrderEditor(ctx, db, id); err != nil {
 		return nil, err
 	}
 	result, err := db.ExecContext(ctx, `
@@ -452,7 +464,7 @@ func updateReadingOrder(ctx context.Context, db *sqlx.DB, id int, payload Readin
 }
 
 func deleteReadingOrder(ctx context.Context, db *sqlx.DB, id int) (*struct{}, error) {
-	if err := requireReadingOrderAuthor(ctx, db, id); err != nil {
+	if err := requireReadingOrderEditor(ctx, db, id); err != nil {
 		return nil, err
 	}
 	result, err := db.ExecContext(ctx, `
@@ -482,7 +494,7 @@ func setReadingOrderComicsWithAuth(ctx context.Context, db *sqlx.DB, input *SetR
 		return nil, err
 	}
 	if enforceAuthor {
-		if err := requireReadingOrderAuthor(ctx, db, input.ID); err != nil {
+		if err := requireReadingOrderEditor(ctx, db, input.ID); err != nil {
 			return nil, err
 		}
 	}
@@ -542,21 +554,32 @@ func setReadingOrderComicsWithAuth(ctx context.Context, db *sqlx.DB, input *SetR
 	return fetchReadingOrderDetail(ctx, db, ro)
 }
 
-func requireReadingOrderAuthor(ctx context.Context, db *sqlx.DB, id int) error {
+func requireReadingOrderEditor(ctx context.Context, db *sqlx.DB, id int) error {
 	userID, err := currentUserID(ctx)
 	if err != nil {
 		return err
 	}
 
-	var authorID sql.NullInt64
-	if err := db.GetContext(ctx, &authorID, `SELECT author_user_id FROM reading_orders WHERE id = ?`, id); err != nil {
+	var row struct {
+		AuthorID sql.NullInt64 `db:"author_user_id"`
+		IsAdmin  bool          `db:"is_admin"`
+	}
+	if err := db.GetContext(ctx, &row, `
+		SELECT ro.author_user_id, COALESCE(current_user.is_admin, 0) AS is_admin
+		FROM reading_orders ro
+		LEFT JOIN users current_user ON current_user.id = ?
+		WHERE ro.id = ?
+	`, userID, id); err != nil {
 		if err == sql.ErrNoRows {
 			return huma.Error404NotFound("reading order not found")
 		}
 		return huma.Error500InternalServerError("failed to check reading order author")
 	}
-	if !authorID.Valid || int(authorID.Int64) != userID {
-		return huma.Error403Forbidden("only the reading order author can edit it")
+	if row.IsAdmin {
+		return nil
+	}
+	if !row.AuthorID.Valid || int(row.AuthorID.Int64) != userID {
+		return huma.Error403Forbidden("only the reading order author or an admin can edit it")
 	}
 	return nil
 }

--- a/backend/internal/api/series.go
+++ b/backend/internal/api/series.go
@@ -311,7 +311,7 @@ func importLocalSeriesFromMetron(ctx context.Context, db *sqlx.DB, client *metro
 		return nil, err
 	}
 
-	job := startLocalSeriesMetronImport(importJobs, db, client, covers, id, metronID)
+	job := startLocalSeriesMetronImport(ctx, importJobs, db, client, covers, id, metronID)
 	return &MetronImportJobOutput{Body: job}, nil
 }
 

--- a/backend/internal/api/user_permissions.go
+++ b/backend/internal/api/user_permissions.go
@@ -100,6 +100,47 @@ func updateUserMetronPermissions(ctx context.Context, db *sqlx.DB, userID int, p
 	return &UserAdminOutput{Body: UserAdminView{User: user, MetronPermissions: permissions}}, nil
 }
 
+func updateUserAdmin(ctx context.Context, db *sqlx.DB, userID int, payload UpdateUserAdminPayload) (*UserAdminOutput, error) {
+	currentUserID, err := requireAdminUser(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	if userID <= 0 {
+		return nil, huma.Error400BadRequest("user id is required")
+	}
+
+	user, err := getUserByID(ctx, db, userID)
+	if err != nil {
+		return nil, err
+	}
+	if userID == currentUserID && !payload.IsAdmin {
+		return nil, huma.Error400BadRequest("cannot remove your own admin role")
+	}
+	if user.IsAdmin && !payload.IsAdmin {
+		var adminCount int
+		if err := db.GetContext(ctx, &adminCount, `SELECT COUNT(*) FROM users WHERE is_admin = 1`); err != nil {
+			return nil, huma.Error500InternalServerError("failed to count admins")
+		}
+		if adminCount <= 1 {
+			return nil, huma.Error400BadRequest("cannot remove the only admin account")
+		}
+	}
+
+	if _, err := db.ExecContext(ctx, `UPDATE users SET is_admin = ? WHERE id = ?`, payload.IsAdmin, userID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to update admin role")
+	}
+
+	updated, err := getUserByID(ctx, db, userID)
+	if err != nil {
+		return nil, err
+	}
+	permissions, err := metronPermissionsForUser(ctx, db, userID)
+	if err != nil {
+		return nil, err
+	}
+	return &UserAdminOutput{Body: UserAdminView{User: updated, MetronPermissions: permissions}}, nil
+}
+
 func metronPermissionsForUser(ctx context.Context, db *sqlx.DB, userID int) (UserMetronPermissions, error) {
 	var row struct {
 		IsAdmin     bool           `db:"is_admin"`

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -33,6 +34,7 @@ const (
 
 	loginRateLimitMaxAttempts = 5
 	loginRateLimitWindow      = time.Minute
+	passwordHashIterations    = 600000
 )
 
 type contextUserIDKey struct{}
@@ -511,6 +513,12 @@ func loginUser(ctx context.Context, db *sqlx.DB, payload UserCredentialsPayload)
 	if !checkPassword(payload.Password, row.PasswordHash) {
 		return nil, huma.Error401Unauthorized("invalid user name or password")
 	}
+	if passwordHashNeedsUpgrade(row.PasswordHash) {
+		passwordHash, err := hashPassword(payload.Password)
+		if err == nil {
+			_, _ = db.ExecContext(ctx, `UPDATE users SET password_hash = ? WHERE id = ?`, passwordHash, row.ID)
+		}
+	}
 	cookie, err := createSession(ctx, db, row.ID)
 	if err != nil {
 		return nil, err
@@ -812,13 +820,17 @@ func hashPassword(password string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	key := derivePasswordKey([]byte(password), salt, 120000, 32)
-	return fmt.Sprintf("pbkdf2_sha256$120000$%s$%s", base64.RawStdEncoding.EncodeToString(salt), base64.RawStdEncoding.EncodeToString(key)), nil
+	key := derivePasswordKey([]byte(password), salt, passwordHashIterations, 32)
+	return fmt.Sprintf("pbkdf2_sha256$%d$%s$%s", passwordHashIterations, base64.RawStdEncoding.EncodeToString(salt), base64.RawStdEncoding.EncodeToString(key)), nil
 }
 
 func checkPassword(password, encoded string) bool {
 	parts := strings.Split(encoded, "$")
-	if len(parts) != 4 || parts[0] != "pbkdf2_sha256" || parts[1] != "120000" {
+	if len(parts) != 4 || parts[0] != "pbkdf2_sha256" {
+		return false
+	}
+	iterations, err := strconv.Atoi(parts[1])
+	if err != nil || iterations <= 0 {
 		return false
 	}
 	salt, err := base64.RawStdEncoding.DecodeString(parts[2])
@@ -829,8 +841,17 @@ func checkPassword(password, encoded string) bool {
 	if err != nil {
 		return false
 	}
-	actual := derivePasswordKey([]byte(password), salt, 120000, len(expected))
+	actual := derivePasswordKey([]byte(password), salt, iterations, len(expected))
 	return subtle.ConstantTimeCompare(actual, expected) == 1
+}
+
+func passwordHashNeedsUpgrade(encoded string) bool {
+	parts := strings.Split(encoded, "$")
+	if len(parts) != 4 || parts[0] != "pbkdf2_sha256" {
+		return false
+	}
+	iterations, err := strconv.Atoi(parts[1])
+	return err == nil && iterations < passwordHashIterations
 }
 
 func derivePasswordKey(password, salt []byte, iterations, keyLen int) []byte {

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -9,9 +9,11 @@ import (
 	"database/sql"
 	"encoding/base64"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -28,9 +30,51 @@ const (
 	userInviteTokenBytes = 32
 	userInviteTTL        = 7 * 24 * time.Hour
 	sessionTTL           = 30 * 24 * time.Hour
+
+	loginRateLimitMaxAttempts = 5
+	loginRateLimitWindow      = time.Minute
 )
 
 type contextUserIDKey struct{}
+
+var authLoginLimiter = newLoginRateLimiter(loginRateLimitMaxAttempts, loginRateLimitWindow)
+
+type loginRateLimiter struct {
+	maxAttempts int
+	window      time.Duration
+	mu          sync.Mutex
+	attempts    map[string]loginRateLimitEntry
+}
+
+type loginRateLimitEntry struct {
+	count      int
+	windowEnds time.Time
+}
+
+func newLoginRateLimiter(maxAttempts int, window time.Duration) *loginRateLimiter {
+	return &loginRateLimiter{
+		maxAttempts: maxAttempts,
+		window:      window,
+		attempts:    map[string]loginRateLimitEntry{},
+	}
+}
+
+func (l *loginRateLimiter) allow(key string, now time.Time) bool {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	entry := l.attempts[key]
+	if entry.windowEnds.IsZero() || !now.Before(entry.windowEnds) {
+		l.attempts[key] = loginRateLimitEntry{count: 1, windowEnds: now.Add(l.window)}
+		return true
+	}
+	if entry.count >= l.maxAttempts {
+		return false
+	}
+	entry.count++
+	l.attempts[key] = entry
+	return true
+}
 
 func RegisterUserRoutes(api huma.API, db *sqlx.DB) {
 	huma.Register(api, huma.Operation{
@@ -170,6 +214,10 @@ func RegisterUserRoutes(api huma.API, db *sqlx.DB) {
 func UserMiddleware(db *sqlx.DB) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if isLoginRequest(r) && !authLoginLimiter.allow(clientIP(r), time.Now()) {
+				http.Error(w, "too many login attempts, try again later", http.StatusTooManyRequests)
+				return
+			}
 			if isUserRouteAllowedWithoutSession(r.URL.Path) {
 				next.ServeHTTP(w, r)
 				return
@@ -199,6 +247,24 @@ func UserMiddleware(db *sqlx.DB) func(http.Handler) http.Handler {
 			next.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), contextUserIDKey{}, userID)))
 		})
 	}
+}
+
+func isLoginRequest(r *http.Request) bool {
+	path := strings.TrimPrefix(r.URL.Path, "/api")
+	return r.Method == http.MethodPost && path == "/auth/login"
+}
+
+func clientIP(r *http.Request) string {
+	if forwardedFor := strings.TrimSpace(r.Header.Get("X-Forwarded-For")); forwardedFor != "" {
+		if ip := strings.TrimSpace(strings.Split(forwardedFor, ",")[0]); ip != "" {
+			return ip
+		}
+	}
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err == nil && host != "" {
+		return host
+	}
+	return r.RemoteAddr
 }
 
 func isUserRouteAllowedWithoutSession(path string) bool {

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -135,6 +135,18 @@ func RegisterUserRoutes(api huma.API, db *sqlx.DB) {
 	}, func(ctx context.Context, input *UpdateUserMetronPermissionsInput) (*UserAdminOutput, error) {
 		return updateUserMetronPermissions(ctx, db, input.ID, input.Body)
 	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "updateUserAdmin",
+		Tags:        []string{tagUsers},
+		Summary:     "Update user admin role",
+		Description: "Promotes or demotes a user account. Admin users only.",
+		Method:      http.MethodPut,
+		Path:        "/users/{id}/admin",
+		Errors:      []int{400, 401, 403, 404, 500},
+	}, func(ctx context.Context, input *UpdateUserAdminInput) (*UserAdminOutput, error) {
+		return updateUserAdmin(ctx, db, input.ID, input.Body)
+	})
 }
 
 func UserMiddleware(db *sqlx.DB) func(http.Handler) http.Handler {

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -10,6 +10,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -723,11 +724,20 @@ func createSession(ctx context.Context, db *sqlx.DB, userID int) (*http.Cookie, 
 	`, token, userID, expiresAt.Format(time.RFC3339)); err != nil {
 		return nil, huma.Error500InternalServerError("failed to save session")
 	}
-	return &http.Cookie{Name: sessionCookieName, Value: token, Path: "/", Expires: expiresAt, HttpOnly: true, SameSite: http.SameSiteLaxMode}, nil
+	return &http.Cookie{Name: sessionCookieName, Value: token, Path: "/", Expires: expiresAt, HttpOnly: true, Secure: secureSessionCookies(), SameSite: http.SameSiteLaxMode}, nil
 }
 
 func expiredSessionCookie() *http.Cookie {
-	return &http.Cookie{Name: sessionCookieName, Value: "", Path: "/", MaxAge: -1, HttpOnly: true, SameSite: http.SameSiteLaxMode}
+	return &http.Cookie{Name: sessionCookieName, Value: "", Path: "/", MaxAge: -1, HttpOnly: true, Secure: secureSessionCookies(), SameSite: http.SameSiteLaxMode}
+}
+
+func secureSessionCookies() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("COOKIE_SECURE"))) {
+	case "false", "0", "no", "off":
+		return false
+	default:
+		return true
+	}
 }
 
 func cookieHeader(cookie *http.Cookie) []http.Cookie {

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -26,6 +26,7 @@ const (
 
 	userInviteTokenBytes = 32
 	userInviteTTL        = 7 * 24 * time.Hour
+	sessionTTL           = 30 * 24 * time.Hour
 )
 
 type contextUserIDKey struct{}
@@ -693,13 +694,21 @@ func userIDFromSessionToken(ctx context.Context, db *sqlx.DB, token string) (int
 	if token == "" {
 		return 0, huma.Error401Unauthorized("login required")
 	}
-	var userID int
-	if err := db.GetContext(ctx, &userID, `
-		SELECT user_id FROM user_sessions WHERE token = ?
+	var row struct {
+		UserID    int    `db:"user_id"`
+		ExpiresAt string `db:"expires_at"`
+	}
+	if err := db.GetContext(ctx, &row, `
+		SELECT user_id, expires_at FROM user_sessions WHERE token = ?
 	`, token); err != nil {
 		return 0, huma.Error401Unauthorized("login required")
 	}
-	return userID, nil
+	expiresAt, err := time.Parse(time.RFC3339, row.ExpiresAt)
+	if err != nil || !expiresAt.After(time.Now().UTC()) {
+		_, _ = db.ExecContext(ctx, `DELETE FROM user_sessions WHERE token = ?`, token)
+		return 0, huma.Error401Unauthorized("login required")
+	}
+	return row.UserID, nil
 }
 
 func createSession(ctx context.Context, db *sqlx.DB, userID int) (*http.Cookie, error) {
@@ -707,13 +716,14 @@ func createSession(ctx context.Context, db *sqlx.DB, userID int) (*http.Cookie, 
 	if err != nil {
 		return nil, huma.Error500InternalServerError("failed to create session")
 	}
+	expiresAt := time.Now().UTC().Add(sessionTTL)
 	if _, err := db.ExecContext(ctx, `
-		INSERT INTO user_sessions (token, user_id)
-		VALUES (?, ?)
-	`, token, userID); err != nil {
+		INSERT INTO user_sessions (token, user_id, expires_at)
+		VALUES (?, ?, ?)
+	`, token, userID, expiresAt.Format(time.RFC3339)); err != nil {
 		return nil, huma.Error500InternalServerError("failed to save session")
 	}
-	return &http.Cookie{Name: sessionCookieName, Value: token, Path: "/", HttpOnly: true, SameSite: http.SameSiteLaxMode}, nil
+	return &http.Cookie{Name: sessionCookieName, Value: token, Path: "/", Expires: expiresAt, HttpOnly: true, SameSite: http.SameSiteLaxMode}, nil
 }
 
 func expiredSessionCookie() *http.Cookie {

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -285,16 +285,6 @@ func currentUserID(ctx context.Context) (int, error) {
 	return userID, nil
 }
 
-func contextWithDefaultUser(ctx context.Context, db *sqlx.DB) context.Context {
-	if _, err := currentUserID(ctx); err == nil {
-		return ctx
-	}
-	if userID, err := ensureDefaultUser(ctx, db); err == nil {
-		return context.WithValue(ctx, contextUserIDKey{}, userID)
-	}
-	return ctx
-}
-
 func userMode(ctx context.Context, db *sqlx.DB) (string, bool, error) {
 	var mode string
 	if err := db.GetContext(ctx, &mode, `SELECT value FROM app_settings WHERE key = 'user_mode'`); err != nil {

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/jmoiron/sqlx"
@@ -22,6 +23,9 @@ const (
 
 	sessionCookieName = "comichero_session"
 	defaultUserName   = "Default"
+
+	userInviteTokenBytes = 32
+	userInviteTTL        = 7 * 24 * time.Hour
 )
 
 type contextUserIDKey struct{}
@@ -122,6 +126,18 @@ func RegisterUserRoutes(api huma.API, db *sqlx.DB) {
 		Errors:      []int{401, 403, 500},
 	}, func(ctx context.Context, input *struct{}) (*UserListOutput, error) {
 		return listUsers(ctx, db)
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "createUserInvite",
+		Tags:        []string{tagUsers},
+		Summary:     "Create user invite",
+		Description: "Creates a single-use registration invite. Admin users only.",
+		Method:      http.MethodPost,
+		Path:        "/users/invites",
+		Errors:      []int{401, 403, 500},
+	}, func(ctx context.Context, input *struct{}) (*UserInviteOutput, error) {
+		return createUserInvite(ctx, db)
 	})
 
 	huma.Register(api, huma.Operation{
@@ -339,7 +355,18 @@ func registerUser(ctx context.Context, db *sqlx.DB, payload UserCredentialsPaylo
 	if err != nil {
 		return nil, huma.Error500InternalServerError("failed to hash password")
 	}
-	result, err := db.ExecContext(ctx, `
+
+	tx, err := db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to start registration")
+	}
+	defer tx.Rollback()
+
+	if err := consumeUserInvite(ctx, tx, payload.InviteToken); err != nil {
+		return nil, err
+	}
+
+	result, err := tx.ExecContext(ctx, `
 		INSERT INTO users (name, password_hash)
 		VALUES (?, ?)
 	`, name, passwordHash)
@@ -350,11 +377,59 @@ func registerUser(ctx context.Context, db *sqlx.DB, payload UserCredentialsPaylo
 	if err != nil {
 		return nil, huma.Error500InternalServerError("failed to get user id")
 	}
+	if err := tx.Commit(); err != nil {
+		return nil, huma.Error500InternalServerError("failed to create user")
+	}
 	cookie, err := createSession(ctx, db, int(id))
 	if err != nil {
 		return nil, err
 	}
 	return userStatusForUser(ctx, db, mode, int(id), cookie)
+}
+
+func createUserInvite(ctx context.Context, db *sqlx.DB) (*UserInviteOutput, error) {
+	userID, err := requireAdminUser(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	token, err := randomToken(userInviteTokenBytes)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to create invite token")
+	}
+	expiresAt := time.Now().UTC().Add(userInviteTTL).Format(time.RFC3339)
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO user_invites (token, created_by_user_id, expires_at)
+		VALUES (?, ?, ?)
+	`, token, userID, expiresAt); err != nil {
+		return nil, huma.Error500InternalServerError("failed to save invite")
+	}
+	return &UserInviteOutput{Body: UserInvite{Token: token, ExpiresAt: expiresAt}}, nil
+}
+
+func consumeUserInvite(ctx context.Context, db sqlx.ExtContext, token string) error {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return huma.Error401Unauthorized("valid invite token is required")
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	result, err := db.ExecContext(ctx, `
+		UPDATE user_invites
+		SET used_at = ?
+		WHERE token = ?
+		  AND used_at = ''
+		  AND (expires_at = '' OR expires_at > ?)
+	`, now, token, now)
+	if err != nil {
+		return huma.Error500InternalServerError("failed to consume invite")
+	}
+	rows, err := result.RowsAffected()
+	if err != nil {
+		return huma.Error500InternalServerError("failed to check invite")
+	}
+	if rows == 0 {
+		return huma.Error401Unauthorized("valid invite token is required")
+	}
+	return nil
 }
 
 func loginUser(ctx context.Context, db *sqlx.DB, payload UserCredentialsPayload) (*UserStatusOutput, error) {

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -196,7 +196,7 @@ func isUserRouteAllowedWithoutSession(path string) bool {
 func currentUserID(ctx context.Context) (int, error) {
 	userID, ok := ctx.Value(contextUserIDKey{}).(int)
 	if !ok || userID <= 0 {
-		return 1, nil
+		return 0, huma.Error401Unauthorized("login required")
 	}
 	return userID, nil
 }

--- a/backend/internal/db/migrations/005_user_invites.sql
+++ b/backend/internal/db/migrations/005_user_invites.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+CREATE TABLE user_invites (
+    token              TEXT PRIMARY KEY,
+    created_by_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    expires_at         TEXT NOT NULL DEFAULT '',
+    used_at            TEXT NOT NULL DEFAULT '',
+    created_at         TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_user_invites_unused_expiry
+ON user_invites(used_at, expires_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_user_invites_unused_expiry;
+DROP TABLE user_invites;

--- a/backend/internal/db/migrations/006_user_session_expiry.sql
+++ b/backend/internal/db/migrations/006_user_session_expiry.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+ALTER TABLE user_sessions ADD COLUMN expires_at TEXT NOT NULL DEFAULT '';
+
+UPDATE user_sessions
+SET expires_at = strftime('%Y-%m-%dT%H:%M:%SZ', 'now', '+30 days')
+WHERE expires_at = '';
+
+CREATE INDEX idx_user_sessions_expires_at
+ON user_sessions(expires_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_user_sessions_expires_at;
+ALTER TABLE user_sessions DROP COLUMN expires_at;

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -33,6 +33,7 @@ import {
   registerUser,
   setupUsers,
   updateAccount,
+  updateUserAdmin,
   updateUserMetronPermissions,
 } from '@/api/client.js'
 
@@ -51,6 +52,7 @@ const userAdminRows = ref([])
 const accountSaving = ref(false)
 const accountDeleting = ref(false)
 const savingUserID = ref(null)
+const savingAdminUserID = ref(null)
 const search = ref('')
 const defaultListOptions = {
   readingOrders: { filter: 'all', sort: 'name', direction: 'asc' },
@@ -381,6 +383,21 @@ async function saveUserMetronPermissions(userID, payload) {
     error.value = err.message
   } finally {
     savingUserID.value = null
+  }
+}
+
+async function saveUserAdmin(userID, payload) {
+  savingAdminUserID.value = userID
+  error.value = ''
+  try {
+    const updated = await updateUserAdmin(userID, payload)
+    userAdminRows.value = userAdminRows.value.map((entry) => (
+      entry.user.id === userID ? updated : entry
+    ))
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    savingAdminUserID.value = null
   }
 }
 
@@ -1003,7 +1020,10 @@ onUnmounted(() => {
         v-else-if="activeView === 'users'"
         :users="userAdminRows"
         :saving-user-id="savingUserID"
+        :saving-admin-user-id="savingAdminUserID"
+        :current-user-id="currentUser?.id"
         @save="saveUserMetronPermissions"
+        @save-admin="saveUserAdmin"
       />
 
       <AccountView

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -25,6 +25,7 @@ import { usePagination } from '@/composables/usePagination.js'
 import { useReadingOrders } from '@/composables/useReadingOrders.js'
 import { useSeries } from '@/composables/useSeries.js'
 import {
+  createUserInvite,
   deleteAccount as deleteAccountRequest,
   getUserStatus,
   listUsers,
@@ -47,12 +48,14 @@ const authSaving = ref(false)
 const userStatus = ref(null)
 const authMode = ref('login')
 const setupForm = ref({ mode: 'single', name: '', password: '' })
-const authForm = ref({ name: '', password: '' })
+const authForm = ref({ name: '', password: '', inviteToken: '' })
 const userAdminRows = ref([])
+const generatedInvite = ref(null)
 const accountSaving = ref(false)
 const accountDeleting = ref(false)
 const savingUserID = ref(null)
 const savingAdminUserID = ref(null)
+const generatingInvite = ref(false)
 const search = ref('')
 const defaultListOptions = {
   readingOrders: { filter: 'all', sort: 'name', direction: 'asc' },
@@ -358,6 +361,9 @@ async function submitAuth() {
   error.value = ''
   try {
     const payload = { name: authForm.value.name, password: authForm.value.password }
+    if (authMode.value === 'register') {
+      payload.inviteToken = authForm.value.inviteToken
+    }
     userStatus.value = authMode.value === 'register' ? await registerUser(payload) : await loginUser(payload)
     await applyCurrentRoute({ replace: true, force: true })
   } catch (err) {
@@ -369,6 +375,18 @@ async function submitAuth() {
 
 async function loadUserAdminRows() {
   userAdminRows.value = await listUsers()
+}
+
+async function generateUserInvite() {
+  generatingInvite.value = true
+  error.value = ''
+  try {
+    generatedInvite.value = await createUserInvite()
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    generatingInvite.value = false
+  }
 }
 
 async function saveUserMetronPermissions(userID, payload) {
@@ -953,6 +971,10 @@ onUnmounted(() => {
             required
           >
         </label>
+        <label v-if="authMode === 'register'">
+          <span>Invite token</span>
+          <input v-model.trim="authForm.inviteToken" type="text" autocomplete="one-time-code" required>
+        </label>
       </div>
 
       <div v-if="error" class="toast error-toast" role="alert">
@@ -1022,8 +1044,11 @@ onUnmounted(() => {
         :saving-user-id="savingUserID"
         :saving-admin-user-id="savingAdminUserID"
         :current-user-id="currentUser?.id"
+        :invite="generatedInvite"
+        :generating-invite="generatingInvite"
         @save="saveUserMetronPermissions"
         @save-admin="saveUserAdmin"
+        @generate-invite="generateUserInvite"
       />
 
       <AccountView

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -253,6 +253,10 @@ export function updateUserMetronPermissions(id, payload) {
   return send(`/users/${id}/metron-permissions`, 'PUT', payload)
 }
 
+export function updateUserAdmin(id, payload) {
+  return send(`/users/${id}/admin`, 'PUT', payload)
+}
+
 export function deleteComic(id) {
   return request(`/comics/${id}`, { method: 'DELETE' })
 }

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -249,6 +249,10 @@ export function listUsers() {
   return request('/users')
 }
 
+export function createUserInvite() {
+  return send('/users/invites', 'POST', {})
+}
+
 export function updateUserMetronPermissions(id, payload) {
   return send(`/users/${id}/metron-permissions`, 'PUT', payload)
 }

--- a/ui/src/components/UserManagementView.vue
+++ b/ui/src/components/UserManagementView.vue
@@ -25,9 +25,17 @@ const props = defineProps({
     type: Number,
     default: null,
   },
+  invite: {
+    type: Object,
+    default: null,
+  },
+  generatingInvite: {
+    type: Boolean,
+    default: false,
+  },
 })
 
-const emit = defineEmits(['save', 'save-admin'])
+const emit = defineEmits(['save', 'save-admin', 'generate-invite'])
 const drafts = reactive({})
 
 watch(
@@ -97,6 +105,22 @@ function saveAdmin(entry) {
 
 <template>
   <section class="browse-view user-management-view">
+    <section class="user-invite-panel">
+      <div>
+        <p class="eyebrow">Invites</p>
+        <h3>Invite a user</h3>
+        <p class="muted">New accounts need a single-use invite token to register.</p>
+      </div>
+      <button class="primary-button" type="button" :disabled="generatingInvite" @click="$emit('generate-invite')">
+        {{ generatingInvite ? 'Generating...' : 'Generate invite' }}
+      </button>
+      <div v-if="invite?.token" class="invite-token-box">
+        <span>Invite token</span>
+        <code>{{ invite.token }}</code>
+        <small>Expires at {{ invite.expiresAt }}</small>
+      </div>
+    </section>
+
     <div v-if="users.length === 0" class="empty-panel">
       No users yet.
     </div>

--- a/ui/src/components/UserManagementView.vue
+++ b/ui/src/components/UserManagementView.vue
@@ -17,9 +17,17 @@ const props = defineProps({
     type: Number,
     default: null,
   },
+  savingAdminUserID: {
+    type: Number,
+    default: null,
+  },
+  currentUserID: {
+    type: Number,
+    default: null,
+  },
 })
 
-const emit = defineEmits(['save'])
+const emit = defineEmits(['save', 'save-admin'])
 const drafts = reactive({})
 
 watch(
@@ -32,6 +40,7 @@ watch(
         allowed: Boolean(permissions.allowed),
         scopes: normalizeScopes(permissions.scopes),
         hourlyLimit: permissions.hourlyLimit ?? 0,
+        isAdmin: Boolean(entry.user.isAdmin),
       }
     })
   },
@@ -46,7 +55,7 @@ function normalizeScopes(scopes = []) {
 
 function draftFor(userID) {
   if (!drafts[userID]) {
-    drafts[userID] = { allowed: false, scopes: [], hourlyLimit: 0 }
+    drafts[userID] = { allowed: false, scopes: [], hourlyLimit: 0, isAdmin: false }
   }
   return drafts[userID]
 }
@@ -78,6 +87,12 @@ function save(entry) {
     hourlyLimit: Number(draft.hourlyLimit) || 0,
   })
 }
+
+function saveAdmin(entry) {
+  emit('save-admin', entry.user.id, {
+    isAdmin: Boolean(draftFor(entry.user.id).isAdmin),
+  })
+}
 </script>
 
 <template>
@@ -93,10 +108,28 @@ function save(entry) {
             <h3>{{ entry.user.name }}</h3>
             <p>{{ entry.user.isAdmin ? 'Admin' : 'User' }}</p>
           </div>
-          <label class="compact-toggle">
-            <input v-model="draftFor(entry.user.id).allowed" type="checkbox">
-            <span>Metron access</span>
-          </label>
+          <div class="user-permission-toggles">
+            <label class="compact-toggle">
+              <input
+                v-model="draftFor(entry.user.id).isAdmin"
+                type="checkbox"
+                :disabled="entry.user.id === currentUserID"
+              >
+              <span>Admin user</span>
+            </label>
+            <button
+              type="button"
+              class="secondary-button compact-button"
+              :disabled="savingAdminUserID === entry.user.id || entry.user.id === currentUserID"
+              @click="saveAdmin(entry)"
+            >
+              {{ savingAdminUserID === entry.user.id ? 'Saving...' : 'Save role' }}
+            </button>
+            <label class="compact-toggle">
+              <input v-model="draftFor(entry.user.id).allowed" type="checkbox">
+              <span>Metron access</span>
+            </label>
+          </div>
         </div>
 
         <fieldset class="permission-scopes" :disabled="!draftFor(entry.user.id).allowed">

--- a/ui/src/composables/useReadingOrders.js
+++ b/ui/src/composables/useReadingOrders.js
@@ -107,7 +107,7 @@ export function useReadingOrders({ activeView, viewMode, error, saving, loadComi
     function editReadingOrder() {
         if (!selectedOrder.value) return
         if (selectedOrder.value.canEdit === false) {
-            error.value = 'Only the author can edit this reading order.'
+            error.value = 'Only the author or an admin can edit this reading order.'
             return
         }
         error.value = ''
@@ -127,7 +127,7 @@ export function useReadingOrders({ activeView, viewMode, error, saving, loadComi
 
     async function saveReadingOrder() {
         if (orderForm.value.id && selectedOrder.value?.canEdit === false) {
-            error.value = 'Only the author can edit this reading order.'
+            error.value = 'Only the author or an admin can edit this reading order.'
             return
         }
         saving.value = true
@@ -152,7 +152,7 @@ export function useReadingOrders({ activeView, viewMode, error, saving, loadComi
 
     async function deleteReadingOrder() {
         if (selectedOrder.value?.canEdit === false) {
-            error.value = 'Only the author can delete this reading order.'
+            error.value = 'Only the author or an admin can delete this reading order.'
             return
         }
         if (!orderForm.value.id || !confirm(`Delete ${orderForm.value.name}?`)) return

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -746,6 +746,42 @@ textarea {
   gap: 12px;
 }
 
+.user-invite-panel {
+  display: grid;
+  gap: 12px;
+  max-width: 840px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-soft);
+  padding: 14px;
+}
+
+.user-invite-panel .primary-button {
+  justify-self: start;
+}
+
+.invite-token-box {
+  display: grid;
+  gap: 4px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 12px;
+}
+
+.invite-token-box span,
+.invite-token-box small {
+  color: var(--muted);
+  font-size: 0.86rem;
+  font-weight: 700;
+}
+
+.invite-token-box code {
+  overflow-wrap: anywhere;
+  color: var(--heading);
+  font-weight: 800;
+}
+
 .empty-panel {
   border: 1px dashed var(--line-strong);
   border-radius: 8px;

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -790,6 +790,19 @@ textarea {
   font-weight: 700;
 }
 
+.user-permission-toggles {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.compact-button {
+  min-height: 36px;
+  padding: 7px 10px;
+}
+
 .compact-toggle,
 .permission-scopes label {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Issue 1: make currentUserID fail closed and require explicit user context for per-user handlers.
- Issue 2: require single-use admin-generated invite tokens for self-registration.
- Issue 3: add expiring sessions and reject/delete expired session tokens.
- Issue 4: set Secure on session cookies by default with COOKIE_SECURE opt-out documentation.
- Issue 5: rate limit login attempts by client IP.
- Issue 6: preserve triggering user context for background Metron jobs and remove default-user fallback.
- Nice-to-have: increase new PBKDF2-SHA256 hashes to 600,000 iterations while accepting old hashes.

## Verification
- go test ./... from backend/
- npm run build from ui/