### PR TITLE
Fix dashboard loading with favorite-only rows

### DIFF
--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -471,9 +471,11 @@ func TestDashboardNextComicAdvancesAfterRead(t *testing.T) {
 		INSERT INTO series (id, name, series_year) VALUES (1, 'Alpha', 2020);
 		INSERT INTO comics (id, series_id, series, series_year, issue, publisher)
 		VALUES (1, 1, 'Alpha', 2020, '1', 'Pub'), (2, 1, 'Alpha', 2020, '2', 'Pub');
-		INSERT INTO reading_orders (id, name, author_user_id) VALUES (1, 'Alpha order', 1);
+		INSERT INTO reading_orders (id, name, author_user_id) VALUES
+			(1, 'Alpha order', 1),
+			(2, 'Favorite only', 1);
 		INSERT INTO user_reading_orders (reading_order_id, user_id, started_at)
-		VALUES (1, 1, '2026-07-01T10:00:00Z');
+		VALUES (1, 1, '2026-07-01T10:00:00Z'), (2, 1, NULL);
 		INSERT INTO reading_order_comics (reading_order_id, comic_id, position)
 		VALUES (1, 1, 1), (1, 2, 2);
 	`); err != nil {

--- a/backend/internal/api/dashboard.go
+++ b/backend/internal/api/dashboard.go
@@ -103,7 +103,7 @@ func dashboardReadingOrders(ctx context.Context, db *sqlx.DB, userID int) ([]Das
 		SELECT ro.id, ro.name, started.started_at
 		FROM user_reading_orders started
 		JOIN reading_orders ro ON ro.id = started.reading_order_id
-		WHERE started.user_id = ?
+		WHERE started.user_id = ? AND started.started_at IS NOT NULL
 		ORDER BY started.started_at, ro.name
 	`, userID); err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ func dashboardArcs(ctx context.Context, db *sqlx.DB, userID int) ([]DashboardIte
 			)
 		LEFT JOIN comics c ON c.id = next_ac.comic_id
 		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
-		WHERE started.user_id = ?
+		WHERE started.user_id = ? AND started.started_at IS NOT NULL
 		ORDER BY started.started_at, a.name
 	`, userID, userID, userID, userID); err != nil {
 		return nil, err
@@ -231,7 +231,7 @@ func dashboardCharacters(ctx context.Context, db *sqlx.DB, userID int) ([]Dashbo
 			)
 		LEFT JOIN comics c ON c.id = next_cc.comic_id
 		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
-		WHERE started.user_id = ?
+		WHERE started.user_id = ? AND started.started_at IS NOT NULL
 		ORDER BY started.started_at, ch.name
 	`, userID, userID, userID, userID); err != nil {
 		return nil, err
@@ -283,7 +283,7 @@ func dashboardSeries(ctx context.Context, db *sqlx.DB, userID int) ([]DashboardI
 			LIMIT 1
 		)
 		LEFT JOIN user_comics uc ON uc.comic_id = c.id AND uc.user_id = ?
-		WHERE started.user_id = ?
+		WHERE started.user_id = ? AND started.started_at IS NOT NULL
 		ORDER BY started.started_at, s.name, s.series_year
 	`, userID, userID, userID, userID); err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary
- exclude favorite-only preference rows from dashboard continuation queries
- prevent nullable `started_at` values from causing dashboard 500 responses
- add regression coverage for content that is favorited but not started

## Validation
- `go test ./...`
- `npm run build`
- `git diff --check`