### PR TITLE
Refresh achievements

### DIFF
--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -212,11 +212,23 @@ func TestUserStatisticsAndAchievements(t *testing.T) {
 			description TEXT NOT NULL DEFAULT '',
 			favorite INTEGER NOT NULL DEFAULT 0
 		);
+		CREATE TABLE user_arc_starts (
+			arc_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (arc_id, user_id)
+		);
 		CREATE TABLE arc_comics (
 			arc_id INTEGER NOT NULL REFERENCES arcs(id) ON DELETE CASCADE,
 			comic_id INTEGER NOT NULL REFERENCES comics(id) ON DELETE CASCADE,
 			position INTEGER NOT NULL DEFAULT 0,
 			note TEXT NOT NULL DEFAULT ''
+		);
+		CREATE TABLE user_series_starts (
+			series_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (series_id, user_id)
 		);
 		CREATE TABLE characters (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -224,6 +236,12 @@ func TestUserStatisticsAndAchievements(t *testing.T) {
 			description TEXT NOT NULL DEFAULT '',
 			image TEXT NOT NULL DEFAULT '',
 			favorite INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE TABLE user_character_starts (
+			character_id INTEGER NOT NULL,
+			user_id INTEGER NOT NULL,
+			started_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (character_id, user_id)
 		);
 		CREATE TABLE comic_characters (
 			comic_id INTEGER NOT NULL REFERENCES comics(id) ON DELETE CASCADE,
@@ -247,9 +265,12 @@ func TestUserStatisticsAndAchievements(t *testing.T) {
 		INSERT INTO reading_order_comics (reading_order_id, comic_id, position)
 		VALUES (1, 1, 1), (1, 2, 2), (2, 3, 1);
 		INSERT INTO arcs (id, name) VALUES (1, 'Alpha arc'), (2, 'Beta arc');
+		INSERT INTO user_arc_starts (arc_id, user_id, started_at) VALUES (1, 1, '2026-07-01T09:30:00Z');
 		INSERT INTO arc_comics (arc_id, comic_id, position)
 		VALUES (1, 1, 1), (1, 2, 2), (2, 3, 1);
+		INSERT INTO user_series_starts (series_id, user_id, started_at) VALUES (1, 1, '2026-07-01T09:45:00Z');
 		INSERT INTO characters (id, name) VALUES (1, 'Hero'), (2, 'Sidekick'), (3, 'Cameo');
+		INSERT INTO user_character_starts (character_id, user_id, started_at) VALUES (1, 1, '2026-07-01T09:50:00Z');
 		INSERT INTO comic_characters (comic_id, character_id)
 		VALUES (1, 1), (1, 2), (2, 2), (3, 3);
 	`); err != nil {
@@ -279,8 +300,8 @@ func TestUserStatisticsAndAchievements(t *testing.T) {
 	if stats.AuthoredReadingOrders != 1 || stats.StartedReadingOrders != 1 || stats.CompletedReadingOrders != 1 {
 		t.Fatalf("reading order stats = authored %d started %d completed %d; want 1/1/1", stats.AuthoredReadingOrders, stats.StartedReadingOrders, stats.CompletedReadingOrders)
 	}
-	if stats.StartedArcs != 1 || stats.CompletedArcs != 1 {
-		t.Fatalf("arc stats = started %d completed %d; want 1/1", stats.StartedArcs, stats.CompletedArcs)
+	if stats.StartedArcs != 1 || stats.CompletedArcs != 1 || stats.StartedSeries != 1 || stats.StartedCharacters != 1 {
+		t.Fatalf("started/completed stats = arcs %d/%d series %d characters %d; want 1/1/1/1", stats.StartedArcs, stats.CompletedArcs, stats.StartedSeries, stats.StartedCharacters)
 	}
 	if stats.CharactersMet != 2 {
 		t.Fatalf("characters met = %d; want 2", stats.CharactersMet)
@@ -290,9 +311,17 @@ func TestUserStatisticsAndAchievements(t *testing.T) {
 	for _, achievement := range result.Body.Achievements {
 		achievements[achievement.ID] = achievement
 	}
-	for _, id := range []string{"first-read", "list-finisher", "arc-explorer", "curator"} {
+	for _, id := range []string{"first-read", "reading-order-finisher", "arc-explorer", "series-finisher", "curator"} {
 		if !achievements[id].Earned {
 			t.Fatalf("achievement %q not earned", id)
+		}
+	}
+	for _, id := range []string{"reading-order-starter", "arc-starter", "series-starter", "character-starter"} {
+		if !achievements[id].Earned {
+			t.Fatalf("started achievement %q not earned", id)
+		}
+		if achievements[id].EarnedAt == "" {
+			t.Fatalf("started achievement %q missing earned timestamp", id)
 		}
 	}
 	if achievements["first-read"].EarnedAt != "2026-07-01T10:00:00Z" {

--- a/backend/internal/api/models.go
+++ b/backend/internal/api/models.go
@@ -130,6 +130,7 @@ type UserStatistics struct {
 	TotalComics            int     `json:"totalComics"          doc:"Total comics in the local library." example:"120"`
 	ReadComics             int     `json:"readComics"           doc:"Comics marked read by the current user." example:"42"`
 	UnreadComics           int     `json:"unreadComics"         doc:"Comics not yet marked read by the current user." example:"78"`
+	SkippedComics          int     `json:"skippedComics"        doc:"Comics skipped by the current user." example:"3"`
 	ReadProgress           float64 `json:"readProgress"         doc:"Fraction of local comics marked read by the current user, from 0 to 1." minimum:"0" maximum:"1" example:"0.35"`
 	FirstReadAt            string  `json:"firstReadAt,omitempty" doc:"Timestamp when the current user first marked a comic read." example:"2026-07-08T13:45:00Z"`
 	LastReadAt             string  `json:"lastReadAt,omitempty"  doc:"Timestamp when the current user most recently marked a comic read." example:"2026-07-08T14:15:00Z"`
@@ -137,10 +138,12 @@ type UserStatistics struct {
 	CompletedSeries        int     `json:"completedSeries"      doc:"Number of distinct series where every local comic is marked read by the current user." example:"2"`
 	DistinctReadPublishers int     `json:"distinctReadPublishers" doc:"Number of distinct publishers where the current user has read at least one comic." example:"3"`
 	AuthoredReadingOrders  int     `json:"authoredReadingOrders" doc:"Reading orders authored by the current user." example:"4"`
-	StartedReadingOrders   int     `json:"startedReadingOrders" doc:"Reading orders where the current user has read at least one included comic." example:"5"`
+	StartedReadingOrders   int     `json:"startedReadingOrders" doc:"Reading orders formally started by the current user." example:"5"`
 	CompletedReadingOrders int     `json:"completedReadingOrders" doc:"Reading orders where every included comic is marked read by the current user." example:"2"`
-	StartedArcs            int     `json:"startedArcs"          doc:"Story arcs where the current user has read at least one included comic." example:"3"`
+	StartedArcs            int     `json:"startedArcs"          doc:"Story arcs formally started by the current user." example:"3"`
 	CompletedArcs          int     `json:"completedArcs"        doc:"Story arcs where every included comic is marked read by the current user." example:"1"`
+	StartedSeries          int     `json:"startedSeries"        doc:"Series formally started by the current user." example:"4"`
+	StartedCharacters      int     `json:"startedCharacters"    doc:"Characters formally started by the current user." example:"6"`
 	CharactersMet          int     `json:"charactersMet"        doc:"Distinct characters appearing in comics marked read by the current user." example:"17"`
 }
 

--- a/backend/internal/api/statistics.go
+++ b/backend/internal/api/statistics.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"net/http"
 
@@ -60,6 +61,14 @@ func readUserStatistics(ctx context.Context, db *sqlx.DB, userID int) (UserStati
 		return stats, err
 	}
 	stats.UnreadComics = stats.TotalComics - stats.ReadComics
+	if err := db.GetContext(ctx, &stats.SkippedComics, `
+		SELECT COUNT(*)
+		FROM user_comics uc
+		JOIN comics c ON c.id = uc.comic_id
+		WHERE uc.user_id = ? AND uc.skipped = 1
+	`, userID); err != nil {
+		return stats, err
+	}
 	if stats.TotalComics > 0 {
 		stats.ReadProgress = float64(stats.ReadComics) / float64(stats.TotalComics)
 	}
@@ -138,12 +147,8 @@ func readUserStatistics(ctx context.Context, db *sqlx.DB, userID int) (UserStati
 	}
 	if err := db.GetContext(ctx, &stats.StartedArcs, `
 		SELECT COUNT(*)
-		FROM (
-			SELECT ac.arc_id
-			FROM arc_comics ac
-			JOIN user_comics uc ON uc.comic_id = ac.comic_id AND uc.user_id = ? AND uc.read = 1
-			GROUP BY ac.arc_id
-		)
+		FROM user_arc_starts
+		WHERE user_id = ?
 	`, userID); err != nil {
 		return stats, err
 	}
@@ -156,6 +161,20 @@ func readUserStatistics(ctx context.Context, db *sqlx.DB, userID int) (UserStati
 			GROUP BY ac.arc_id
 			HAVING COUNT(*) > 0 AND SUM(CASE WHEN uc.read = 1 THEN 1 ELSE 0 END) = COUNT(*)
 		)
+	`, userID); err != nil {
+		return stats, err
+	}
+	if err := db.GetContext(ctx, &stats.StartedSeries, `
+		SELECT COUNT(*)
+		FROM user_series_starts
+		WHERE user_id = ?
+	`, userID); err != nil {
+		return stats, err
+	}
+	if err := db.GetContext(ctx, &stats.StartedCharacters, `
+		SELECT COUNT(*)
+		FROM user_character_starts
+		WHERE user_id = ?
 	`, userID); err != nil {
 		return stats, err
 	}
@@ -178,9 +197,12 @@ func achievementEarnedAt(ctx context.Context, db *sqlx.DB, userID int, stats Use
 		target int
 	}{
 		{id: "first-read", target: 1},
+		{id: "five-issue-warmup", target: 5},
 		{id: "page-turner", target: 10},
+		{id: "trade-reader", target: 25},
 		{id: "longbox-hero", target: 50},
 		{id: "century-stack", target: 100},
+		{id: "quarter-bin-legend", target: 250},
 	} {
 		value, err := readThresholdTimestamp(ctx, db, userID, item.target)
 		if err != nil {
@@ -190,23 +212,70 @@ func achievementEarnedAt(ctx context.Context, db *sqlx.DB, userID int, stats Use
 			earnedAt[item.id] = value
 		}
 	}
+	if value, err := readStartedThresholdTimestamp(ctx, db, "user_reading_orders", userID, 1); err != nil {
+		return nil, err
+	} else if value != "" {
+		earnedAt["reading-order-starter"] = value
+	}
+	if value, err := readStartedThresholdTimestamp(ctx, db, "user_arc_starts", userID, 1); err != nil {
+		return nil, err
+	} else if value != "" {
+		earnedAt["arc-starter"] = value
+	}
+	if value, err := readStartedThresholdTimestamp(ctx, db, "user_series_starts", userID, 1); err != nil {
+		return nil, err
+	} else if value != "" {
+		earnedAt["series-starter"] = value
+	}
+	if value, err := readStartedThresholdTimestamp(ctx, db, "user_character_starts", userID, 1); err != nil {
+		return nil, err
+	} else if value != "" {
+		earnedAt["character-starter"] = value
+	}
 	if stats.DistinctReadSeries >= 5 {
 		earnedAt["series-sampler"] = stats.LastReadAt
+	}
+	if stats.DistinctReadSeries >= 10 {
+		earnedAt["series-cartographer"] = stats.LastReadAt
 	}
 	if stats.DistinctReadPublishers >= 3 {
 		earnedAt["publisher-tour"] = stats.LastReadAt
 	}
+	if stats.DistinctReadPublishers >= 10 {
+		earnedAt["imprint-explorer"] = stats.LastReadAt
+	}
 	if stats.CharactersMet >= 10 {
 		earnedAt["cast-collector"] = stats.LastReadAt
 	}
-	if stats.StartedReadingOrders >= 1 {
-		earnedAt["list-starter"] = stats.LastReadAt
+	if stats.CharactersMet >= 50 {
+		earnedAt["ensemble-cast"] = stats.LastReadAt
 	}
 	if stats.CompletedReadingOrders >= 1 {
-		earnedAt["list-finisher"] = stats.LastReadAt
+		earnedAt["reading-order-finisher"] = stats.LastReadAt
+	}
+	if stats.CompletedReadingOrders >= 5 {
+		earnedAt["reading-order-closer"] = stats.LastReadAt
 	}
 	if stats.CompletedArcs >= 1 {
 		earnedAt["arc-explorer"] = stats.LastReadAt
+	}
+	if stats.CompletedArcs >= 5 {
+		earnedAt["arc-completionist"] = stats.LastReadAt
+	}
+	if stats.CompletedSeries >= 1 {
+		earnedAt["series-finisher"] = stats.LastReadAt
+	}
+	if stats.CompletedSeries >= 5 {
+		earnedAt["shelf-finisher"] = stats.LastReadAt
+	}
+	if stats.SkippedComics >= 1 {
+		earnedAt["editorial-instinct"] = stats.LastReadAt
+	}
+	if stats.AuthoredReadingOrders >= 1 {
+		earnedAt["curator"] = stats.LastReadAt
+	}
+	if stats.AuthoredReadingOrders >= 5 {
+		earnedAt["architect"] = stats.LastReadAt
 	}
 	return earnedAt, nil
 }
@@ -226,20 +295,74 @@ func readThresholdTimestamp(ctx context.Context, db *sqlx.DB, userID, target int
 	return earnedAt, err
 }
 
+func readStartedThresholdTimestamp(ctx context.Context, db *sqlx.DB, table string, userID, target int) (string, error) {
+	var earnedAt string
+	query := fmt.Sprintf(`
+		SELECT COALESCE(CASE WHEN COUNT(*) >= ? THEN MAX(started_at) ELSE '' END, '')
+		FROM (
+			SELECT started_at
+			FROM %s
+			WHERE user_id = ? AND started_at <> ''
+			ORDER BY started_at
+			LIMIT ?
+		)
+	`, table)
+	err := db.GetContext(ctx, &earnedAt, query, target, userID, target)
+	return earnedAt, err
+}
+
+type achievementDefinition struct {
+	id          string
+	name        string
+	description string
+	category    string
+	progress    int
+	target      int
+}
+
 func buildAchievements(stats UserStatistics, earnedAt map[string]string) []Achievement {
-	return []Achievement{
-		newAchievement("first-read", "First Issue", "Mark one comic as read.", "Reading", stats.ReadComics, 1, earnedAt),
-		newAchievement("page-turner", "Page Turner", "Read 10 comics.", "Reading", stats.ReadComics, 10, earnedAt),
-		newAchievement("longbox-hero", "Longbox Hero", "Read 50 comics.", "Reading", stats.ReadComics, 50, earnedAt),
-		newAchievement("century-stack", "Century Stack", "Read 100 comics.", "Reading", stats.ReadComics, 100, earnedAt),
-		newAchievement("series-sampler", "Series Sampler", "Read comics from 5 different series.", "Discovery", stats.DistinctReadSeries, 5, earnedAt),
-		newAchievement("publisher-tour", "Publisher Tour", "Read comics from 3 different publishers.", "Discovery", stats.DistinctReadPublishers, 3, earnedAt),
-		newAchievement("cast-collector", "Cast Collector", "Meet 10 characters through read comics.", "Discovery", stats.CharactersMet, 10, earnedAt),
-		newAchievement("list-starter", "List Starter", "Start reading a reading order.", "Reading Orders", stats.StartedReadingOrders, 1, earnedAt),
-		newAchievement("list-finisher", "List Finisher", "Complete a reading order.", "Reading Orders", stats.CompletedReadingOrders, 1, earnedAt),
-		newAchievement("arc-explorer", "Arc Explorer", "Complete a story arc.", "Arcs", stats.CompletedArcs, 1, earnedAt),
-		newAchievement("curator", "Curator", "Create a reading order.", "Library", stats.AuthoredReadingOrders, 1, earnedAt),
+	definitions := []achievementDefinition{
+		{"first-read", "First Issue", "Mark your first comic as read.", "Reading", stats.ReadComics, 1},
+		{"five-issue-warmup", "Five-Issue Warmup", "Read 5 comics.", "Reading", stats.ReadComics, 5},
+		{"page-turner", "Page Turner", "Read 10 comics.", "Reading", stats.ReadComics, 10},
+		{"trade-reader", "Trade Reader", "Read 25 comics.", "Reading", stats.ReadComics, 25},
+		{"longbox-hero", "Longbox Hero", "Read 50 comics.", "Reading", stats.ReadComics, 50},
+		{"century-stack", "Century Stack", "Read 100 comics.", "Reading", stats.ReadComics, 100},
+		{"quarter-bin-legend", "Quarter-Bin Legend", "Read 250 comics.", "Reading", stats.ReadComics, 250},
+		{"editorial-instinct", "Editorial Instinct", "Skip a comic that does not belong in your current path.", "Reading", stats.SkippedComics, 1},
+		{"series-sampler", "Series Sampler", "Read comics from 5 different series.", "Discovery", stats.DistinctReadSeries, 5},
+		{"series-cartographer", "Series Cartographer", "Read comics from 10 different series.", "Discovery", stats.DistinctReadSeries, 10},
+		{"publisher-tour", "Publisher Tour", "Read comics from 3 different publishers.", "Discovery", stats.DistinctReadPublishers, 3},
+		{"imprint-explorer", "Imprint Explorer", "Read comics from 10 different publishers.", "Discovery", stats.DistinctReadPublishers, 10},
+		{"cast-collector", "Cast Collector", "Meet 10 characters through read comics.", "Discovery", stats.CharactersMet, 10},
+		{"ensemble-cast", "Ensemble Cast", "Meet 50 characters through read comics.", "Discovery", stats.CharactersMet, 50},
+		{"reading-order-starter", "Reading Order Starter", "Start a reading order.", "Started", stats.StartedReadingOrders, 1},
+		{"arc-starter", "Arc Starter", "Start a story arc.", "Started", stats.StartedArcs, 1},
+		{"series-starter", "Series Starter", "Start a series.", "Started", stats.StartedSeries, 1},
+		{"character-starter", "Character Starter", "Start a character path.", "Started", stats.StartedCharacters, 1},
+		{"reading-order-finisher", "Reading Order Finisher", "Complete a reading order.", "Completion", stats.CompletedReadingOrders, 1},
+		{"reading-order-closer", "Reading Order Closer", "Complete 5 reading orders.", "Completion", stats.CompletedReadingOrders, 5},
+		{"arc-explorer", "Arc Explorer", "Complete a story arc.", "Completion", stats.CompletedArcs, 1},
+		{"arc-completionist", "Arc Completionist", "Complete 5 story arcs.", "Completion", stats.CompletedArcs, 5},
+		{"series-finisher", "Series Finisher", "Complete a series.", "Completion", stats.CompletedSeries, 1},
+		{"shelf-finisher", "Shelf Finisher", "Complete 5 series.", "Completion", stats.CompletedSeries, 5},
+		{"curator", "Curator", "Create a reading order.", "Library", stats.AuthoredReadingOrders, 1},
+		{"architect", "Architect", "Create 5 reading orders.", "Library", stats.AuthoredReadingOrders, 5},
 	}
+
+	achievements := make([]Achievement, 0, len(definitions))
+	for _, definition := range definitions {
+		achievements = append(achievements, newAchievement(
+			definition.id,
+			definition.name,
+			definition.description,
+			definition.category,
+			definition.progress,
+			definition.target,
+			earnedAt,
+		))
+	}
+	return achievements
 }
 
 func newAchievement(id, name, description, category string, progress, target int, earnedAt map[string]string) Achievement {

--- a/ui/src/components/ProgressView.vue
+++ b/ui/src/components/ProgressView.vue
@@ -70,6 +70,10 @@ function achievementTimestampLabel(achievement) {
             <small>Read comics</small>
           </span>
           <span>
+            <strong>{{ statisticsView.statistics.skippedComics }}</strong>
+            <small>Skipped comics</small>
+          </span>
+          <span>
             <strong>{{ formatTimestamp(statisticsView.statistics.firstReadAt) }}</strong>
             <small>First read timestamp</small>
           </span>
@@ -99,8 +103,24 @@ function achievementTimestampLabel(achievement) {
             <small>Reading orders completed</small>
           </span>
           <span>
+            <strong>{{ statisticsView.statistics.startedReadingOrders }}</strong>
+            <small>Reading orders started</small>
+          </span>
+          <span>
             <strong>{{ statisticsView.statistics.completedArcs }}</strong>
             <small>Story arcs completed</small>
+          </span>
+          <span>
+            <strong>{{ statisticsView.statistics.startedArcs }}</strong>
+            <small>Story arcs started</small>
+          </span>
+          <span>
+            <strong>{{ statisticsView.statistics.startedSeries }}</strong>
+            <small>Series started</small>
+          </span>
+          <span>
+            <strong>{{ statisticsView.statistics.startedCharacters }}</strong>
+            <small>Character paths started</small>
           </span>
           <span>
             <strong>{{ statisticsView.statistics.charactersMet }}</strong>


### PR DESCRIPTION
## Summary
- expand achievements with new reading, discovery, started-content, completion, skip, and curator milestones
- align started arc statistics with the formal started state and add started series/character plus skipped-comic stats
- surface the new progress stats in the Progress view

## Verification
- go test ./...
- npm run lint
- npm run build