### PR TITLE
Add explicit started reading state

### DIFF
--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -342,6 +342,7 @@ func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (reading_order_id, user_id)
 		);
+		CREATE TABLE user_arc_starts (arc_id INTEGER NOT NULL, user_id INTEGER NOT NULL, started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (arc_id, user_id));
 		CREATE TABLE comics (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			series_id INTEGER REFERENCES series(id) ON DELETE SET NULL,
@@ -922,6 +923,7 @@ func TestArcCreateEntriesFavoriteAndProgress(t *testing.T) {
 			image TEXT NOT NULL DEFAULT '',
 			favorite INTEGER NOT NULL DEFAULT 0
 		);
+		CREATE TABLE user_arc_starts (arc_id INTEGER NOT NULL, user_id INTEGER NOT NULL, started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (arc_id, user_id));
 		CREATE TABLE comics (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			series_id INTEGER REFERENCES series(id) ON DELETE SET NULL,
@@ -1035,6 +1037,7 @@ func TestSeriesFavoriteAndProgress(t *testing.T) {
 		CREATE UNIQUE INDEX idx_series_metron_series_id
 		ON series(metron_series_id)
 		WHERE metron_series_id IS NOT NULL;
+		CREATE TABLE user_series_starts (series_id INTEGER NOT NULL, user_id INTEGER NOT NULL, started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (series_id, user_id));
 		CREATE TABLE comics (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			series_id INTEGER REFERENCES series(id) ON DELETE SET NULL,
@@ -1120,6 +1123,7 @@ func TestSeriesSyncDoesNotFailWhenPruneFails(t *testing.T) {
 		);
 		CREATE UNIQUE INDEX idx_series_name_year
 		ON series(name, series_year);
+		CREATE TABLE user_series_starts (series_id INTEGER NOT NULL, user_id INTEGER NOT NULL, started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (series_id, user_id));
 		CREATE TABLE comics (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			series_id INTEGER REFERENCES series(id) ON DELETE SET NULL,

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -185,6 +185,12 @@ func TestUserStatisticsAndAchievements(t *testing.T) {
 			rating_count INTEGER NOT NULL DEFAULT 0,
 			author_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
 		);
+		CREATE TABLE user_reading_orders (
+			reading_order_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (reading_order_id, user_id)
+		);
 		CREATE TABLE reading_order_ratings (
 			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
 			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -237,6 +243,7 @@ func TestUserStatisticsAndAchievements(t *testing.T) {
 			(2, 1, 1, '2026-07-02T12:30:00Z'),
 			(4, 2, 1, '2026-07-03T08:00:00Z');
 		INSERT INTO reading_orders (id, name, author_user_id) VALUES (1, 'Alpha order', 1), (2, 'Other order', 2);
+		INSERT INTO user_reading_orders (reading_order_id, user_id) VALUES (1, 1);
 		INSERT INTO reading_order_comics (reading_order_id, comic_id, position)
 		VALUES (1, 1, 1), (1, 2, 2), (2, 3, 1);
 		INSERT INTO arcs (id, name) VALUES (1, 'Alpha arc'), (2, 'Beta arc');
@@ -320,6 +327,12 @@ func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
 			rating REAL NOT NULL DEFAULT 0,
 			rating_count INTEGER NOT NULL DEFAULT 0,
 			author_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
+		);
+		CREATE TABLE user_reading_orders (
+			reading_order_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (reading_order_id, user_id)
 		);
 		CREATE TABLE reading_order_ratings (
 			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
@@ -721,6 +734,12 @@ func setupReadingOrderCBLTestDB(t *testing.T) *sqlx.DB {
 			rating_count INTEGER NOT NULL DEFAULT 0,
 			author_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
 		);
+		CREATE TABLE user_reading_orders (
+			reading_order_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (reading_order_id, user_id)
+		);
 		CREATE TABLE reading_order_ratings (
 			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
 			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -828,6 +847,59 @@ func TestRateReadingOrderUsesUserRatings(t *testing.T) {
 	}
 	if cleared.Body.MyRating != nil {
 		t.Fatalf("my rating after clear = %#v; want nil", cleared.Body.MyRating)
+	}
+}
+
+func TestStartReadingOrderIsPerUserAndIdempotent(t *testing.T) {
+	ctx := testUserContext()
+	db := setupReadingOrderCBLTestDB(t)
+	if _, err := db.Exec(`INSERT INTO users (id, name) VALUES (2, 'Second Reader')`); err != nil {
+		t.Fatalf("insert second user: %v", err)
+	}
+
+	created, err := createReadingOrder(ctx, db, nil, ReadingOrderPayload{Name: "Started order"})
+	if err != nil {
+		t.Fatalf("create reading order: %v", err)
+	}
+	started, err := startReadingOrder(ctx, db, created.Body.ID)
+	if err != nil {
+		t.Fatalf("start reading order: %v", err)
+	}
+	if started.Body.StartedAt == nil || *started.Body.StartedAt == "" {
+		t.Fatal("startedAt is empty after starting reading order")
+	}
+	firstStartedAt := *started.Body.StartedAt
+	startedList, err := listReadingOrders(ctx, db, &ReadingOrderListInput{Started: "true"})
+	if err != nil {
+		t.Fatalf("list started reading orders: %v", err)
+	}
+	if len(startedList.Body) != 1 || startedList.Body[0].ID != created.Body.ID {
+		t.Fatalf("started reading orders = %#v; want created order", startedList.Body)
+	}
+
+	startedAgain, err := startReadingOrder(ctx, db, created.Body.ID)
+	if err != nil {
+		t.Fatalf("start reading order again: %v", err)
+	}
+	if startedAgain.Body.StartedAt == nil || *startedAgain.Body.StartedAt != firstStartedAt {
+		t.Fatalf("repeated start changed startedAt from %q to %#v", firstStartedAt, startedAgain.Body.StartedAt)
+	}
+
+	secondCtx := context.WithValue(context.Background(), contextUserIDKey{}, 2)
+	secondDetail, err := getReadingOrder(secondCtx, db, created.Body.ID)
+	if err != nil {
+		t.Fatalf("get reading order as second user: %v", err)
+	}
+	if secondDetail.Body.StartedAt != nil {
+		t.Fatalf("second user's startedAt = %#v; want nil", secondDetail.Body.StartedAt)
+	}
+
+	stopped, err := stopReadingOrder(ctx, db, created.Body.ID)
+	if err != nil {
+		t.Fatalf("stop reading order: %v", err)
+	}
+	if stopped.Body.StartedAt != nil {
+		t.Fatalf("startedAt after stop = %#v; want nil", stopped.Body.StartedAt)
 	}
 }
 
@@ -2201,6 +2273,12 @@ func setupMountedAuthTestDB(t *testing.T) *sqlx.DB {
 			rating REAL NOT NULL DEFAULT 0,
 			rating_count INTEGER NOT NULL DEFAULT 0,
 			author_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
+		);
+		CREATE TABLE user_reading_orders (
+			reading_order_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (reading_order_id, user_id)
 		);
 		CREATE TABLE reading_order_ratings (
 			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,

--- a/backend/internal/api/arcs.go
+++ b/backend/internal/api/arcs.go
@@ -35,6 +35,21 @@ func RegisterArcRoutes(api huma.API, db *sqlx.DB) {
 		return getArc(ctx, db, input.ID)
 	})
 
+	for _, operation := range []struct {
+		id      string
+		summary string
+		method  string
+		started bool
+	}{{"startArc", "Start reading an arc", http.MethodPost, true}, {"stopArc", "Stop reading an arc", http.MethodDelete, false}} {
+		op := operation
+		huma.Register(api, huma.Operation{OperationID: op.id, Tags: []string{tagArcs}, Summary: op.summary, Method: op.method, Path: "/arcs/{id}/start", Errors: errsWrite}, func(ctx context.Context, input *ArcInput) (*ArcDetailOutput, error) {
+			if err := setContentStarted(ctx, db, "user_arc_starts", "arc_id", "arcs", input.ID, op.started); err != nil {
+				return nil, err
+			}
+			return getArc(ctx, db, input.ID)
+		})
+	}
+
 	huma.Register(api, huma.Operation{
 		OperationID:   "createArc",
 		Tags:          []string{tagArcs},
@@ -119,6 +134,7 @@ func arcListQuery(input *ArcListInput, userID int) (string, []any, error) {
 			a.description,
 			a.image,
 			a.favorite,
+			started.started_at AS started_at,
 			CASE
 				WHEN COUNT(c.id) = 0 THEN 0.0
 				ELSE CAST(SUM(CASE WHEN COALESCE(uc.read, 0) = 1 THEN 1 ELSE 0 END) AS REAL) / COUNT(c.id)
@@ -127,8 +143,9 @@ func arcListQuery(input *ArcListInput, userID int) (string, []any, error) {
 		LEFT JOIN arc_comics ac ON ac.arc_id = a.id
 		LEFT JOIN comics c ON c.id = ac.comic_id
 		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
+		LEFT JOIN user_arc_starts started ON started.arc_id = a.id AND started.user_id = ?
 	`)
-	query.args = append(query.args, userID)
+	query.args = append(query.args, userID, userID)
 
 	if input.Query != "" {
 		search := "%" + input.Query + "%"
@@ -138,6 +155,13 @@ func arcListQuery(input *ArcListInput, userID int) (string, []any, error) {
 		return "", nil, err
 	} else if ok {
 		query.where("a.favorite = ?", favorite)
+	}
+	if started, ok, err := parseOptionalBool(input.Started, "started"); err != nil {
+		return "", nil, err
+	} else if ok && started {
+		query.where("started.started_at IS NOT NULL")
+	} else if ok {
+		query.where("started.started_at IS NULL")
 	}
 	if input.ComicID > 0 {
 		query.where(`
@@ -165,10 +189,17 @@ func arcListOrder(sort, direction string) string {
 }
 
 func getArc(ctx context.Context, db *sqlx.DB, id int) (*ArcDetailOutput, error) {
+	userID, err := currentUserID(ctx)
+	if err != nil {
+		return nil, err
+	}
 	var arc Arc
 	if err := db.GetContext(ctx, &arc, `
-		SELECT * FROM arcs WHERE id = ?
-	`, id); err != nil {
+		SELECT a.*, started.started_at AS started_at
+		FROM arcs a
+		LEFT JOIN user_arc_starts started ON started.arc_id = a.id AND started.user_id = ?
+		WHERE a.id = ?
+	`, userID, id); err != nil {
 		return nil, huma.Error404NotFound("arc not found")
 	}
 

--- a/backend/internal/api/characters.go
+++ b/backend/internal/api/characters.go
@@ -49,6 +49,21 @@ func RegisterCharacterRoutes(api huma.API, db *sqlx.DB) {
 	}, func(ctx context.Context, input *UpdateCharacterFavoriteInput) (*CharacterDetailOutput, error) {
 		return updateCharacterFavorite(ctx, db, input.ID, input.Body.Favorite)
 	})
+
+	for _, operation := range []struct {
+		id      string
+		summary string
+		method  string
+		started bool
+	}{{"startCharacter", "Start reading a character", http.MethodPost, true}, {"stopCharacter", "Stop reading a character", http.MethodDelete, false}} {
+		op := operation
+		huma.Register(api, huma.Operation{OperationID: op.id, Tags: []string{tagCharacters}, Summary: op.summary, Method: op.method, Path: "/characters/{id}/start", Errors: errsWrite}, func(ctx context.Context, input *CharacterInput) (*CharacterDetailOutput, error) {
+			if err := setContentStarted(ctx, db, "user_character_starts", "character_id", "characters", input.ID, op.started); err != nil {
+				return nil, err
+			}
+			return getCharacter(ctx, db, input.ID)
+		})
+	}
 }
 
 func listCharacters(ctx context.Context, db *sqlx.DB, input *CharacterListInput) (*CharacterListOutput, error) {
@@ -57,15 +72,16 @@ func listCharacters(ctx context.Context, db *sqlx.DB, input *CharacterListInput)
 		return nil, err
 	}
 	query := newSelectQuery(`
-		SELECT ch.*,
+		SELECT ch.*, started.started_at AS started_at,
 			COUNT(cc.comic_id) AS appearance_count,
 			COALESCE(AVG(CASE WHEN COALESCE(uc.read, 0) = 1 THEN 1.0 ELSE 0 END), 0) AS progress
 		FROM characters ch
 		LEFT JOIN comic_characters cc ON cc.character_id = ch.id
 		LEFT JOIN comics c ON c.id = cc.comic_id
 		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
+		LEFT JOIN user_character_starts started ON started.character_id = ch.id AND started.user_id = ?
 	`)
-	query.args = append(query.args, userID)
+	query.args = append(query.args, userID, userID)
 	if input.Query != "" {
 		search := "%" + input.Query + "%"
 		query.where(`(
@@ -80,6 +96,13 @@ func listCharacters(ctx context.Context, db *sqlx.DB, input *CharacterListInput)
 		return nil, err
 	} else if ok {
 		query.where("ch.favorite = ?", favorite)
+	}
+	if started, ok, err := parseOptionalBool(input.Started, "started"); err != nil {
+		return nil, err
+	} else if ok && started {
+		query.where("started.started_at IS NOT NULL")
+	} else if ok {
+		query.where("started.started_at IS NULL")
 	}
 	query.groupBy("GROUP BY ch.id")
 	query.orderBy(characterListOrder(input.Sort, input.Direction))
@@ -173,16 +196,17 @@ func getCharacterRow(ctx context.Context, db *sqlx.DB, id int) (Character, error
 	}
 	var character Character
 	if err := db.GetContext(ctx, &character, `
-		SELECT ch.*,
+		SELECT ch.*, started.started_at AS started_at,
 			COUNT(cc.comic_id) AS appearance_count,
 			COALESCE(AVG(CASE WHEN COALESCE(uc.read, 0) = 1 THEN 1.0 ELSE 0 END), 0) AS progress
 		FROM characters ch
 		LEFT JOIN comic_characters cc ON cc.character_id = ch.id
 		LEFT JOIN comics c ON c.id = cc.comic_id
 		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
+		LEFT JOIN user_character_starts started ON started.character_id = ch.id AND started.user_id = ?
 		WHERE ch.id = ?
 		GROUP BY ch.id
-	`, userID, id); err != nil {
+	`, userID, userID, id); err != nil {
 		if err == sql.ErrNoRows {
 			return Character{}, huma.Error404NotFound("character not found")
 		}

--- a/backend/internal/api/content_starts.go
+++ b/backend/internal/api/content_starts.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/jmoiron/sqlx"
+)
+
+func setContentStarted(ctx context.Context, db *sqlx.DB, table, idColumn, entityTable string, id int, started bool) error {
+	userID, err := currentUserID(ctx)
+	if err != nil {
+		return err
+	}
+	var exists int
+	if err := db.GetContext(ctx, &exists, fmt.Sprintf("SELECT COUNT(*) FROM %s WHERE id = ?", entityTable), id); err != nil {
+		return huma.Error500InternalServerError("failed to check item")
+	}
+	if exists == 0 {
+		return huma.Error404NotFound("item not found")
+	}
+	if started {
+		_, err = db.ExecContext(ctx, fmt.Sprintf(`
+			INSERT INTO %s (%s, user_id, started_at)
+			VALUES (?, ?, ?)
+			ON CONFLICT(%s, user_id) DO NOTHING
+		`, table, idColumn, idColumn), id, userID, time.Now().UTC().Format(time.RFC3339))
+	} else {
+		_, err = db.ExecContext(ctx, fmt.Sprintf(`DELETE FROM %s WHERE %s = ? AND user_id = ?`, table, idColumn), id, userID)
+	}
+	if err != nil {
+		return huma.Error500InternalServerError("failed to update started state")
+	}
+	return nil
+}

--- a/backend/internal/api/metron_import_test.go
+++ b/backend/internal/api/metron_import_test.go
@@ -38,6 +38,12 @@ func newMetronImportTestDB(t *testing.T) *sqlx.DB {
 		CREATE UNIQUE INDEX idx_reading_orders_metron_reading_list_id
 		ON reading_orders(metron_reading_list_id)
 		WHERE metron_reading_list_id IS NOT NULL;
+		CREATE TABLE user_reading_orders (
+			reading_order_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (reading_order_id, user_id)
+		);
 		CREATE TABLE reading_order_ratings (
 			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
 			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/internal/api/metron_import_test.go
+++ b/backend/internal/api/metron_import_test.go
@@ -105,6 +105,7 @@ func newMetronImportTestDB(t *testing.T) *sqlx.DB {
 		CREATE UNIQUE INDEX idx_series_metron_series_id
 		ON series(metron_series_id)
 		WHERE metron_series_id IS NOT NULL;
+		CREATE TABLE user_series_starts (series_id INTEGER NOT NULL, user_id INTEGER NOT NULL, started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (series_id, user_id));
 
 		CREATE TABLE characters (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -117,6 +118,7 @@ func newMetronImportTestDB(t *testing.T) *sqlx.DB {
 		CREATE UNIQUE INDEX idx_characters_metron_character_id
 		ON characters(metron_character_id)
 		WHERE metron_character_id IS NOT NULL;
+		CREATE TABLE user_character_starts (character_id INTEGER NOT NULL, user_id INTEGER NOT NULL, started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (character_id, user_id));
 
 		CREATE TABLE character_aliases (
 			character_id INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
@@ -141,6 +143,7 @@ func newMetronImportTestDB(t *testing.T) *sqlx.DB {
 		CREATE UNIQUE INDEX idx_arcs_metron_arc_id
 		ON arcs(metron_arc_id)
 		WHERE metron_arc_id IS NOT NULL;
+		CREATE TABLE user_arc_starts (arc_id INTEGER NOT NULL, user_id INTEGER NOT NULL, started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP, PRIMARY KEY (arc_id, user_id));
 
 		CREATE TABLE arc_comics (
 			arc_id INTEGER NOT NULL REFERENCES arcs(id) ON DELETE CASCADE,

--- a/backend/internal/api/models.go
+++ b/backend/internal/api/models.go
@@ -300,6 +300,7 @@ type Character struct {
 	Description       string   `json:"description"                db:"description"         doc:"Character description from Metron."`
 	Image             string   `json:"image"                      db:"image"               doc:"Character image URL from Metron." format:"uri"`
 	Favorite          bool     `json:"favorite"                   db:"favorite"            doc:"Whether this character is marked as a favorite." example:"true"`
+	StartedAt         *string  `json:"startedAt,omitempty"        db:"started_at"          doc:"When the current user formally started reading this character."`
 	Progress          float64  `json:"progress"                   db:"progress"            doc:"Fraction of appearances marked read, from 0 to 1." minimum:"0" maximum:"1" example:"0.5"`
 	Aliases           []string `json:"aliases"                    db:"-"                   doc:"Known character aliases."`
 	AppearanceCount   int      `json:"appearanceCount"            db:"appearance_count"    doc:"Number of local comics this character appears in." example:"25"`
@@ -313,6 +314,7 @@ type CharacterDetail struct {
 type CharacterListInput struct {
 	Query     string `query:"q"        doc:"Case-insensitive text search across character names and aliases." example:"bat"`
 	Favorite  string `query:"favorite" doc:"Filter characters by favorite status. Use true or false." enum:"true,false" example:"true"`
+	Started   string `query:"started" doc:"Filter characters by current-user started status." enum:"true,false" example:"true"`
 	Sort      string `query:"sort"     doc:"Sort field." enum:"name,appearances,aliases,progress" example:"name"`
 	Direction string `query:"direction" doc:"Sort direction." enum:"asc,desc" example:"asc"`
 	Limit     int    `query:"limit"    doc:"Maximum rows to return, from 1 to 100." minimum:"1" maximum:"100" example:"50"`
@@ -342,6 +344,7 @@ type ComicSeries struct {
 	Name        string   `json:"name"        db:"name"        doc:"Series name." example:"Batman"`
 	SeriesYear  int      `json:"seriesYear"  db:"series_year" doc:"Series start year or volume year used in generated comic titles." minimum:"0" example:"2011"`
 	Favorite    bool     `json:"favorite"    db:"favorite"    doc:"Whether this series is marked as a favorite." example:"true"`
+	StartedAt   *string  `json:"startedAt,omitempty" db:"started_at" doc:"When the current user formally started reading this series."`
 	Publisher   string   `json:"publisher"   db:"publisher"   doc:"Publisher name from Metron series metadata." example:"DC Comics"`
 	Volume      int      `json:"volume"      db:"volume"      doc:"Metron series volume number." example:"2"`
 	YearEnd     int      `json:"yearEnd"     db:"year_end"    doc:"Final publication year from Metron, when known." example:"2016"`
@@ -362,6 +365,7 @@ type ComicSeriesDetail struct {
 type ComicSeriesListInput struct {
 	Query     string `query:"q"        doc:"Case-insensitive text search across series names, publishers, years, and issue numbers." example:"batman"`
 	Favorite  string `query:"favorite" doc:"Filter series by favorite status. Use true or false." enum:"true,false" example:"true"`
+	Started   string `query:"started" doc:"Filter series by current-user started status." enum:"true,false" example:"true"`
 	Sort      string `query:"sort"     doc:"Sort field." enum:"name,year,publisher,entries,progress" example:"name"`
 	Direction string `query:"direction" doc:"Sort direction." enum:"asc,desc" example:"asc"`
 	Limit     int    `query:"limit"    doc:"Maximum rows to return, from 1 to 100." minimum:"1" maximum:"100" example:"50"`
@@ -555,6 +559,7 @@ type Arc struct {
 	Description string  `json:"description" db:"description" doc:"Arc description or notes."`
 	Image       string  `json:"image"       db:"image"       doc:"Story arc image URL from Metron." format:"uri"`
 	Favorite    bool    `json:"favorite"    db:"favorite"    doc:"Whether this arc is marked as a favorite." example:"true"`
+	StartedAt   *string `json:"startedAt,omitempty" db:"started_at" doc:"When the current user formally started reading this arc."`
 	Progress    float64 `json:"progress"    db:"progress"    doc:"Fraction of entries marked read, from 0 to 1." minimum:"0" maximum:"1" example:"0.5"`
 }
 
@@ -582,6 +587,7 @@ type ArcDetail struct {
 type ArcListInput struct {
 	Query     string `query:"q"        doc:"Case-insensitive text search across name and description." example:"batman"`
 	Favorite  string `query:"favorite" doc:"Filter arcs by favorite status. Use true or false." enum:"true,false" example:"true"`
+	Started   string `query:"started" doc:"Filter arcs by current-user started status." enum:"true,false" example:"true"`
 	ComicID   int    `query:"comicId"  doc:"Filter arcs to those containing a comic." example:"42"`
 	Sort      string `query:"sort"     doc:"Sort field." enum:"name,progress" example:"name"`
 	Direction string `query:"direction" doc:"Sort direction." enum:"asc,desc" example:"asc"`

--- a/backend/internal/api/models.go
+++ b/backend/internal/api/models.go
@@ -435,6 +435,7 @@ type ReadingOrder struct {
 	Rating      float64  `json:"rating"      db:"rating"      doc:"Average user rating from 1 to 5, or 0 when unrated." minimum:"0" maximum:"5" example:"4.5"`
 	RatingCount int      `json:"ratingCount" db:"rating_count" doc:"Number of user ratings represented by this score." example:"23"`
 	MyRating    *float64 `json:"myRating,omitempty" db:"my_rating" doc:"Current user's rating for this reading order, when rated." minimum:"1" maximum:"5" example:"4"`
+	StartedAt   *string  `json:"startedAt,omitempty" db:"started_at" doc:"When the current user formally started this reading order." example:"2026-07-10T12:30:00Z"`
 	Progress    float64  `json:"progress"    db:"progress"    doc:"Fraction of entries marked read, from 0 to 1." minimum:"0" maximum:"1" example:"0.5"`
 	AuthorName  string   `json:"authorName"  db:"author_name" doc:"Display name of the reading-order author." example:"Default"`
 	CanEdit     bool     `json:"canEdit"     db:"can_edit"    doc:"Whether the current user may edit this reading order." example:"true"`
@@ -488,6 +489,7 @@ type ReadingOrderDetail struct {
 type ReadingOrderListInput struct {
 	Query     string `query:"q"        doc:"Case-insensitive text search across name and description." example:"batman"`
 	Favorite  string `query:"favorite" doc:"Filter reading orders by favorite status. Use true or false." enum:"true,false" example:"true"`
+	Started   string `query:"started" doc:"Filter reading orders by whether the current user formally started them. Use true or false." enum:"true,false" example:"true"`
 	ComicID   int    `query:"comicId"  doc:"Filter reading orders to those containing a comic." example:"42"`
 	Sort      string `query:"sort"     doc:"Sort field." enum:"name,progress,rating" example:"name"`
 	Direction string `query:"direction" doc:"Sort direction." enum:"asc,desc" example:"asc"`

--- a/backend/internal/api/readingorders.go
+++ b/backend/internal/api/readingorders.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/jmoiron/sqlx"
@@ -18,7 +19,7 @@ func RegisterReadingOrderRoutes(api huma.API, db *sqlx.DB, covers *CoverCache) {
 		OperationID: "listReadingOrders",
 		Tags:        []string{tagReadingOrders},
 		Summary:     "List reading orders",
-		Description: "Returns reading orders with computed read progress. Results can be filtered by text, favorite status, or a comic they contain.",
+		Description: "Returns reading orders with computed read progress. Results can be filtered by text, favorite status, current-user started status, or a comic they contain.",
 		Method:      http.MethodGet,
 		Path:        "/readingOrders",
 		Errors:      errsRead,
@@ -98,6 +99,30 @@ func RegisterReadingOrderRoutes(api huma.API, db *sqlx.DB, covers *CoverCache) {
 		Errors:      errsWrite,
 	}, func(ctx context.Context, input *UpdateReadingOrderRatingInput) (*ReadingOrderDetailOutput, error) {
 		return rateReadingOrder(ctx, db, input.ID, input.Body.Rating)
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "startReadingOrder",
+		Tags:        []string{tagReadingOrders},
+		Summary:     "Start a reading order",
+		Description: "Formally marks a reading order as started by the current user. Repeated requests preserve the original start time.",
+		Method:      http.MethodPost,
+		Path:        "/readingOrders/{id}/start",
+		Errors:      errsWrite,
+	}, func(ctx context.Context, input *ReadingOrderInput) (*ReadingOrderDetailOutput, error) {
+		return startReadingOrder(ctx, db, input.ID)
+	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "stopReadingOrder",
+		Tags:        []string{tagReadingOrders},
+		Summary:     "Stop reading a reading order",
+		Description: "Removes the current user's active reading-order start state without changing comic read history.",
+		Method:      http.MethodDelete,
+		Path:        "/readingOrders/{id}/start",
+		Errors:      errsWrite,
+	}, func(ctx context.Context, input *ReadingOrderInput) (*ReadingOrderDetailOutput, error) {
+		return stopReadingOrder(ctx, db, input.ID)
 	})
 
 	huma.Register(api, huma.Operation{
@@ -194,6 +219,7 @@ func readingOrderListQuery(input *ReadingOrderListInput, userID int, editUserID 
 			COALESCE(rating_summary.rating, 0) AS rating,
 			COALESCE(rating_summary.rating_count, 0) AS rating_count,
 			my_rating.rating AS my_rating,
+			started.started_at AS started_at,
 			COALESCE(author.name, '') AS author_name,
 			CASE
 				WHEN ro.author_user_id = ?
@@ -216,8 +242,10 @@ func readingOrderListQuery(input *ReadingOrderListInput, userID int, editUserID 
 		) rating_summary ON rating_summary.reading_order_id = ro.id
 		LEFT JOIN reading_order_ratings my_rating
 			ON my_rating.reading_order_id = ro.id AND my_rating.user_id = ?
+		LEFT JOIN user_reading_orders started
+			ON started.reading_order_id = ro.id AND started.user_id = ?
 	`)
-	query.args = append(query.args, editUserID, editUserID, userID, userID)
+	query.args = append(query.args, editUserID, editUserID, userID, userID, userID)
 
 	if input.Query != "" {
 		search := "%" + input.Query + "%"
@@ -227,6 +255,13 @@ func readingOrderListQuery(input *ReadingOrderListInput, userID int, editUserID 
 		return "", nil, err
 	} else if ok {
 		query.where("ro.favorite = ?", favorite)
+	}
+	if started, ok, err := parseOptionalBool(input.Started, "started"); err != nil {
+		return "", nil, err
+	} else if ok && started {
+		query.where("started.started_at IS NOT NULL")
+	} else if ok {
+		query.where("started.started_at IS NULL")
 	}
 	if input.ComicID > 0 {
 		query.where(`
@@ -349,6 +384,7 @@ func getReadingOrderRow(ctx context.Context, db *sqlx.DB, id int) (ReadingOrder,
 			COALESCE(rating_summary.rating, 0) AS rating,
 			COALESCE(rating_summary.rating_count, 0) AS rating_count,
 			my_rating.rating AS my_rating,
+			started.started_at AS started_at,
 			0.0 AS progress,
 			COALESCE(author.name, '') AS author_name,
 			CASE
@@ -365,14 +401,64 @@ func getReadingOrderRow(ctx context.Context, db *sqlx.DB, id int) (ReadingOrder,
 		) rating_summary ON rating_summary.reading_order_id = ro.id
 		LEFT JOIN reading_order_ratings my_rating
 			ON my_rating.reading_order_id = ro.id AND my_rating.user_id = ?
+		LEFT JOIN user_reading_orders started
+			ON started.reading_order_id = ro.id AND started.user_id = ?
 		WHERE ro.id = ?
-	`, editUserID, editUserID, userID, id); err != nil {
+	`, editUserID, editUserID, userID, userID, id); err != nil {
 		if err == sql.ErrNoRows {
 			return ReadingOrder{}, huma.Error404NotFound("reading order not found")
 		}
 		return ReadingOrder{}, huma.Error500InternalServerError("failed to fetch reading order")
 	}
 	return readingOrder, nil
+}
+
+func startReadingOrder(ctx context.Context, db *sqlx.DB, id int) (*ReadingOrderDetailOutput, error) {
+	userID, err := currentUserID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var exists int
+	if err := db.GetContext(ctx, &exists, `SELECT COUNT(*) FROM reading_orders WHERE id = ?`, id); err != nil {
+		return nil, huma.Error500InternalServerError("failed to check reading order")
+	}
+	if exists == 0 {
+		return nil, huma.Error404NotFound("reading order not found")
+	}
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO user_reading_orders (reading_order_id, user_id, started_at)
+		VALUES (?, ?, ?)
+		ON CONFLICT(reading_order_id, user_id) DO NOTHING
+	`, id, userID, time.Now().UTC().Format(time.RFC3339)); err != nil {
+		return nil, huma.Error500InternalServerError("failed to start reading order")
+	}
+	return getReadingOrder(ctx, db, id)
+}
+
+func stopReadingOrder(ctx context.Context, db *sqlx.DB, id int) (*ReadingOrderDetailOutput, error) {
+	userID, err := currentUserID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	result, err := db.ExecContext(ctx, `
+		DELETE FROM user_reading_orders
+		WHERE reading_order_id = ? AND user_id = ?
+	`, id, userID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to stop reading order")
+	}
+	if deleted, err := result.RowsAffected(); err != nil {
+		return nil, huma.Error500InternalServerError("failed to check reading order state")
+	} else if deleted == 0 {
+		var exists int
+		if err := db.GetContext(ctx, &exists, `SELECT COUNT(*) FROM reading_orders WHERE id = ?`, id); err != nil {
+			return nil, huma.Error500InternalServerError("failed to check reading order")
+		}
+		if exists == 0 {
+			return nil, huma.Error404NotFound("reading order not found")
+		}
+	}
+	return getReadingOrder(ctx, db, id)
 }
 
 func fetchReadingOrderDetail(ctx context.Context, db *sqlx.DB, ro ReadingOrder) (*ReadingOrderDetailOutput, error) {

--- a/backend/internal/api/series.go
+++ b/backend/internal/api/series.go
@@ -50,6 +50,21 @@ func RegisterSeriesRoutes(api huma.API, db *sqlx.DB, client *metron.Client, cove
 		return updateSeriesFavorite(ctx, db, input.ID, input.Body.Favorite)
 	})
 
+	for _, operation := range []struct {
+		id      string
+		summary string
+		method  string
+		started bool
+	}{{"startSeries", "Start reading a series", http.MethodPost, true}, {"stopSeries", "Stop reading a series", http.MethodDelete, false}} {
+		op := operation
+		huma.Register(api, huma.Operation{OperationID: op.id, Tags: []string{tagSeries}, Summary: op.summary, Method: op.method, Path: "/series/{id}/start", Errors: errsWrite}, func(ctx context.Context, input *ComicSeriesInput) (*ComicSeriesDetailOutput, error) {
+			if err := setContentStarted(ctx, db, "user_series_starts", "series_id", "series", input.ID, op.started); err != nil {
+				return nil, err
+			}
+			return getSeries(ctx, db, input.ID)
+		})
+	}
+
 	huma.Register(api, huma.Operation{
 		OperationID:   "importSeriesFromMetron",
 		Tags:          []string{tagSeries, tagMetron},
@@ -80,7 +95,7 @@ func listSeries(ctx context.Context, db *sqlx.DB, input *ComicSeriesListInput) (
 	if err != nil {
 		return nil, err
 	}
-	countQuery, countArgs, err := seriesListCountQuery(input)
+	countQuery, countArgs, err := seriesListCountQuery(input, userID)
 	if err != nil {
 		return nil, err
 	}
@@ -110,6 +125,7 @@ func seriesListQuery(input *ComicSeriesListInput, userID int) (string, []any, er
 			s.name,
 			s.series_year,
 			s.favorite,
+			started.started_at AS started_at,
 			s.publisher,
 			s.volume,
 			s.year_end,
@@ -132,8 +148,9 @@ func seriesListQuery(input *ComicSeriesListInput, userID int) (string, []any, er
 		FROM series s
 		LEFT JOIN comics c ON c.series_id = s.id
 		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
+		LEFT JOIN user_series_starts started ON started.series_id = s.id AND started.user_id = ?
 	`)
-	query.args = append(query.args, userID)
+	query.args = append(query.args, userID, userID)
 
 	if err := applySeriesListFilters(query, input); err != nil {
 		return "", nil, err
@@ -145,8 +162,9 @@ func seriesListQuery(input *ComicSeriesListInput, userID int) (string, []any, er
 	return sql, args, nil
 }
 
-func seriesListCountQuery(input *ComicSeriesListInput) (string, []any, error) {
-	query := newSelectQuery(`SELECT s.id FROM series s`)
+func seriesListCountQuery(input *ComicSeriesListInput, userID int) (string, []any, error) {
+	query := newSelectQuery(`SELECT s.id FROM series s LEFT JOIN user_series_starts started ON started.series_id = s.id AND started.user_id = ?`)
+	query.args = append(query.args, userID)
 	if err := applySeriesListFilters(query, input); err != nil {
 		return "", nil, err
 	}
@@ -170,6 +188,13 @@ func applySeriesListFilters(query *selectQuery, input *ComicSeriesListInput) err
 		return err
 	} else if ok {
 		query.where("s.favorite = ?", favorite)
+	}
+	if started, ok, err := parseOptionalBool(input.Started, "started"); err != nil {
+		return err
+	} else if ok && started {
+		query.where("started.started_at IS NOT NULL")
+	} else if ok {
+		query.where("started.started_at IS NULL")
 	}
 	return nil
 }
@@ -232,6 +257,7 @@ func getSeriesRow(ctx context.Context, db *sqlx.DB, id int) (ComicSeries, error)
 			s.name,
 			s.series_year,
 			s.favorite,
+			started.started_at AS started_at,
 			s.publisher,
 			s.volume,
 			s.year_end,
@@ -254,9 +280,10 @@ func getSeriesRow(ctx context.Context, db *sqlx.DB, id int) (ComicSeries, error)
 		FROM series s
 		LEFT JOIN comics c ON c.series_id = s.id
 		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
+		LEFT JOIN user_series_starts started ON started.series_id = s.id AND started.user_id = ?
 		WHERE s.id = ?
 		GROUP BY s.id
-	`, userID, id); err != nil {
+	`, userID, userID, id); err != nil {
 		if err == sql.ErrNoRows {
 			return ComicSeries{}, huma.Error404NotFound("series not found")
 		}

--- a/backend/internal/api/statistics.go
+++ b/backend/internal/api/statistics.go
@@ -119,12 +119,8 @@ func readUserStatistics(ctx context.Context, db *sqlx.DB, userID int) (UserStati
 	}
 	if err := db.GetContext(ctx, &stats.StartedReadingOrders, `
 		SELECT COUNT(*)
-		FROM (
-			SELECT roc.reading_order_id
-			FROM reading_order_comics roc
-			JOIN user_comics uc ON uc.comic_id = roc.comic_id AND uc.user_id = ? AND uc.read = 1
-			GROUP BY roc.reading_order_id
-		)
+		FROM user_reading_orders
+		WHERE user_id = ?
 	`, userID); err != nil {
 		return stats, err
 	}

--- a/backend/internal/db/migrations/010_user_reading_order_starts.sql
+++ b/backend/internal/db/migrations/010_user_reading_order_starts.sql
@@ -8,6 +8,36 @@ CREATE TABLE user_reading_orders (
 CREATE INDEX idx_user_reading_orders_user_started
 ON user_reading_orders(user_id, started_at);
 
+CREATE TABLE user_arc_starts (
+    arc_id     INTEGER NOT NULL REFERENCES arcs(id) ON DELETE CASCADE,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    started_at TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (arc_id, user_id)
+);
+CREATE INDEX idx_user_arc_starts_user_started ON user_arc_starts(user_id, started_at);
+
+CREATE TABLE user_series_starts (
+    series_id  INTEGER NOT NULL REFERENCES series(id) ON DELETE CASCADE,
+    user_id    INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    started_at TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (series_id, user_id)
+);
+CREATE INDEX idx_user_series_starts_user_started ON user_series_starts(user_id, started_at);
+
+CREATE TABLE user_character_starts (
+    character_id INTEGER NOT NULL REFERENCES characters(id) ON DELETE CASCADE,
+    user_id      INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    started_at   TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (character_id, user_id)
+);
+CREATE INDEX idx_user_character_starts_user_started ON user_character_starts(user_id, started_at);
+
 -- +goose Down
+DROP INDEX IF EXISTS idx_user_character_starts_user_started;
+DROP TABLE user_character_starts;
+DROP INDEX IF EXISTS idx_user_series_starts_user_started;
+DROP TABLE user_series_starts;
+DROP INDEX IF EXISTS idx_user_arc_starts_user_started;
+DROP TABLE user_arc_starts;
 DROP INDEX IF EXISTS idx_user_reading_orders_user_started;
 DROP TABLE user_reading_orders;

--- a/backend/internal/db/migrations/010_user_reading_order_starts.sql
+++ b/backend/internal/db/migrations/010_user_reading_order_starts.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+CREATE TABLE user_reading_orders (
+    reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
+    user_id          INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    started_at       TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (reading_order_id, user_id)
+);
+CREATE INDEX idx_user_reading_orders_user_started
+ON user_reading_orders(user_id, started_at);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_user_reading_orders_user_started;
+DROP TABLE user_reading_orders;

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -116,6 +116,7 @@ const activeListParams = computed(() => {
   const params = {}
   if (options.filter === 'favorites') params.favorite = true
   if (options.filter === 'other') params.favorite = false
+  if (options.filter === 'started') params.started = true
   if (options.status && options.status !== 'all') params.status = options.status
   if (options.sort) params.sort = options.sort
   if (options.direction) params.direction = options.direction
@@ -218,6 +219,7 @@ const {
   selectedOrder,
   quickSavingOrderID,
   ratingSaving,
+  startSaving,
   cblImporting,
   orderForm,
   visibleOrders,
@@ -226,6 +228,8 @@ const {
   openReadingOrder,
   toggleReadingOrderFavorite,
   rateSelectedReadingOrder,
+  startSelectedReadingOrder,
+  stopSelectedReadingOrder,
   refreshSelectedReadingOrderDetail,
   newReadingOrder,
   saveReadingOrder,
@@ -1637,11 +1641,14 @@ onUnmounted(() => {
         :read-only="isReadOnlyGuest"
         :saving="saving"
         :rating-saving="ratingSaving"
+        :start-saving="startSaving"
         @back="backToPreviousPage"
         @copy="copySelectedReadingOrder"
         @edit="editReadingOrder"
         @export-cbl="exportSelectedReadingOrderCBL"
         @rate="rateSelectedReadingOrder"
+        @start="startSelectedReadingOrder"
+        @stop="stopSelectedReadingOrder"
         @open-comic="openOrderComic"
         @toggle-read="toggleComicRead"
         @toggle-skipped="toggleComicSkipped"

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -156,10 +156,12 @@ const {
 
 const {
   selectedSeries,
+  startSaving: seriesStartSaving,
   visibleSeries,
   seriesBrowseSections,
   openSeries,
   toggleSeriesFavorite,
+  toggleSelectedSeriesStarted,
   importSelectedSeriesFromMetron,
   seriesImportRunning,
   refreshSelectedSeriesDetail,
@@ -176,10 +178,12 @@ const {
 const {
   selectedCharacter,
   quickSavingCharacterID,
+  startSaving: characterStartSaving,
   visibleCharacters,
   characterBrowseSections,
   openCharacter,
   toggleCharacterFavorite,
+  toggleSelectedCharacterStarted,
   importSelectedCharacterAppearances,
   characterImportRunning,
   refreshSelectedCharacterDetail,
@@ -196,12 +200,14 @@ const {
 const {
   selectedArc,
   quickSavingArcID,
+  startSaving: arcStartSaving,
   arcForm,
   visibleArcs,
   arcBrowseSections,
   arcProgress,
   openArc,
   toggleArcFavorite,
+  toggleSelectedArcStarted,
   newArc,
   editArc,
   loadArcs,
@@ -1683,10 +1689,12 @@ onUnmounted(() => {
         :selected-comic-id="selectedComic?.id"
         :quick-saving-comic-id="quickSavingComicID"
         :quick-saving-arc-id="quickSavingArcID"
+        :start-saving="arcStartSaving"
         :read-only="isReadOnlyGuest"
         @back="backToPreviousPage"
         @edit="editArc"
         @toggle-favorite="toggleArcFavorite"
+        @toggle-started="toggleSelectedArcStarted"
         @open-comic="openComic"
         @toggle-read="toggleComicRead"
         @toggle-skipped="toggleComicSkipped"
@@ -1719,9 +1727,11 @@ onUnmounted(() => {
         :selected-comic-id="selectedComic?.id"
         :quick-saving-comic-id="quickSavingComicID"
         :import-running="seriesImportRunning(selectedSeries)"
+        :start-saving="seriesStartSaving"
         :read-only="isReadOnlyGuest"
         @back="backToPreviousPage"
         @toggle-favorite="toggleSeriesFavorite"
+        @toggle-started="toggleSelectedSeriesStarted"
         @import-series="importSelectedSeriesFromMetron"
         @open-comic="openComic"
         @toggle-read="toggleComicRead"
@@ -1756,9 +1766,11 @@ onUnmounted(() => {
         :quick-saving-comic-id="quickSavingComicID"
         :quick-saving-character-id="quickSavingCharacterID"
         :import-running="characterImportRunning(selectedCharacter)"
+        :start-saving="characterStartSaving"
         :read-only="isReadOnlyGuest"
         @back="backToPreviousPage"
         @toggle-favorite="toggleCharacterFavorite"
+        @toggle-started="toggleSelectedCharacterStarted"
         @import-appearances="importSelectedCharacterAppearances"
         @open-comic="openComic"
         @toggle-read="toggleComicRead"

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -159,6 +159,14 @@ export function getArc(id) {
   return request(`/arcs/${id}`)
 }
 
+export function startReadingOrder(id) {
+  return send(`/readingOrders/${id}/start`, 'POST', {})
+}
+
+export function stopReadingOrder(id) {
+  return request(`/readingOrders/${id}/start`, { method: 'DELETE' })
+}
+
 export function createArc(payload) {
   return send('/arcs', 'POST', payload)
 }

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -183,12 +183,20 @@ export function setArcComics(id, payload) {
   return send(`/arcs/${id}/comics`, 'PUT', payload)
 }
 
+export function setArcStarted(id, started) {
+  return request(`/arcs/${id}/start`, { method: started ? 'POST' : 'DELETE' })
+}
+
 export function getSeries(id) {
   return request(`/series/${id}`)
 }
 
 export function updateSeriesFavorite(id, favorite) {
   return send(`/series/${id}/favorite`, 'PATCH', { favorite })
+}
+
+export function setSeriesStarted(id, started) {
+  return request(`/series/${id}/start`, { method: started ? 'POST' : 'DELETE' })
 }
 
 export function importLocalSeriesFromMetron(id) {
@@ -201,6 +209,10 @@ export function getCharacter(id) {
 
 export function updateCharacterFavorite(id, favorite) {
   return send(`/characters/${id}/favorite`, 'PATCH', { favorite })
+}
+
+export function setCharacterStarted(id, started) {
+  return request(`/characters/${id}/start`, { method: started ? 'POST' : 'DELETE' })
 }
 
 export function searchMetronCharacters(params) {

--- a/ui/src/components/AppSidebar.vue
+++ b/ui/src/components/AppSidebar.vue
@@ -115,14 +115,6 @@ function toggleAccountMenu() {
         <span>Comics</span>
       </router-link>
       <router-link
-        v-if="user"
-        :to="{ name: 'progress' }"
-        :class="{ active: activeView === 'progress' }"
-        @click="closeMenus"
-      >
-        <span>Progress</span>
-      </router-link>
-      <router-link
         :to="{ name: 'series' }"
         :class="{ active: activeView === 'series' }"
         @click="closeMenus"

--- a/ui/src/components/ArcDetailView.vue
+++ b/ui/src/components/ArcDetailView.vue
@@ -24,9 +24,17 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  startSaving: { type: Boolean, default: false },
 })
 
-defineEmits(['back', 'toggle-favorite', 'open-comic', 'toggle-read', 'toggle-skipped'])
+defineEmits([
+  'back',
+  'toggle-favorite',
+  'toggle-started',
+  'open-comic',
+  'toggle-read',
+  'toggle-skipped',
+])
 </script>
 
 <template>
@@ -34,6 +42,15 @@ defineEmits(['back', 'toggle-favorite', 'open-comic', 'toggle-read', 'toggle-ski
     <header class="detail-nav sticky-toolbar">
       <button class="secondary-button" type="button" @click="$emit('back')">Back</button>
       <div class="detail-nav-actions">
+        <button
+          v-if="selectedArc && !readOnly"
+          :class="selectedArc.startedAt ? 'secondary-button' : 'primary-button'"
+          type="button"
+          :disabled="startSaving"
+          @click="$emit('toggle-started')"
+        >
+          {{ startSaving ? 'Saving...' : selectedArc.startedAt ? 'Stop reading' : 'Start reading' }}
+        </button>
         <button
           v-if="selectedArc && !readOnly"
           type="button"
@@ -79,6 +96,10 @@ defineEmits(['back', 'toggle-favorite', 'open-comic', 'toggle-read', 'toggle-ski
             <strong>{{ selectedArc.comics.length }}</strong>
             <small>Comics</small>
           </span>
+          <span v-if="selectedArc.startedAt"
+            ><strong>Started</strong
+            ><small>{{ new Date(selectedArc.startedAt).toLocaleDateString() }}</small></span
+          >
         </div>
 
         <ComicListView

--- a/ui/src/components/ArcDetailView.vue
+++ b/ui/src/components/ArcDetailView.vue
@@ -44,15 +44,6 @@ defineEmits([
       <div class="detail-nav-actions">
         <button
           v-if="selectedArc && !readOnly"
-          :class="selectedArc.startedAt ? 'secondary-button' : 'primary-button'"
-          type="button"
-          :disabled="startSaving"
-          @click="$emit('toggle-started')"
-        >
-          {{ startSaving ? 'Saving...' : selectedArc.startedAt ? 'Stop reading' : 'Start reading' }}
-        </button>
-        <button
-          v-if="selectedArc && !readOnly"
           type="button"
           class="favorite-toggle detail-favorite-toggle"
           :class="{ active: selectedArc.favorite }"
@@ -62,6 +53,15 @@ defineEmits([
           @click="$emit('toggle-favorite', selectedArc)"
         >
           <span aria-hidden="true">{{ selectedArc.favorite ? '★' : '☆' }}</span>
+        </button>
+        <button
+          v-if="selectedArc && !readOnly"
+          :class="selectedArc.startedAt ? 'secondary-button' : 'primary-button'"
+          type="button"
+          :disabled="startSaving"
+          @click="$emit('toggle-started')"
+        >
+          {{ startSaving ? 'Saving...' : selectedArc.startedAt ? 'Stop reading' : 'Start reading' }}
         </button>
       </div>
     </header>

--- a/ui/src/components/ArcsBrowseView.vue
+++ b/ui/src/components/ArcsBrowseView.vue
@@ -60,11 +60,18 @@ const sortOptions = [
   { value: 'name', label: 'Name' },
   { value: 'progress', label: 'Progress' },
 ]
+const filterOptions = [
+  { value: 'all', label: 'All' },
+  { value: 'favorites', label: 'Favorites' },
+  { value: 'started', label: 'Started' },
+  { value: 'other', label: 'Other' },
+]
 
 const visibleArcs = computed(() => props.arcs)
 const visibleSections = computed(() => {
   if (props.filter === 'favorites') return sectionList('Favorites', visibleArcs.value)
   if (props.filter === 'other') return sectionList('Other Arcs', visibleArcs.value)
+  if (props.filter === 'started') return sectionList('Started Arcs', visibleArcs.value)
   return sectionList('All Arcs', visibleArcs.value)
 })
 
@@ -85,6 +92,7 @@ function sectionList(title, arcs) {
             :sort="sort"
             :direction="direction"
             :sort-options="sortOptions"
+            :filter-options="filterOptions"
             @update:search="$emit('update:search', $event)"
             @update:filter="$emit('update:filter', $event)"
             @update:sort="$emit('update:sort', $event)"
@@ -113,6 +121,7 @@ function sectionList(title, arcs) {
                   <span>
                     <strong>{{ arc.name }}</strong>
                     <small>{{ arc.description || 'No description' }}</small>
+                    <span v-if="arc.startedAt" class="started-pill">Started</span>
                   </span>
                 </button>
                 <button

--- a/ui/src/components/BrowseListTools.vue
+++ b/ui/src/components/BrowseListTools.vue
@@ -26,6 +26,14 @@ const props = defineProps({
     type: Array,
     required: true,
   },
+  filterOptions: {
+    type: Array,
+    default: () => [
+      { value: 'all', label: 'All' },
+      { value: 'favorites', label: 'Favorites' },
+      { value: 'other', label: 'Other' },
+    ],
+  },
 })
 
 const emit = defineEmits(['update:search', 'update:filter', 'update:sort', 'update:direction'])
@@ -39,33 +47,17 @@ const searchModel = computed({
 <template>
   <div class="comic-list-tools browse-list-tools">
     <input v-model="searchModel" type="search" :placeholder="searchPlaceholder" />
-    <div class="inline-filter-tabs" role="tablist" aria-label="Favorite filter">
+    <div class="inline-filter-tabs" role="tablist" aria-label="List filter">
       <button
+        v-for="option in filterOptions"
+        :key="option.value"
         type="button"
-        :class="{ active: filter === 'all' }"
+        :class="{ active: filter === option.value }"
         role="tab"
-        :aria-selected="filter === 'all'"
-        @click="$emit('update:filter', 'all')"
+        :aria-selected="filter === option.value"
+        @click="$emit('update:filter', option.value)"
       >
-        All
-      </button>
-      <button
-        type="button"
-        :class="{ active: filter === 'favorites' }"
-        role="tab"
-        :aria-selected="filter === 'favorites'"
-        @click="$emit('update:filter', 'favorites')"
-      >
-        Favorites
-      </button>
-      <button
-        type="button"
-        :class="{ active: filter === 'other' }"
-        role="tab"
-        :aria-selected="filter === 'other'"
-        @click="$emit('update:filter', 'other')"
-      >
-        Other
+        {{ option.label }}
       </button>
     </div>
     <select

--- a/ui/src/components/BrowseListTools.vue
+++ b/ui/src/components/BrowseListTools.vue
@@ -47,7 +47,12 @@ const searchModel = computed({
 <template>
   <div class="comic-list-tools browse-list-tools">
     <input v-model="searchModel" type="search" :placeholder="searchPlaceholder" />
-    <div class="inline-filter-tabs" role="tablist" aria-label="List filter">
+    <div
+      class="inline-filter-tabs"
+      :class="{ 'four-filter-tabs': filterOptions.length === 4 }"
+      role="tablist"
+      aria-label="List filter"
+    >
       <button
         v-for="option in filterOptions"
         :key="option.value"

--- a/ui/src/components/CharacterDetailView.vue
+++ b/ui/src/components/CharacterDetailView.vue
@@ -53,6 +53,18 @@ function characterProgress(character) {
       <div class="detail-nav-actions">
         <button
           v-if="selectedCharacter && !readOnly"
+          type="button"
+          class="favorite-toggle detail-favorite-toggle"
+          :class="{ active: selectedCharacter.favorite }"
+          :disabled="quickSavingCharacterId === selectedCharacter.id"
+          :aria-label="selectedCharacter.favorite ? 'Remove from favorites' : 'Add to favorites'"
+          :title="selectedCharacter.favorite ? 'Remove from favorites' : 'Add to favorites'"
+          @click="$emit('toggle-favorite', selectedCharacter)"
+        >
+          <span aria-hidden="true">{{ selectedCharacter.favorite ? '★' : '☆' }}</span>
+        </button>
+        <button
+          v-if="selectedCharacter && !readOnly"
           :class="selectedCharacter.startedAt ? 'secondary-button' : 'primary-button'"
           type="button"
           :disabled="startSaving"
@@ -65,18 +77,6 @@ function characterProgress(character) {
                 ? 'Stop reading'
                 : 'Start reading'
           }}
-        </button>
-        <button
-          v-if="selectedCharacter && !readOnly"
-          type="button"
-          class="favorite-toggle detail-favorite-toggle"
-          :class="{ active: selectedCharacter.favorite }"
-          :disabled="quickSavingCharacterId === selectedCharacter.id"
-          :aria-label="selectedCharacter.favorite ? 'Remove from favorites' : 'Add to favorites'"
-          :title="selectedCharacter.favorite ? 'Remove from favorites' : 'Add to favorites'"
-          @click="$emit('toggle-favorite', selectedCharacter)"
-        >
-          <span aria-hidden="true">{{ selectedCharacter.favorite ? '★' : '☆' }}</span>
         </button>
         <button
           v-if="selectedCharacter?.metronCharacterId && !readOnly"

--- a/ui/src/components/CharacterDetailView.vue
+++ b/ui/src/components/CharacterDetailView.vue
@@ -28,11 +28,13 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  startSaving: { type: Boolean, default: false },
 })
 
 defineEmits([
   'back',
   'toggle-favorite',
+  'toggle-started',
   'import-appearances',
   'open-comic',
   'toggle-read',
@@ -49,6 +51,21 @@ function characterProgress(character) {
     <header class="detail-nav sticky-toolbar">
       <button class="secondary-button" type="button" @click="$emit('back')">Back</button>
       <div class="detail-nav-actions">
+        <button
+          v-if="selectedCharacter && !readOnly"
+          :class="selectedCharacter.startedAt ? 'secondary-button' : 'primary-button'"
+          type="button"
+          :disabled="startSaving"
+          @click="$emit('toggle-started')"
+        >
+          {{
+            startSaving
+              ? 'Saving...'
+              : selectedCharacter.startedAt
+                ? 'Stop reading'
+                : 'Start reading'
+          }}
+        </button>
         <button
           v-if="selectedCharacter && !readOnly"
           type="button"
@@ -103,6 +120,10 @@ function characterProgress(character) {
             <strong>{{ selectedCharacter.aliases?.length || 0 }}</strong>
             <small>Aliases</small>
           </span>
+          <span v-if="selectedCharacter.startedAt"
+            ><strong>Started</strong
+            ><small>{{ new Date(selectedCharacter.startedAt).toLocaleDateString() }}</small></span
+          >
         </div>
         <div class="progress-meter" aria-label="Character read progress">
           <span :style="{ width: characterProgress(selectedCharacter) }"></span>

--- a/ui/src/components/CharactersBrowseView.vue
+++ b/ui/src/components/CharactersBrowseView.vue
@@ -62,11 +62,18 @@ const sortOptions = [
   { value: 'aliases', label: 'Aliases' },
   { value: 'progress', label: 'Progress' },
 ]
+const filterOptions = [
+  { value: 'all', label: 'All' },
+  { value: 'favorites', label: 'Favorites' },
+  { value: 'started', label: 'Started' },
+  { value: 'other', label: 'Other' },
+]
 
 const visibleCharacters = computed(() => props.characters)
 const visibleSections = computed(() => {
   if (props.filter === 'favorites') return sectionList('Favorites', visibleCharacters.value)
   if (props.filter === 'other') return sectionList('Other Characters', visibleCharacters.value)
+  if (props.filter === 'started') return sectionList('Started Characters', visibleCharacters.value)
   return sectionList('All Characters', visibleCharacters.value)
 })
 const hasFilters = computed(() => props.searchTerm || props.filter !== 'all')
@@ -91,6 +98,7 @@ function characterProgress(character) {
           :sort="sort"
           :direction="direction"
           :sort-options="sortOptions"
+          :filter-options="filterOptions"
           @update:search="$emit('update:search', $event)"
           @update:filter="$emit('update:filter', $event)"
           @update:sort="$emit('update:sort', $event)"
@@ -125,6 +133,7 @@ function characterProgress(character) {
                       character.aliases.join(', ')
                     }}</small>
                     <small v-else>No aliases saved</small>
+                    <span v-if="character.startedAt" class="started-pill">Started</span>
                   </span>
                 </button>
                 <button

--- a/ui/src/components/ComicDetailView.vue
+++ b/ui/src/components/ComicDetailView.vue
@@ -82,24 +82,6 @@ function seriesLabel(comic) {
       <div class="detail-nav-actions">
         <button
           v-if="selectedComic && !readOnly"
-          class="secondary-button"
-          type="button"
-          :disabled="metronActionDisabled"
-          @click="runMetronAction"
-        >
-          {{ metronActionLabel }}
-        </button>
-        <button
-          v-if="selectedComic?.metronIssueId && !readOnly"
-          class="ghost-button"
-          type="button"
-          :disabled="metronActionDisabled"
-          @click="forceMetronRefresh"
-        >
-          Force refresh
-        </button>
-        <button
-          v-if="selectedComic && !readOnly"
           class="read-toggle-button large"
           type="button"
           :disabled="quickSavingComicId === selectedComic.id"
@@ -116,6 +98,24 @@ function seriesLabel(comic) {
           @click="$emit('toggle-skipped', selectedComic)"
         >
           {{ selectedComic.skipped ? 'Unskip' : 'Skip' }}
+        </button>
+        <button
+          v-if="selectedComic && !readOnly"
+          class="secondary-button"
+          type="button"
+          :disabled="metronActionDisabled"
+          @click="runMetronAction"
+        >
+          {{ metronActionLabel }}
+        </button>
+        <button
+          v-if="selectedComic?.metronIssueId && !readOnly"
+          class="ghost-button"
+          type="button"
+          :disabled="metronActionDisabled"
+          @click="forceMetronRefresh"
+        >
+          Force refresh
         </button>
       </div>
     </header>

--- a/ui/src/components/ReadingOrderDetailView.vue
+++ b/ui/src/components/ReadingOrderDetailView.vue
@@ -34,6 +34,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  startSaving: {
+    type: Boolean,
+    default: false,
+  },
 })
 
 const emit = defineEmits([
@@ -43,6 +47,8 @@ const emit = defineEmits([
   'export-cbl',
   'open-comic',
   'rate',
+  'start',
+  'stop',
   'toggle-read',
   'toggle-skipped',
 ])
@@ -67,6 +73,24 @@ const renderedDescription = computed(() => {
       <button class="secondary-button" type="button" @click="$emit('back')">Back</button>
 
       <div class="detail-nav-actions">
+        <button
+          v-if="selectedOrder && !readOnly && !selectedOrder.startedAt"
+          class="primary-button"
+          type="button"
+          :disabled="startSaving"
+          @click="$emit('start')"
+        >
+          {{ startSaving ? 'Starting...' : 'Start reading order' }}
+        </button>
+        <button
+          v-if="selectedOrder && !readOnly && selectedOrder.startedAt"
+          class="secondary-button"
+          type="button"
+          :disabled="startSaving"
+          @click="$emit('stop')"
+        >
+          {{ startSaving ? 'Stopping...' : 'Stop reading' }}
+        </button>
         <button
           v-if="selectedOrder"
           class="secondary-button"
@@ -146,6 +170,10 @@ const renderedDescription = computed(() => {
           <span v-if="selectedOrder.authorName">
             <strong>{{ selectedOrder.authorName }}</strong>
             <small>Author</small>
+          </span>
+          <span v-if="selectedOrder.startedAt">
+            <strong>Started</strong>
+            <small>{{ new Date(selectedOrder.startedAt).toLocaleDateString() }}</small>
           </span>
         </div>
 

--- a/ui/src/components/ReadingOrderDetailView.vue
+++ b/ui/src/components/ReadingOrderDetailView.vue
@@ -92,12 +92,12 @@ const renderedDescription = computed(() => {
           {{ startSaving ? 'Stopping...' : 'Stop reading' }}
         </button>
         <button
-          v-if="selectedOrder"
-          class="secondary-button"
+          v-if="selectedOrder?.canEdit"
+          class="primary-button"
           type="button"
-          @click="$emit('export-cbl')"
+          @click="$emit('edit')"
         >
-          Export CBL
+          Edit
         </button>
         <button
           v-if="
@@ -114,12 +114,12 @@ const renderedDescription = computed(() => {
           {{ saving ? 'Copying...' : 'Copy' }}
         </button>
         <button
-          v-if="selectedOrder?.canEdit"
-          class="primary-button"
+          v-if="selectedOrder"
+          class="secondary-button"
           type="button"
-          @click="$emit('edit')"
+          @click="$emit('export-cbl')"
         >
-          Edit
+          Export CBL
         </button>
       </div>
     </header>

--- a/ui/src/components/ReadingOrdersBrowseView.vue
+++ b/ui/src/components/ReadingOrdersBrowseView.vue
@@ -69,11 +69,18 @@ const sortOptions = [
   { value: 'rating', label: 'Rating' },
   { value: 'progress', label: 'Progress' },
 ]
+const filterOptions = [
+  { value: 'all', label: 'All' },
+  { value: 'favorites', label: 'Favorites' },
+  { value: 'started', label: 'Started' },
+  { value: 'other', label: 'Other' },
+]
 
 const visibleOrders = computed(() => props.orders)
 const visibleSections = computed(() => {
   if (props.filter === 'favorites') return sectionList('Favorites', visibleOrders.value)
   if (props.filter === 'other') return sectionList('Other Orders', visibleOrders.value)
+  if (props.filter === 'started') return sectionList('Started Orders', visibleOrders.value)
   return sectionList('All Orders', visibleOrders.value)
 })
 const hasFilters = computed(() => props.searchTerm || props.filter !== 'all')
@@ -106,6 +113,7 @@ function handleCBLFile(event) {
             :sort="sort"
             :direction="direction"
             :sort-options="sortOptions"
+            :filter-options="filterOptions"
             @update:search="$emit('update:search', $event)"
             @update:filter="$emit('update:filter', $event)"
             @update:sort="$emit('update:sort', $event)"
@@ -177,6 +185,7 @@ function handleCBLFile(event) {
                       Rating: {{ formatRating(order.rating) }}
                       <template v-if="order.ratingCount">({{ order.ratingCount }})</template>
                     </span>
+                    <span v-if="order.startedAt" class="started-pill">Started</span>
                   </span>
                 </button>
                 <button

--- a/ui/src/components/SeriesBrowseView.vue
+++ b/ui/src/components/SeriesBrowseView.vue
@@ -64,11 +64,18 @@ const sortOptions = [
   { value: 'entries', label: 'Entries' },
   { value: 'progress', label: 'Progress' },
 ]
+const filterOptions = [
+  { value: 'all', label: 'All' },
+  { value: 'favorites', label: 'Favorites' },
+  { value: 'started', label: 'Started' },
+  { value: 'other', label: 'Other' },
+]
 
 const visibleSeries = computed(() => props.series)
 const visibleSections = computed(() => {
   if (props.filter === 'favorites') return sectionList('Favorites', visibleSeries.value)
   if (props.filter === 'other') return sectionList('Other Series', visibleSeries.value)
+  if (props.filter === 'started') return sectionList('Started Series', visibleSeries.value)
   return sectionList('All Series', visibleSeries.value)
 })
 const hasFilters = computed(() => props.searchTerm || props.filter !== 'all')
@@ -98,6 +105,7 @@ function seriesPublisherLabel(series) {
           :sort="sort"
           :direction="direction"
           :sort-options="sortOptions"
+          :filter-options="filterOptions"
           @update:search="$emit('update:search', $event)"
           @update:filter="$emit('update:filter', $event)"
           @update:sort="$emit('update:sort', $event)"
@@ -138,6 +146,7 @@ function seriesPublisherLabel(series) {
                   <span>
                     <strong>{{ item.name }}{{ seriesYearLabel(item) }}</strong>
                     <small>{{ seriesPublisherLabel(item) }}</small>
+                    <span v-if="item.startedAt" class="started-pill">Started</span>
                   </span>
                 </button>
                 <button

--- a/ui/src/components/SeriesDetailView.vue
+++ b/ui/src/components/SeriesDetailView.vue
@@ -53,17 +53,6 @@ function seriesPublisherLabel(series) {
       <div class="detail-nav-actions">
         <button
           v-if="selectedSeries && !readOnly"
-          :class="selectedSeries.startedAt ? 'secondary-button' : 'primary-button'"
-          type="button"
-          :disabled="startSaving"
-          @click="$emit('toggle-started')"
-        >
-          {{
-            startSaving ? 'Saving...' : selectedSeries.startedAt ? 'Stop reading' : 'Start reading'
-          }}
-        </button>
-        <button
-          v-if="selectedSeries && !readOnly"
           type="button"
           class="favorite-toggle detail-favorite-toggle"
           :class="{ active: selectedSeries.favorite }"
@@ -72,6 +61,17 @@ function seriesPublisherLabel(series) {
           @click="$emit('toggle-favorite', selectedSeries)"
         >
           <span aria-hidden="true">{{ selectedSeries.favorite ? '★' : '☆' }}</span>
+        </button>
+        <button
+          v-if="selectedSeries && !readOnly"
+          :class="selectedSeries.startedAt ? 'secondary-button' : 'primary-button'"
+          type="button"
+          :disabled="startSaving"
+          @click="$emit('toggle-started')"
+        >
+          {{
+            startSaving ? 'Saving...' : selectedSeries.startedAt ? 'Stop reading' : 'Start reading'
+          }}
         </button>
         <button
           v-if="selectedSeries?.metronSeriesId && !readOnly"

--- a/ui/src/components/SeriesDetailView.vue
+++ b/ui/src/components/SeriesDetailView.vue
@@ -23,11 +23,13 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  startSaving: { type: Boolean, default: false },
 })
 
 defineEmits([
   'back',
   'toggle-favorite',
+  'toggle-started',
   'import-series',
   'open-comic',
   'toggle-read',
@@ -49,6 +51,17 @@ function seriesPublisherLabel(series) {
     <header class="detail-nav sticky-toolbar">
       <button class="secondary-button" type="button" @click="$emit('back')">Back</button>
       <div class="detail-nav-actions">
+        <button
+          v-if="selectedSeries && !readOnly"
+          :class="selectedSeries.startedAt ? 'secondary-button' : 'primary-button'"
+          type="button"
+          :disabled="startSaving"
+          @click="$emit('toggle-started')"
+        >
+          {{
+            startSaving ? 'Saving...' : selectedSeries.startedAt ? 'Stop reading' : 'Start reading'
+          }}
+        </button>
         <button
           v-if="selectedSeries && !readOnly"
           type="button"
@@ -101,6 +114,10 @@ function seriesPublisherLabel(series) {
             <strong>{{ seriesPublisherLabel(selectedSeries) }}</strong>
             <small>Publisher</small>
           </span>
+          <span v-if="selectedSeries.startedAt"
+            ><strong>Started</strong
+            ><small>{{ new Date(selectedSeries.startedAt).toLocaleDateString() }}</small></span
+          >
         </div>
 
         <ComicListView

--- a/ui/src/composables/useArcs.js
+++ b/ui/src/composables/useArcs.js
@@ -4,6 +4,7 @@ import {
   deleteArc as removeArc,
   getArc,
   listArcs,
+  setArcStarted,
   setArcComics,
   updateArc,
 } from '@/api/client.js'
@@ -13,6 +14,7 @@ export function useArcs({ activeView, viewMode, error, saving, loadComics, loadP
   const arcs = ref([])
   const selectedArc = ref(null)
   const quickSavingArcID = ref(null)
+  const startSaving = ref(false)
   const arcForm = ref(emptyArc())
 
   const visibleArcs = computed(() => arcs.value)
@@ -75,6 +77,23 @@ export function useArcs({ activeView, viewMode, error, saving, loadComics, loadP
     }
     if (arcForm.value?.id === detail.id) {
       arcForm.value = { ...arcForm.value, favorite: detail.favorite }
+    }
+  }
+
+  async function toggleSelectedArcStarted() {
+    if (!selectedArc.value?.id || startSaving.value) return
+    startSaving.value = true
+    error.value = ''
+    try {
+      const detail = await setArcStarted(selectedArc.value.id, !selectedArc.value.startedAt)
+      selectedArc.value = detail
+      arcs.value = arcs.value.map((arc) =>
+        arc.id === detail.id ? { ...arc, startedAt: detail.startedAt || null } : arc,
+      )
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      startSaving.value = false
     }
   }
 
@@ -147,12 +166,14 @@ export function useArcs({ activeView, viewMode, error, saving, loadComics, loadP
     arcs,
     selectedArc,
     quickSavingArcID,
+    startSaving,
     arcForm,
     visibleArcs,
     arcBrowseSections,
     arcProgress,
     openArc,
     toggleArcFavorite,
+    toggleSelectedArcStarted,
     newArc,
     editArc,
     saveArc,

--- a/ui/src/composables/useCharacters.js
+++ b/ui/src/composables/useCharacters.js
@@ -3,6 +3,7 @@ import {
   getCharacter,
   importMetronCharacterAppearances,
   listCharacters,
+  setCharacterStarted,
   updateCharacterFavorite,
 } from '@/api/client.js'
 import { formatProgress } from '@/domain/readingOrders.js'
@@ -18,6 +19,7 @@ export function useCharacters({
   const characters = ref([])
   const selectedCharacter = ref(null)
   const quickSavingCharacterID = ref(null)
+  const startSaving = ref(false)
 
   const visibleCharacters = computed(() => characters.value)
   const favoriteVisibleCharacters = computed(() =>
@@ -70,6 +72,28 @@ export function useCharacters({
     }
   }
 
+  async function toggleSelectedCharacterStarted() {
+    if (!selectedCharacter.value?.id || startSaving.value) return
+    startSaving.value = true
+    error.value = ''
+    try {
+      const detail = await setCharacterStarted(
+        selectedCharacter.value.id,
+        !selectedCharacter.value.startedAt,
+      )
+      selectedCharacter.value = detail
+      characters.value = characters.value.map((character) =>
+        character.id === detail.id
+          ? { ...character, startedAt: detail.startedAt || null }
+          : character,
+      )
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      startSaving.value = false
+    }
+  }
+
   function characterProgress(character) {
     return formatProgress(character?.progress ?? 0)
   }
@@ -117,10 +141,12 @@ export function useCharacters({
     characters,
     selectedCharacter,
     quickSavingCharacterID,
+    startSaving,
     visibleCharacters,
     characterBrowseSections,
     openCharacter,
     toggleCharacterFavorite,
+    toggleSelectedCharacterStarted,
     characterProgress,
     importSelectedCharacterAppearances,
     characterImportRunning,

--- a/ui/src/composables/useReadingOrders.js
+++ b/ui/src/composables/useReadingOrders.js
@@ -7,6 +7,8 @@ import {
   getReadingOrder,
   importReadingOrderCBL,
   rateReadingOrder,
+  startReadingOrder,
+  stopReadingOrder,
   setReadingOrderComics,
   updateReadingOrder,
   listReadingOrders,
@@ -30,6 +32,7 @@ export function useReadingOrders({
   const selectedOrder = ref(null)
   const quickSavingOrderID = ref(null)
   const ratingSaving = ref(false)
+  const startSaving = ref(false)
   const cblImporting = ref(false)
   const orderForm = ref(emptyReadingOrder())
 
@@ -90,6 +93,42 @@ export function useReadingOrders({
       error.value = err.message
     } finally {
       quickSavingOrderID.value = null
+    }
+  }
+
+  async function startSelectedReadingOrder() {
+    if (!selectedOrder.value?.id || selectedOrder.value.startedAt || startSaving.value) return
+
+    startSaving.value = true
+    error.value = ''
+    try {
+      const detail = await startReadingOrder(selectedOrder.value.id)
+      selectedOrder.value = detail
+      readingOrders.value = readingOrders.value.map((order) =>
+        order.id === detail.id ? { ...order, startedAt: detail.startedAt } : order,
+      )
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      startSaving.value = false
+    }
+  }
+
+  async function stopSelectedReadingOrder() {
+    if (!selectedOrder.value?.id || !selectedOrder.value.startedAt || startSaving.value) return
+
+    startSaving.value = true
+    error.value = ''
+    try {
+      const detail = await stopReadingOrder(selectedOrder.value.id)
+      selectedOrder.value = detail
+      readingOrders.value = readingOrders.value.map((order) =>
+        order.id === detail.id ? { ...order, startedAt: null } : order,
+      )
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      startSaving.value = false
     }
   }
 
@@ -316,6 +355,7 @@ export function useReadingOrders({
     selectedOrder,
     quickSavingOrderID,
     ratingSaving,
+    startSaving,
     cblImporting,
     orderForm,
     visibleOrders,
@@ -325,6 +365,8 @@ export function useReadingOrders({
     refreshSelectedReadingOrderDetail,
     toggleReadingOrderFavorite,
     rateSelectedReadingOrder,
+    startSelectedReadingOrder,
+    stopSelectedReadingOrder,
     newReadingOrder,
     editReadingOrder,
     saveReadingOrder,

--- a/ui/src/composables/useSeries.js
+++ b/ui/src/composables/useSeries.js
@@ -1,5 +1,11 @@
 import { computed, ref } from 'vue'
-import { getSeries, importMetronSeries, listSeries, updateSeriesFavorite } from '@/api/client.js'
+import {
+  getSeries,
+  importMetronSeries,
+  listSeries,
+  setSeriesStarted,
+  updateSeriesFavorite,
+} from '@/api/client.js'
 
 export function useSeries({
   activeView,
@@ -11,6 +17,7 @@ export function useSeries({
 }) {
   const series = ref([])
   const selectedSeries = ref(null)
+  const startSaving = ref(false)
 
   const visibleSeries = computed(() => series.value)
   const favoriteVisibleSeries = computed(() => series.value.filter((item) => item.favorite))
@@ -56,6 +63,26 @@ export function useSeries({
     }
   }
 
+  async function toggleSelectedSeriesStarted() {
+    if (!selectedSeries.value?.id || startSaving.value) return
+    startSaving.value = true
+    error.value = ''
+    try {
+      const detail = await setSeriesStarted(
+        selectedSeries.value.id,
+        !selectedSeries.value.startedAt,
+      )
+      selectedSeries.value = detail
+      series.value = series.value.map((item) =>
+        item.id === detail.id ? { ...item, startedAt: detail.startedAt || null } : item,
+      )
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      startSaving.value = false
+    }
+  }
+
   async function importSelectedSeriesFromMetron() {
     if (!selectedSeries.value?.metronSeriesId || seriesImportRunning(selectedSeries.value)) return
 
@@ -92,10 +119,12 @@ export function useSeries({
   return {
     series,
     selectedSeries,
+    startSaving,
     visibleSeries,
     seriesBrowseSections,
     openSeries,
     toggleSeriesFavorite,
+    toggleSelectedSeriesStarted,
     importSelectedSeriesFromMetron,
     seriesImportRunning,
     refreshSelectedSeriesDetail,

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1942,6 +1942,21 @@ textarea {
   line-height: 1.2;
 }
 
+.started-pill {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin-top: 8px;
+  border: 1px solid var(--primary);
+  border-radius: 999px;
+  background: var(--primary-soft);
+  color: var(--primary-strong);
+  padding: 4px 9px;
+  font-size: 0.78rem;
+  font-weight: 800;
+  line-height: 1.2;
+}
+
 .favorite-pill {
   background: var(--warning-soft);
   color: var(--warning-ink);

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -2955,6 +2955,10 @@ textarea {
   grid-template-columns: repeat(4, minmax(0, 1fr));
 }
 
+.four-filter-tabs {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
 .comic-list-view {
   display: grid;
   gap: 12px;
@@ -3031,6 +3035,10 @@ textarea {
 
 .comic-list-tools .issue-status-tabs {
   min-width: 320px;
+}
+
+.comic-list-tools .four-filter-tabs {
+  min-width: 360px;
 }
 
 .issue-list {


### PR DESCRIPTION
## Summary
- add per-user start and stop state for reading orders, arcs, series, and characters
- expose started filters and overview indicators for each supported collection
- keep formal start timestamps separate from comic read progress and use them for started reading-order statistics
- keep the four-option filter control on one row and remove Progress from the main navigation while retaining it in the user menu

## Verification
- go test ./... from backend
- npm run lint from ui
- npm run build from ui