### PR TITLE
Add dashboard landing page

### DIFF
--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -306,6 +306,170 @@ func TestUserStatisticsAndAchievements(t *testing.T) {
 	}
 }
 
+func TestDashboardNextComicAdvancesAfterRead(t *testing.T) {
+	ctx := testUserContext()
+	db, err := sqlx.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open db: %v", err)
+	}
+	t.Cleanup(func() {
+		db.Close()
+	})
+
+	if _, err := db.Exec(`
+		CREATE TABLE users (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL UNIQUE,
+			email TEXT NOT NULL DEFAULT '',
+			email_verified_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
+			password_hash TEXT NOT NULL DEFAULT '',
+			is_default INTEGER NOT NULL DEFAULT 0,
+			is_admin INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE series (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			series_year INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE comics (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			metron_issue_id INTEGER,
+			series_id INTEGER REFERENCES series(id) ON DELETE SET NULL,
+			series TEXT NOT NULL,
+			series_year INTEGER NOT NULL DEFAULT 0,
+			issue TEXT NOT NULL,
+			publisher TEXT NOT NULL,
+			cover_date TEXT NOT NULL DEFAULT '',
+			cover_image TEXT NOT NULL DEFAULT '',
+			description TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE user_comics (
+			comic_id INTEGER NOT NULL REFERENCES comics(id) ON DELETE CASCADE,
+			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+			read INTEGER NOT NULL DEFAULT 0,
+			skipped INTEGER NOT NULL DEFAULT 0,
+			read_at TEXT NOT NULL DEFAULT '',
+			PRIMARY KEY (comic_id, user_id)
+		);
+		CREATE TABLE reading_orders (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			metron_reading_list_id INTEGER,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			image TEXT NOT NULL DEFAULT '',
+			favorite INTEGER NOT NULL DEFAULT 0,
+			author_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
+		);
+		CREATE TABLE user_reading_orders (
+			reading_order_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (reading_order_id, user_id)
+		);
+		CREATE TABLE reading_order_ratings (
+			reading_order_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			rating REAL NOT NULL,
+			PRIMARY KEY (reading_order_id, user_id)
+		);
+		CREATE TABLE reading_order_comics (
+			reading_order_id INTEGER NOT NULL,
+			comic_id INTEGER NOT NULL,
+			position INTEGER NOT NULL DEFAULT 0,
+			note TEXT NOT NULL DEFAULT '',
+			tags TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE reading_order_children (
+			parent_reading_order_id INTEGER NOT NULL,
+			child_reading_order_id INTEGER NOT NULL,
+			position INTEGER NOT NULL DEFAULT 0,
+			note TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE arcs (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			image TEXT NOT NULL DEFAULT '',
+			favorite INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE user_arc_starts (
+			arc_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (arc_id, user_id)
+		);
+		CREATE TABLE arc_comics (
+			arc_id INTEGER NOT NULL,
+			comic_id INTEGER NOT NULL,
+			position INTEGER NOT NULL DEFAULT 0,
+			note TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE characters (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			metron_character_id INTEGER,
+			name TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT '',
+			image TEXT NOT NULL DEFAULT '',
+			favorite INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE user_character_starts (
+			character_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (character_id, user_id)
+		);
+		CREATE TABLE comic_characters (
+			comic_id INTEGER NOT NULL,
+			character_id INTEGER NOT NULL,
+			PRIMARY KEY (comic_id, character_id)
+		);
+		CREATE TABLE user_series_starts (
+			series_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (series_id, user_id)
+		);
+
+		INSERT INTO users (id, name, is_default) VALUES (1, 'Reader', 1);
+		INSERT INTO series (id, name, series_year) VALUES (1, 'Alpha', 2020);
+		INSERT INTO comics (id, series_id, series, series_year, issue, publisher)
+		VALUES (1, 1, 'Alpha', 2020, '1', 'Pub'), (2, 1, 'Alpha', 2020, '2', 'Pub');
+		INSERT INTO reading_orders (id, name, author_user_id) VALUES (1, 'Alpha order', 1);
+		INSERT INTO user_reading_orders (reading_order_id, user_id, started_at)
+		VALUES (1, 1, '2026-07-01T10:00:00Z');
+		INSERT INTO reading_order_comics (reading_order_id, comic_id, position)
+		VALUES (1, 1, 1), (1, 2, 2);
+	`); err != nil {
+		t.Fatalf("create schema: %v", err)
+	}
+
+	dashboard, err := getDashboard(ctx, db)
+	if err != nil {
+		t.Fatalf("getDashboard: %v", err)
+	}
+	if len(dashboard.Body.Items) != 1 {
+		t.Fatalf("dashboard items = %d; want 1", len(dashboard.Body.Items))
+	}
+	if got := dashboard.Body.Items[0].NextComic.ID; got != 1 {
+		t.Fatalf("next comic = %d; want 1", got)
+	}
+
+	read := true
+	input := &UpdateComicReadInput{}
+	input.Body.Read = &read
+	if _, err := updateComicReadStatus(ctx, db, 1, input); err != nil {
+		t.Fatalf("updateComicReadStatus: %v", err)
+	}
+
+	dashboard, err = getDashboard(ctx, db)
+	if err != nil {
+		t.Fatalf("getDashboard after read: %v", err)
+	}
+	if got := dashboard.Body.Items[0].NextComic.ID; got != 2 {
+		t.Fatalf("next comic after read = %d; want 2", got)
+	}
+}
+
 func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
 	ctx := testUserContext()
 	db, err := sqlx.Open("sqlite", ":memory:")
@@ -1182,6 +1346,7 @@ func TestDocsConfigAndRouteMetadata(t *testing.T) {
 	RegisterCharacterRoutes(api, nil)
 	RegisterReadingOrderRoutes(api, nil, nil)
 	RegisterArcRoutes(api, nil)
+	RegisterDashboardRoutes(api, nil)
 	RegisterStatisticsRoutes(api, nil)
 	RegisterMetronRoutes(api, nil, metron.New(metron.Config{}), nil, newMetronImportJobStore())
 
@@ -1189,8 +1354,8 @@ func TestDocsConfigAndRouteMetadata(t *testing.T) {
 	if openAPI.Info.Description == "" {
 		t.Fatal("OpenAPI description is empty")
 	}
-	if len(openAPI.Tags) != 8 {
-		t.Fatalf("len(tags) = %d; want 8", len(openAPI.Tags))
+	if len(openAPI.Tags) != 9 {
+		t.Fatalf("len(tags) = %d; want 9", len(openAPI.Tags))
 	}
 
 	listComics := openAPI.Paths["/comics"].Get
@@ -1204,6 +1369,11 @@ func TestDocsConfigAndRouteMetadata(t *testing.T) {
 	accountStatistics := openAPI.Paths["/account/statistics"].Get
 	if len(accountStatistics.Tags) != 1 || accountStatistics.Tags[0] != tagStatistics {
 		t.Fatalf("account statistics tags = %#v; want Statistics tag", accountStatistics.Tags)
+	}
+
+	dashboard := openAPI.Paths["/dashboard"].Get
+	if len(dashboard.Tags) != 1 || dashboard.Tags[0] != tagDashboard {
+		t.Fatalf("dashboard tags = %#v; want Dashboard tag", dashboard.Tags)
 	}
 
 	listCharacters := openAPI.Paths["/characters"].Get

--- a/backend/internal/api/dashboard.go
+++ b/backend/internal/api/dashboard.go
@@ -1,0 +1,368 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/jmoiron/sqlx"
+)
+
+type dashboardComicRow struct {
+	ID            int     `db:"id"`
+	Name          string  `db:"name"`
+	StartedAt     string  `db:"started_at"`
+	Progress      float64 `db:"progress"`
+	ComicID       int     `db:"comic_id"`
+	MetronIssueID *int    `db:"metron_issue_id"`
+	SeriesID      *int    `db:"series_id"`
+	Series        string  `db:"series"`
+	SeriesYear    int     `db:"series_year"`
+	Issue         string  `db:"issue"`
+	Publisher     string  `db:"publisher"`
+	CoverDate     string  `db:"cover_date"`
+	CoverImage    string  `db:"cover_image"`
+	Description   string  `db:"description"`
+	Read          bool    `db:"read"`
+	Skipped       bool    `db:"skipped"`
+}
+
+func RegisterDashboardRoutes(api huma.API, db *sqlx.DB) {
+	huma.Register(api, huma.Operation{
+		OperationID: "getDashboard",
+		Tags:        []string{tagDashboard},
+		Summary:     "Get dashboard",
+		Description: "Returns started reading content with each item's next unread and unskipped comic, plus achievement highlights.",
+		Method:      http.MethodGet,
+		Path:        "/dashboard",
+		Errors:      []int{401, 500},
+	}, func(ctx context.Context, input *struct{}) (*DashboardOutput, error) {
+		return getDashboard(ctx, db)
+	})
+}
+
+func getDashboard(ctx context.Context, db *sqlx.DB) (*DashboardOutput, error) {
+	userID, err := currentUserID(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	items, err := dashboardItems(ctx, db, userID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to fetch dashboard")
+	}
+	achievements, err := dashboardAchievements(ctx, db, userID)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to fetch dashboard achievements")
+	}
+
+	return &DashboardOutput{
+		Body: DashboardView{
+			Items:        items,
+			Achievements: achievements,
+		},
+	}, nil
+}
+
+func dashboardItems(ctx context.Context, db *sqlx.DB, userID int) ([]DashboardItem, error) {
+	items := []DashboardItem{}
+	for _, loader := range []func(context.Context, *sqlx.DB, int) ([]DashboardItem, error){
+		dashboardReadingOrders,
+		dashboardArcs,
+		dashboardCharacters,
+		dashboardSeries,
+	} {
+		loaded, err := loader(ctx, db, userID)
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, loaded...)
+	}
+
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].StartedAt == items[j].StartedAt {
+			if items[i].Type == items[j].Type {
+				return items[i].Name < items[j].Name
+			}
+			return items[i].Type < items[j].Type
+		}
+		return items[i].StartedAt < items[j].StartedAt
+	})
+	return items, nil
+}
+
+func dashboardReadingOrders(ctx context.Context, db *sqlx.DB, userID int) ([]DashboardItem, error) {
+	rows := []struct {
+		ID        int    `db:"id"`
+		Name      string `db:"name"`
+		StartedAt string `db:"started_at"`
+	}{}
+	if err := db.SelectContext(ctx, &rows, `
+		SELECT ro.id, ro.name, started.started_at
+		FROM user_reading_orders started
+		JOIN reading_orders ro ON ro.id = started.reading_order_id
+		WHERE started.user_id = ?
+		ORDER BY started.started_at, ro.name
+	`, userID); err != nil {
+		return nil, err
+	}
+
+	items := make([]DashboardItem, 0, len(rows))
+	for _, row := range rows {
+		comics := []ReadingOrderComic{}
+		detail, err := getReadingOrder(ctx, db, row.ID)
+		if err != nil {
+			return nil, err
+		}
+		comics = detail.Body.Comics
+
+		next := nextReadingOrderComic(comics)
+		progress := computeProgress(comics)
+		items = append(items, DashboardItem{
+			Type:      "readingOrder",
+			ID:        row.ID,
+			Name:      row.Name,
+			StartedAt: row.StartedAt,
+			Progress:  progress,
+			NextComic: next,
+		})
+	}
+	return items, nil
+}
+
+func dashboardArcs(ctx context.Context, db *sqlx.DB, userID int) ([]DashboardItem, error) {
+	rows := []dashboardComicRow{}
+	if err := db.SelectContext(ctx, &rows, `
+		SELECT
+			a.id,
+			a.name,
+			started.started_at,
+			CASE
+				WHEN totals.total_count = 0 THEN 0.0
+				ELSE CAST(totals.read_count AS REAL) / totals.total_count
+			END AS progress,
+			COALESCE(c.id, 0) AS comic_id,
+			c.metron_issue_id,
+			c.series_id,
+			COALESCE(c.series, '') AS series,
+			COALESCE(c.series_year, 0) AS series_year,
+			COALESCE(c.issue, '') AS issue,
+			COALESCE(c.publisher, '') AS publisher,
+			COALESCE(c.cover_date, '') AS cover_date,
+			COALESCE(c.cover_image, '') AS cover_image,
+			COALESCE(c.description, '') AS description,
+			COALESCE(uc.read, 0) AS read,
+			COALESCE(uc.skipped, 0) AS skipped
+		FROM user_arc_starts started
+		JOIN arcs a ON a.id = started.arc_id
+		LEFT JOIN (
+			SELECT ac.arc_id, COUNT(*) AS total_count,
+				SUM(CASE WHEN COALESCE(uc_total.read, 0) = 1 THEN 1 ELSE 0 END) AS read_count
+			FROM arc_comics ac
+			LEFT JOIN user_comics uc_total ON uc_total.comic_id = ac.comic_id AND uc_total.user_id = ?
+			GROUP BY ac.arc_id
+		) totals ON totals.arc_id = a.id
+		LEFT JOIN arc_comics next_ac ON next_ac.arc_id = a.id
+			AND next_ac.position = (
+				SELECT MIN(candidate.position)
+				FROM arc_comics candidate
+				LEFT JOIN user_comics candidate_uc ON candidate_uc.comic_id = candidate.comic_id AND candidate_uc.user_id = ?
+				WHERE candidate.arc_id = a.id
+					AND COALESCE(candidate_uc.read, 0) = 0
+					AND COALESCE(candidate_uc.skipped, 0) = 0
+			)
+		LEFT JOIN comics c ON c.id = next_ac.comic_id
+		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
+		WHERE started.user_id = ?
+		ORDER BY started.started_at, a.name
+	`, userID, userID, userID, userID); err != nil {
+		return nil, err
+	}
+	return dashboardItemsFromComicRows("arc", rows), nil
+}
+
+func dashboardCharacters(ctx context.Context, db *sqlx.DB, userID int) ([]DashboardItem, error) {
+	rows := []dashboardComicRow{}
+	if err := db.SelectContext(ctx, &rows, `
+		SELECT
+			ch.id,
+			ch.name,
+			started.started_at,
+			COALESCE(totals.progress, 0.0) AS progress,
+			COALESCE(c.id, 0) AS comic_id,
+			c.metron_issue_id,
+			c.series_id,
+			COALESCE(c.series, '') AS series,
+			COALESCE(c.series_year, 0) AS series_year,
+			COALESCE(c.issue, '') AS issue,
+			COALESCE(c.publisher, '') AS publisher,
+			COALESCE(c.cover_date, '') AS cover_date,
+			COALESCE(c.cover_image, '') AS cover_image,
+			COALESCE(c.description, '') AS description,
+			COALESCE(uc.read, 0) AS read,
+			COALESCE(uc.skipped, 0) AS skipped
+		FROM user_character_starts started
+		JOIN characters ch ON ch.id = started.character_id
+		LEFT JOIN (
+			SELECT cc.character_id,
+				AVG(CASE WHEN COALESCE(uc_total.read, 0) = 1 THEN 1.0 ELSE 0.0 END) AS progress
+			FROM comic_characters cc
+			LEFT JOIN user_comics uc_total ON uc_total.comic_id = cc.comic_id AND uc_total.user_id = ?
+			GROUP BY cc.character_id
+		) totals ON totals.character_id = ch.id
+		LEFT JOIN comic_characters next_cc ON next_cc.character_id = ch.id
+			AND next_cc.comic_id = (
+				SELECT candidate.comic_id
+				FROM comic_characters candidate
+				JOIN comics candidate_comic ON candidate_comic.id = candidate.comic_id
+				LEFT JOIN user_comics candidate_uc ON candidate_uc.comic_id = candidate.comic_id AND candidate_uc.user_id = ?
+				WHERE candidate.character_id = ch.id
+					AND COALESCE(candidate_uc.read, 0) = 0
+					AND COALESCE(candidate_uc.skipped, 0) = 0
+				ORDER BY candidate_comic.series, candidate_comic.series_year, CAST(candidate_comic.issue AS REAL), candidate_comic.issue
+				LIMIT 1
+			)
+		LEFT JOIN comics c ON c.id = next_cc.comic_id
+		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
+		WHERE started.user_id = ?
+		ORDER BY started.started_at, ch.name
+	`, userID, userID, userID, userID); err != nil {
+		return nil, err
+	}
+	return dashboardItemsFromComicRows("character", rows), nil
+}
+
+func dashboardSeries(ctx context.Context, db *sqlx.DB, userID int) ([]DashboardItem, error) {
+	rows := []dashboardComicRow{}
+	if err := db.SelectContext(ctx, &rows, `
+		SELECT
+			s.id,
+			CASE WHEN s.series_year > 0 THEN s.name || ' (' || s.series_year || ')' ELSE s.name END AS name,
+			started.started_at,
+			CASE
+				WHEN totals.total_count = 0 THEN 0.0
+				ELSE CAST(totals.read_count AS REAL) / totals.total_count
+			END AS progress,
+			COALESCE(c.id, 0) AS comic_id,
+			c.metron_issue_id,
+			c.series_id,
+			COALESCE(c.series, '') AS series,
+			COALESCE(c.series_year, 0) AS series_year,
+			COALESCE(c.issue, '') AS issue,
+			COALESCE(c.publisher, '') AS publisher,
+			COALESCE(c.cover_date, '') AS cover_date,
+			COALESCE(c.cover_image, '') AS cover_image,
+			COALESCE(c.description, '') AS description,
+			COALESCE(uc.read, 0) AS read,
+			COALESCE(uc.skipped, 0) AS skipped
+		FROM user_series_starts started
+		JOIN series s ON s.id = started.series_id
+		LEFT JOIN (
+			SELECT c_total.series_id, COUNT(*) AS total_count,
+				SUM(CASE WHEN COALESCE(uc_total.read, 0) = 1 THEN 1 ELSE 0 END) AS read_count
+			FROM comics c_total
+			LEFT JOIN user_comics uc_total ON uc_total.comic_id = c_total.id AND uc_total.user_id = ?
+			GROUP BY c_total.series_id
+		) totals ON totals.series_id = s.id
+		LEFT JOIN comics c ON c.id = (
+			SELECT candidate.id
+			FROM comics candidate
+			LEFT JOIN user_comics candidate_uc ON candidate_uc.comic_id = candidate.id AND candidate_uc.user_id = ?
+			WHERE candidate.series_id = s.id
+				AND COALESCE(candidate_uc.read, 0) = 0
+				AND COALESCE(candidate_uc.skipped, 0) = 0
+			ORDER BY candidate.series_year, CAST(candidate.issue AS REAL), candidate.issue
+			LIMIT 1
+		)
+		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
+		WHERE started.user_id = ?
+		ORDER BY started.started_at, s.name, s.series_year
+	`, userID, userID, userID, userID); err != nil {
+		return nil, err
+	}
+	return dashboardItemsFromComicRows("series", rows), nil
+}
+
+func dashboardItemsFromComicRows(contentType string, rows []dashboardComicRow) []DashboardItem {
+	items := make([]DashboardItem, 0, len(rows))
+	for _, row := range rows {
+		comic := nextComic(row.Comic())
+		items = append(items, DashboardItem{
+			Type:      contentType,
+			ID:        row.ID,
+			Name:      row.Name,
+			StartedAt: row.StartedAt,
+			Progress:  row.Progress,
+			NextComic: comic,
+		})
+	}
+	return items
+}
+
+func nextReadingOrderComic(comics []ReadingOrderComic) *Comic {
+	for i := range comics {
+		if !comics[i].Read && !comics[i].Skipped {
+			comic := comics[i].Comic
+			return &comic
+		}
+	}
+	return nil
+}
+
+func nextComic(comic Comic) *Comic {
+	if comic.ID == 0 {
+		return nil
+	}
+	hydrateComicTitle(&comic)
+	return &comic
+}
+
+func (row dashboardComicRow) Comic() Comic {
+	return Comic{
+		ID:            row.ComicID,
+		MetronIssueID: row.MetronIssueID,
+		SeriesID:      row.SeriesID,
+		Series:        row.Series,
+		SeriesYear:    row.SeriesYear,
+		Issue:         row.Issue,
+		Publisher:     row.Publisher,
+		CoverDate:     row.CoverDate,
+		CoverImage:    row.CoverImage,
+		Description:   row.Description,
+		Read:          row.Read,
+		Skipped:       row.Skipped,
+	}
+}
+
+func dashboardAchievements(ctx context.Context, db *sqlx.DB, userID int) (DashboardAchievementSummary, error) {
+	stats, err := readUserStatistics(ctx, db, userID)
+	if err != nil {
+		return DashboardAchievementSummary{}, err
+	}
+	earnedAt, err := achievementEarnedAt(ctx, db, userID, stats)
+	if err != nil {
+		return DashboardAchievementSummary{}, err
+	}
+	achievements := buildAchievements(stats, earnedAt)
+
+	var recent *Achievement
+	var recentTime time.Time
+	var next *Achievement
+	for i := range achievements {
+		achievement := achievements[i]
+		if achievement.Earned {
+			earnedTime, err := time.Parse(time.RFC3339, achievement.EarnedAt)
+			if err == nil && (recent == nil || earnedTime.After(recentTime)) {
+				recent = &achievement
+				recentTime = earnedTime
+			}
+			continue
+		}
+		if next == nil || achievement.Percent > next.Percent {
+			next = &achievement
+		}
+	}
+	return DashboardAchievementSummary{Recent: recent, Next: next}, nil
+}

--- a/backend/internal/api/docs.go
+++ b/backend/internal/api/docs.go
@@ -4,6 +4,7 @@ import "github.com/danielgtaylor/huma/v2"
 
 const (
 	tagComics        = "Comics"
+	tagDashboard     = "Dashboard"
 	tagSeries        = "Series"
 	tagCharacters    = "Characters"
 	tagArcs          = "Arcs"
@@ -28,6 +29,7 @@ func DocsConfig() huma.Config {
 	}
 	config.OpenAPI.Tags = []*huma.Tag{
 		{Name: tagComics, Description: "Track comic metadata, read status, and reading-order membership."},
+		{Name: tagDashboard, Description: "Summarize active reading queues and achievement highlights."},
 		{Name: tagSeries, Description: "Browse local comic series, their read progress, and favorite state."},
 		{Name: tagCharacters, Description: "Browse characters imported from Metron and their local comic appearances."},
 		{Name: tagArcs, Description: "Manage story arcs and their ordered comic entries."},

--- a/backend/internal/api/models.go
+++ b/backend/internal/api/models.go
@@ -165,6 +165,29 @@ type UserStatisticsOutput struct {
 	Body UserStatisticsView
 }
 
+type DashboardItem struct {
+	Type      string  `json:"type"      doc:"Started content type." enum:"readingOrder,arc,character,series" example:"readingOrder"`
+	ID        int     `json:"id"        doc:"Local content identifier." example:"7"`
+	Name      string  `json:"name"      doc:"Started content display name." example:"Batman: Court of Owls"`
+	StartedAt string  `json:"startedAt" doc:"When the current user started this content." example:"2026-07-10T12:30:00Z"`
+	Progress  float64 `json:"progress"  doc:"Read progress for this content, from 0 to 1." minimum:"0" maximum:"1" example:"0.5"`
+	NextComic *Comic  `json:"nextComic,omitempty" doc:"Next unread and unskipped comic in this started content."`
+}
+
+type DashboardAchievementSummary struct {
+	Recent *Achievement `json:"recent,omitempty" doc:"Most recently earned achievement."`
+	Next   *Achievement `json:"next,omitempty"   doc:"Next locked achievement closest to being earned."`
+}
+
+type DashboardView struct {
+	Items        []DashboardItem             `json:"items"        doc:"Started reading orders, arcs, characters, and series with their next comic."`
+	Achievements DashboardAchievementSummary `json:"achievements" doc:"Achievement highlights for the current user."`
+}
+
+type DashboardOutput struct {
+	Body DashboardView
+}
+
 type UserStatusInput struct {
 	Session string `cookie:"comichero_session"`
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -52,6 +52,7 @@ func main() {
 
 	api.RegisterReadingOrderRoutes(humaAPI, database, covers)
 	api.RegisterUserRoutes(humaAPI, database)
+	api.RegisterDashboardRoutes(humaAPI, database)
 	api.RegisterStatisticsRoutes(humaAPI, database)
 	api.RegisterArcRoutes(humaAPI, database)
 	api.RegisterComicRoutes(humaAPI, database, covers)

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -10,6 +10,7 @@ import CharactersBrowseView from '@/components/CharactersBrowseView.vue'
 import CharacterDetailView from '@/components/CharacterDetailView.vue'
 import ComicDetailView from '@/components/ComicDetailView.vue'
 import ComicListView from '@/components/ComicListView.vue'
+import DashboardView from '@/components/DashboardView.vue'
 import MetronImport from '@/components/MetronImport.vue'
 import MetronImportMonitor from '@/components/MetronImportMonitor.vue'
 import ProgressView from '@/components/ProgressView.vue'
@@ -32,6 +33,7 @@ import {
   deleteAccount as deleteAccountRequest,
   deleteUser as deleteUserRequest,
   getAccountStatistics,
+  getDashboard,
   getUserStatus,
   listUsers,
   loginUser,
@@ -43,13 +45,14 @@ import {
   setupUsers,
   updateAccount,
   updatePublicAccess,
+  updateComicReadStatus,
   updateRegistrationMode,
   updateUserAdmin,
   updateUserMetronPermissions,
   verifyEmail,
 } from '@/api/client.js'
 
-const activeView = ref('readingOrders')
+const activeView = ref('dashboard')
 const viewMode = ref('browse')
 const loading = ref(false)
 const saving = ref(false)
@@ -84,6 +87,8 @@ const accountDeleting = ref(false)
 const accountStatistics = ref(null)
 const accountStatisticsLoading = ref(false)
 const accountStatisticsError = ref('')
+const dashboard = ref(null)
+const dashboardLoading = ref(false)
 const savingUserID = ref(null)
 const savingAdminUserID = ref(null)
 const deletingUserID = ref(null)
@@ -290,6 +295,7 @@ const {
 })
 
 const toolbarResultCount = computed(() => {
+  if (activeView.value === 'dashboard') return dashboard.value?.items?.length || 0
   if (activeView.value === 'readingOrders') return visibleOrders.value.length
   if (activeView.value === 'arcs') return visibleArcs.value.length
   if (activeView.value === 'comics') return comics.value.length
@@ -300,6 +306,7 @@ const toolbarResultCount = computed(() => {
   return 0
 })
 const toolbarTotalCount = computed(() => {
+  if (activeView.value === 'dashboard') return dashboard.value?.items?.length || 0
   if (activeView.value === 'readingOrders') return listTotal('readingOrders')
   if (activeView.value === 'arcs') return listTotal('arcs')
   if (activeView.value === 'comics') return listTotal('comics')
@@ -310,6 +317,7 @@ const toolbarTotalCount = computed(() => {
   return 0
 })
 const loadingLabel = computed(() => {
+  if (activeView.value === 'dashboard') return 'Loading dashboard...'
   if (activeView.value === 'readingOrders') return 'Loading orders...'
   if (activeView.value === 'arcs') return 'Loading arcs...'
   if (activeView.value === 'comics') return 'Loading comics...'
@@ -797,6 +805,7 @@ function entityRouteState(routeView, detailMode = 'detail') {
 }
 
 function routeToAppState() {
+  if (route.name === 'dashboard') return { view: 'dashboard', mode: 'browse' }
   if (route.name === 'readingOrders') return { view: 'readingOrders', mode: 'browse' }
   if (route.name === 'readingOrdersNew') return { view: 'readingOrders', mode: 'edit', isNew: true }
   if (route.name === 'readingOrderDetail') return entityRouteState('readingOrders')
@@ -818,10 +827,11 @@ function routeToAppState() {
   if (route.name === 'account') return { view: 'account', mode: 'browse' }
   if (route.name === 'progress') return { view: 'progress', mode: 'browse' }
   if (route.name === 'notFound') return { view: 'notFound', mode: 'browse' }
-  return { view: 'readingOrders', mode: 'browse', replace: true }
+  return { view: 'dashboard', mode: 'browse', replace: true }
 }
 
 function browseRouteLocation(view) {
+  if (view === 'dashboard') return { name: 'dashboard' }
   if (view === 'readingOrders') return { name: 'readingOrders' }
   if (view === 'arcs') return { name: 'arcs' }
   if (view === 'comics') return { name: 'comics' }
@@ -1008,6 +1018,10 @@ async function ensureMetronImportMonitor() {
 }
 
 async function loadActiveViewData(options = {}) {
+  if (activeView.value === 'dashboard') {
+    await loadDashboard()
+    return
+  }
   if (activeView.value === 'readingOrders') {
     await loadReadingOrders(options)
     return
@@ -1044,6 +1058,37 @@ async function loadActiveViewData(options = {}) {
   if (activeView.value === 'progress') {
     await loadAccountStatistics()
     return
+  }
+}
+
+async function loadDashboard() {
+  dashboardLoading.value = true
+  try {
+    dashboard.value = await getDashboard()
+  } finally {
+    dashboardLoading.value = false
+  }
+}
+
+async function markDashboardComicRead(comic) {
+  await setDashboardComicStatus(comic, { read: true })
+}
+
+async function markDashboardComicSkipped(comic) {
+  await setDashboardComicStatus(comic, { skipped: true })
+}
+
+async function setDashboardComicStatus(comic, payload) {
+  if (!comic?.id || quickSavingComicID.value) return
+  quickSavingComicID.value = comic.id
+  error.value = ''
+  try {
+    await updateComicReadStatus(comic.id, payload)
+    await loadDashboard()
+  } catch (err) {
+    error.value = err.message
+  } finally {
+    quickSavingComicID.value = null
   }
 }
 
@@ -1577,6 +1622,18 @@ onUnmounted(() => {
         @error="showError"
         @job-started="trackMetronImportJob"
         @quota-updated="updateMetronQuota"
+      />
+
+      <DashboardView
+        v-else-if="activeView === 'dashboard'"
+        :dashboard="dashboard"
+        :loading="dashboardLoading"
+        :quick-saving-comic-id="quickSavingComicID"
+        :read-only="isReadOnlyGuest"
+        @refresh="loadDashboard"
+        @open-comic="openComic"
+        @mark-read="markDashboardComicRead"
+        @mark-skipped="markDashboardComicSkipped"
       />
 
       <UserManagementView

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -283,6 +283,10 @@ export function getAccountStatistics() {
   return request('/account/statistics')
 }
 
+export function getDashboard() {
+  return request('/dashboard')
+}
+
 export function deleteAccount(payload) {
   return send('/account', 'DELETE', payload)
 }

--- a/ui/src/components/AppSidebar.vue
+++ b/ui/src/components/AppSidebar.vue
@@ -94,6 +94,13 @@ function toggleAccountMenu() {
 
     <nav id="primary-navigation" class="nav-tabs" aria-label="Primary">
       <router-link
+        :to="{ name: 'dashboard' }"
+        :class="{ active: activeView === 'dashboard' }"
+        @click="closeMenus"
+      >
+        <span>Dashboard</span>
+      </router-link>
+      <router-link
         :to="{ name: 'readingOrders' }"
         :class="{ active: activeView === 'readingOrders' }"
         @click="closeMenus"

--- a/ui/src/components/DashboardView.vue
+++ b/ui/src/components/DashboardView.vue
@@ -1,0 +1,143 @@
+<script setup>
+import { computed } from 'vue'
+import { assetURL } from '@/api/client.js'
+import { formatProgress } from '@/domain/readingOrders.js'
+
+const props = defineProps({
+  dashboard: {
+    type: Object,
+    default: null,
+  },
+  loading: {
+    type: Boolean,
+    default: false,
+  },
+  quickSavingComicId: {
+    type: Number,
+    default: null,
+  },
+  readOnly: {
+    type: Boolean,
+    default: false,
+  },
+})
+
+defineEmits(['refresh', 'open-comic', 'mark-read', 'mark-skipped'])
+
+const items = computed(() => props.dashboard?.items || [])
+const recentAchievement = computed(() => props.dashboard?.achievements?.recent || null)
+const nextAchievement = computed(() => props.dashboard?.achievements?.next || null)
+
+function itemTypeLabel(type) {
+  if (type === 'readingOrder') return 'Reading order'
+  if (type === 'arc') return 'Arc'
+  if (type === 'character') return 'Character'
+  if (type === 'series') return 'Series'
+  return 'Started'
+}
+
+function achievementProgress(achievement) {
+  if (!achievement) return ''
+  return `${achievement.progress} / ${achievement.target}`
+}
+</script>
+
+<template>
+  <section class="dashboard-view">
+    <header class="dashboard-header">
+      <div>
+        <p class="eyebrow">Dashboard</p>
+        <h2>Continue reading</h2>
+      </div>
+      <button class="secondary-button" type="button" :disabled="loading" @click="$emit('refresh')">
+        {{ loading ? 'Refreshing...' : 'Refresh' }}
+      </button>
+    </header>
+
+    <div class="dashboard-achievements">
+      <article class="achievement-summary-card">
+        <p class="eyebrow">Recently earned</p>
+        <template v-if="recentAchievement">
+          <h3>{{ recentAchievement.name }}</h3>
+          <p>{{ recentAchievement.description }}</p>
+        </template>
+        <p v-else class="muted">No achievements earned yet.</p>
+      </article>
+      <article class="achievement-summary-card">
+        <p class="eyebrow">Next achievement</p>
+        <template v-if="nextAchievement">
+          <h3>{{ nextAchievement.name }}</h3>
+          <p>{{ nextAchievement.description }}</p>
+          <div class="progress-meter" :aria-label="`${nextAchievement.name} progress`">
+            <span :style="{ width: formatProgress(nextAchievement.percent) }"></span>
+          </div>
+          <small>{{ achievementProgress(nextAchievement) }}</small>
+        </template>
+        <p v-else class="muted">All achievements earned.</p>
+      </article>
+    </div>
+
+    <div v-if="loading && !dashboard" class="empty-panel">
+      <span class="loading-spinner" aria-hidden="true"></span>
+      <p>Loading dashboard...</p>
+    </div>
+
+    <div v-else-if="items.length" class="dashboard-grid">
+      <article v-for="item in items" :key="`${item.type}:${item.id}`" class="dashboard-card">
+        <div class="dashboard-card-header">
+          <div>
+            <p class="eyebrow">{{ itemTypeLabel(item.type) }}</p>
+            <h3>{{ item.name }}</h3>
+          </div>
+          <strong>{{ formatProgress(item.progress) }}</strong>
+        </div>
+
+        <template v-if="item.nextComic">
+          <button
+            class="dashboard-comic"
+            type="button"
+            @click="$emit('open-comic', item.nextComic)"
+          >
+            <img
+              v-if="item.nextComic.coverImage"
+              :src="assetURL(item.nextComic.coverImage)"
+              :alt="`${item.nextComic.title} cover`"
+              loading="lazy"
+            />
+            <span v-else class="dashboard-cover-placeholder" aria-hidden="true"></span>
+            <span>
+              <strong>{{ item.nextComic.title }}</strong>
+              <small>{{ item.nextComic.publisher || 'No publisher saved' }}</small>
+            </span>
+          </button>
+
+          <div v-if="!readOnly" class="dashboard-card-actions">
+            <button
+              class="primary-button"
+              type="button"
+              :disabled="quickSavingComicId === item.nextComic.id"
+              @click="$emit('mark-read', item.nextComic)"
+            >
+              Read
+            </button>
+            <button
+              class="secondary-button"
+              type="button"
+              :disabled="quickSavingComicId === item.nextComic.id"
+              @click="$emit('mark-skipped', item.nextComic)"
+            >
+              Skipped
+            </button>
+          </div>
+        </template>
+
+        <p v-else class="dashboard-complete-copy">No unread comics left here.</p>
+      </article>
+    </div>
+
+    <section v-else class="empty-panel">
+      <h2>No started reading yet</h2>
+      <p>Start a reading order, arc, character, or series and it will appear here.</p>
+    </section>
+  </section>
+</template>

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -16,7 +16,7 @@ const routeAccess = {
 export const router = createRouter({
   history: createWebHistory(),
   routes: [
-    { path: '/', redirect: { name: 'readingOrders' } },
+    { path: '/', redirect: { name: 'dashboard' } },
     { path: '/readingOrders', redirect: { name: 'readingOrders' } },
     { path: '/readingOrders/new', redirect: { name: 'readingOrdersNew' } },
     {
@@ -40,6 +40,12 @@ export const router = createRouter({
       redirect: (to) => ({ name: 'readingOrderEdit', params: { id: to.params.id } }),
     },
     { path: '/achievements', redirect: { name: 'progress' } },
+    {
+      path: '/dashboard',
+      name: 'dashboard',
+      component: EmptyRouteView,
+      meta: { eyebrow: 'Dashboard', title: 'Dashboard', requiresUser: true },
+    },
     {
       path: '/reading-orders',
       name: 'readingOrders',
@@ -176,9 +182,9 @@ export function setRouteAccessContext(context) {
 export function routeAccessRedirect(to) {
   if (!routeAccess.loaded) return null
   if (to.meta.requiresMetron && (!routeAccess.canAccessMetron || routeAccess.readOnlyGuest)) {
-    return { name: 'readingOrders' }
+    return { name: 'dashboard' }
   }
-  if (to.meta.requiresAdmin && !routeAccess.isAdmin) return { name: 'readingOrders' }
+  if (to.meta.requiresAdmin && !routeAccess.isAdmin) return { name: 'dashboard' }
   if (to.meta.requiresUser && !routeAccess.hasUser) return { name: 'readingOrders' }
   return null
 }

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3279,6 +3279,97 @@ textarea {
   font-weight: 800;
 }
 
+.dashboard-view {
+  display: grid;
+  gap: 18px;
+}
+
+.dashboard-header,
+.dashboard-card-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.dashboard-achievements,
+.dashboard-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 14px;
+}
+
+.achievement-summary-card,
+.dashboard-card {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 16px;
+}
+
+.achievement-summary-card h3,
+.dashboard-card h3 {
+  margin: 4px 0 8px;
+}
+
+.achievement-summary-card p,
+.dashboard-card p {
+  margin: 0;
+}
+
+.dashboard-card {
+  display: grid;
+  gap: 14px;
+}
+
+.dashboard-card-header strong {
+  color: var(--accent);
+  white-space: nowrap;
+}
+
+.dashboard-comic {
+  display: grid;
+  grid-template-columns: 56px minmax(0, 1fr);
+  gap: 12px;
+  align-items: center;
+  width: 100%;
+  min-height: 82px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface-strong);
+  color: inherit;
+  padding: 10px;
+  text-align: left;
+}
+
+.dashboard-comic img,
+.dashboard-cover-placeholder {
+  width: 56px;
+  height: 72px;
+  border-radius: 6px;
+  object-fit: cover;
+  background: var(--surface-muted);
+}
+
+.dashboard-comic strong,
+.dashboard-comic small {
+  display: block;
+}
+
+.dashboard-comic strong {
+  overflow-wrap: anywhere;
+}
+
+.dashboard-card-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.dashboard-complete-copy {
+  color: var(--muted);
+}
+
 @media (max-width: 1180px) {
   .reading-order-editor-layout {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary
- add a dashboard API that returns started reading orders, arcs, characters, and series with the next unread/unskipped comic
- make the dashboard the landing page and add it to the main navigation
- add dashboard read/skipped actions that refresh the card to the next comic
- show most recently earned and next earnable achievements

## Verification
- go test ./...
- npm run lint
- npm run build