### PR TITLE
Prevent repeated incomplete comic scans

### DIFF
--- a/backend/internal/api/metron_comic_scanner.go
+++ b/backend/internal/api/metron_comic_scanner.go
@@ -31,13 +31,14 @@ var weekdayNames = map[string]time.Weekday{
 }
 
 type MetronComicScanSettings struct {
-	Enabled            bool     `json:"enabled" doc:"Whether automatic and manual incomplete-data scans are enabled."`
-	ScanComics         bool     `json:"scanComics" doc:"Whether the comics table is included in scans."`
-	Schedule           string   `json:"schedule" enum:"daily,weekly" doc:"Run every day or only on selected weekdays."`
-	Weekdays           []string `json:"weekdays,omitempty" doc:"Lowercase weekday names used by a weekly schedule."`
-	StartTime          string   `json:"startTime" doc:"Server-local scan start time in HH:MM format." example:"02:00"`
-	DailyCallLimit     int      `json:"dailyCallLimit" minimum:"1" doc:"Maximum Metron issue calls shared by all scans during one server-local calendar day." example:"100"`
-	MinIntervalSeconds int      `json:"minIntervalSeconds" minimum:"0" doc:"Minimum seconds between Metron issue calls made by this incomplete-comic scan." example:"20"`
+	Enabled             bool     `json:"enabled" doc:"Whether automatic and manual incomplete-data scans are enabled."`
+	ScanComics          bool     `json:"scanComics" doc:"Whether the comics table is included in scans."`
+	Schedule            string   `json:"schedule" enum:"daily,weekly" doc:"Run every day or only on selected weekdays."`
+	Weekdays            []string `json:"weekdays,omitempty" doc:"Lowercase weekday names used by a weekly schedule."`
+	StartTime           string   `json:"startTime" doc:"Server-local scan start time in HH:MM format." example:"02:00"`
+	DailyCallLimit      int      `json:"dailyCallLimit" minimum:"1" doc:"Maximum Metron issue calls shared by all scans during one server-local calendar day." example:"100"`
+	MinIntervalSeconds  int      `json:"minIntervalSeconds" minimum:"0" doc:"Minimum seconds between Metron issue calls made by this incomplete-comic scan." example:"20"`
+	RecheckCooldownDays int      `json:"recheckCooldownDays" minimum:"0" doc:"Days to wait before re-checking a comic that was already synced but is still missing a field Metron may not provide (e.g. no synopsis on record). 0 disables the cooldown and rechecks every run." example:"30"`
 }
 
 type MetronComicScanStatus struct {
@@ -95,7 +96,7 @@ func (s *metronComicScanner) Stop() {
 }
 
 func defaultMetronComicScanSettings() MetronComicScanSettings {
-	return MetronComicScanSettings{ScanComics: true, Schedule: "daily", StartTime: "02:00", DailyCallLimit: 100, MinIntervalSeconds: 20}
+	return MetronComicScanSettings{ScanComics: true, Schedule: "daily", StartTime: "02:00", DailyCallLimit: 100, MinIntervalSeconds: 20, RecheckCooldownDays: 30}
 }
 
 func loadMetronComicScanSettings(ctx context.Context, db *sqlx.DB) (MetronComicScanSettings, error) {
@@ -126,6 +127,9 @@ func validateMetronComicScanSettings(settings *MetronComicScanSettings) error {
 	}
 	if settings.MinIntervalSeconds < 0 {
 		return errors.New("minIntervalSeconds cannot be negative")
+	}
+	if settings.RecheckCooldownDays < 0 {
+		return errors.New("recheckCooldownDays cannot be negative")
 	}
 	seen := map[string]bool{}
 	weekdays := make([]string, 0, len(settings.Weekdays))
@@ -245,7 +249,15 @@ func (s *metronComicScanner) run(ctx context.Context, settings MetronComicScanSe
 		ID       int `db:"id"`
 		MetronID int `db:"metron_issue_id"`
 	}
-	err := s.db.SelectContext(ctx, &rows, `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (TRIM(publisher) = '' OR TRIM(cover_image) = '' OR TRIM(cover_date) = '' OR TRIM(description) = '') ORDER BY id`)
+	query := `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (TRIM(publisher) = '' OR TRIM(cover_image) = '' OR TRIM(cover_date) = '' OR TRIM(description) = '')`
+	args := []any{}
+	if settings.RecheckCooldownDays > 0 {
+		cutoff := time.Now().Add(-time.Duration(settings.RecheckCooldownDays) * 24 * time.Hour).UTC().Format(time.RFC3339)
+		query += ` AND (metron_synced_at = '' OR metron_synced_at <= ?)`
+		args = append(args, cutoff)
+	}
+	query += ` ORDER BY id`
+	err := s.db.SelectContext(ctx, &rows, query, args...)
 	if err == nil {
 		s.setScanned(len(rows))
 		var nextRequest time.Time
@@ -330,7 +342,8 @@ func enrichIncompleteComicFromMetron(ctx context.Context, db *sqlx.DB, covers *C
 			cover = current
 		}
 	}
-	_, err := db.ExecContext(ctx, `UPDATE comics SET publisher = CASE WHEN TRIM(publisher) = '' THEN ? ELSE publisher END, cover_date = CASE WHEN TRIM(cover_date) = '' THEN ? ELSE cover_date END, cover_image = CASE WHEN TRIM(cover_image) = '' THEN ? ELSE cover_image END, description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END WHERE id = ?`, issue.Publisher, issue.CoverDate, cover, issue.Description, comicID)
+	syncedAt := time.Now().UTC().Format(time.RFC3339)
+	_, err := db.ExecContext(ctx, `UPDATE comics SET publisher = CASE WHEN TRIM(publisher) = '' THEN ? ELSE publisher END, cover_date = CASE WHEN TRIM(cover_date) = '' THEN ? ELSE cover_date END, cover_image = CASE WHEN TRIM(cover_image) = '' THEN ? ELSE cover_image END, description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END, metron_synced_at = ? WHERE id = ?`, issue.Publisher, issue.CoverDate, cover, issue.Description, syncedAt, comicID)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/api/metron_comic_scanner_test.go
+++ b/backend/internal/api/metron_comic_scanner_test.go
@@ -78,6 +78,70 @@ func TestMetronComicScanSubscriptionSendsSnapshotAndProgress(t *testing.T) {
 	}
 }
 
+func TestMetronComicScanCooldownExcludesRecentlySyncedComics(t *testing.T) {
+	db := newMetronComicScannerTestDB(t)
+	if _, err := db.Exec(`CREATE TABLE comics (
+		id INTEGER PRIMARY KEY AUTOINCREMENT,
+		series TEXT NOT NULL DEFAULT '',
+		series_year INTEGER NOT NULL DEFAULT 0,
+		issue TEXT NOT NULL DEFAULT '',
+		publisher TEXT NOT NULL DEFAULT '',
+		cover_date TEXT NOT NULL DEFAULT '',
+		cover_image TEXT NOT NULL DEFAULT '',
+		description TEXT NOT NULL DEFAULT '',
+		read INTEGER NOT NULL DEFAULT 0,
+		metron_issue_id INTEGER,
+		metron_synced_at TEXT NOT NULL DEFAULT ''
+	)`); err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now().UTC()
+	recentlySynced := now.Add(-1 * time.Hour).Format(time.RFC3339)
+	longAgoSynced := now.Add(-40 * 24 * time.Hour).Format(time.RFC3339)
+
+	// Row A: publisher filled, description permanently blank (Metron has none),
+	// synced an hour ago -> still "incomplete" but should be skipped by the cooldown.
+	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, metron_synced_at)
+		VALUES ('A', 'Marvel', '1964-01-01', '/covers/a.jpg', '', 1, ?)`, recentlySynced); err != nil {
+		t.Fatal(err)
+	}
+	// Row B: never synced -> should always be selected.
+	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, metron_synced_at)
+		VALUES ('B', '', '', '', '', 2, '')`); err != nil {
+		t.Fatal(err)
+	}
+	// Row C: synced 40 days ago, past the 30-day cooldown -> should be selected again.
+	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, metron_synced_at)
+		VALUES ('C', 'DC', '1980-01-01', '/covers/c.jpg', '', 3, ?)`, longAgoSynced); err != nil {
+		t.Fatal(err)
+	}
+
+	cutoff := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339)
+	var rows []struct {
+		ID       int `db:"id"`
+		MetronID int `db:"metron_issue_id"`
+	}
+	query := `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (TRIM(publisher) = '' OR TRIM(cover_image) = '' OR TRIM(cover_date) = '' OR TRIM(description) = '') AND (metron_synced_at = '' OR metron_synced_at <= ?) ORDER BY id`
+	if err := db.Select(&rows, query, cutoff); err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[int]bool{}
+	for _, r := range rows {
+		got[r.MetronID] = true
+	}
+	if got[1] {
+		t.Fatal("recently-synced comic with a permanently-blank field should be skipped during cooldown")
+	}
+	if !got[2] {
+		t.Fatal("never-synced comic should always be selected")
+	}
+	if !got[3] {
+		t.Fatal("comic synced past the cooldown window should be selected again")
+	}
+}
+
 func TestComicScanIntervalIsScopedToOneRun(t *testing.T) {
 	var firstRunNext time.Time
 	if err := waitForComicScanInterval(context.Background(), &firstRunNext, time.Second); err != nil {

--- a/backend/internal/db/migrations/012_comic_metron_sync_tracking.sql
+++ b/backend/internal/db/migrations/012_comic_metron_sync_tracking.sql
@@ -1,0 +1,42 @@
+-- +goose Up
+ALTER TABLE comics ADD COLUMN metron_synced_at TEXT NOT NULL DEFAULT '';
+
+CREATE INDEX idx_comics_metron_synced_at
+ON comics(metron_synced_at)
+WHERE metron_issue_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_comics_metron_synced_at;
+
+CREATE TABLE comics_without_sync_tracking (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    series          TEXT    NOT NULL,
+    series_year     INTEGER NOT NULL DEFAULT 0,
+    issue           TEXT    NOT NULL,
+    publisher       TEXT    NOT NULL,
+    cover_date      TEXT    NOT NULL DEFAULT '',
+    cover_image     TEXT    NOT NULL DEFAULT '',
+    description     TEXT    NOT NULL DEFAULT '',
+    read            INTEGER NOT NULL DEFAULT 0,
+    metron_issue_id INTEGER,
+    series_id       INTEGER REFERENCES series(id) ON DELETE SET NULL
+);
+
+INSERT INTO comics_without_sync_tracking (
+    id, series, series_year, issue, publisher, cover_date, cover_image,
+    description, read, metron_issue_id, series_id
+)
+SELECT
+    id, series, series_year, issue, publisher, cover_date, cover_image,
+    description, read, metron_issue_id, series_id
+FROM comics;
+
+DROP TABLE comics;
+ALTER TABLE comics_without_sync_tracking RENAME TO comics;
+
+CREATE UNIQUE INDEX idx_comics_metron_issue_id
+ON comics(metron_issue_id)
+WHERE metron_issue_id IS NOT NULL;
+
+CREATE INDEX idx_comics_series_id_issue
+ON comics(series_id, issue);

--- a/ui/src/components/AppSettingsView.vue
+++ b/ui/src/components/AppSettingsView.vue
@@ -360,8 +360,8 @@ function registrationModeLabel(mode) {
       <p class="muted metron-scan-hint">
         Some issues have no publisher, cover date, or synopsis on Metron itself, so they can stay
         "incomplete" no matter how often they're checked. The cooldown skips a comic for this many
-        days after it was last checked, so those rows stop using up the whole daily call budget.
-        Set to 0 to recheck everything every run.
+        days after it was last checked, so those rows stop using up the whole daily call budget. Set
+        to 0 to recheck everything every run.
       </p>
 
       <fieldset v-if="draft.schedule === 'weekly'" class="permission-scopes">

--- a/ui/src/components/AppSettingsView.vue
+++ b/ui/src/components/AppSettingsView.vue
@@ -57,6 +57,7 @@ function save() {
     startTime: draft.startTime || '02:00',
     dailyCallLimit: Number(draft.dailyCallLimit) || 1,
     minIntervalSeconds: Math.max(0, Number(draft.minIntervalSeconds) || 0),
+    recheckCooldownDays: Math.max(0, Number(draft.recheckCooldownDays) || 0),
   })
 }
 
@@ -351,7 +352,17 @@ function registrationModeLabel(mode) {
           <span>Minimum Metron interval (seconds)</span>
           <input v-model.number="draft.minIntervalSeconds" min="0" step="1" type="number" />
         </label>
+        <label class="metron-scan-field">
+          <span>Re-check cooldown (days)</span>
+          <input v-model.number="draft.recheckCooldownDays" min="0" step="1" type="number" />
+        </label>
       </div>
+      <p class="muted metron-scan-hint">
+        Some issues have no publisher, cover date, or synopsis on Metron itself, so they can stay
+        "incomplete" no matter how often they're checked. The cooldown skips a comic for this many
+        days after it was last checked, so those rows stop using up the whole daily call budget.
+        Set to 0 to recheck everything every run.
+      </p>
 
       <fieldset v-if="draft.schedule === 'weekly'" class="permission-scopes">
         <legend>Run on</legend>
@@ -372,12 +383,16 @@ function registrationModeLabel(mode) {
         </div>
         <div v-if="metronComicScan.running">
           <strong>{{ metronComicScan.updated }}</strong>
-          <span>updated from {{ metronComicScan.scanned }} scanned</span>
+          <span
+            >updated ({{ metronComicScan.failed }} failed) from
+            {{ metronComicScan.scanned }} scanned</span
+          >
         </div>
         <p v-else>
           Quota resets daily · {{ metronComicScan.usageDate }}
           <template v-if="metronComicScan.stopReason">
-            · Last scan: {{ metronComicScan.stopReason }}
+            · Last scan: {{ metronComicScan.stopReason }} ({{ metronComicScan.updated }} updated,
+            {{ metronComicScan.failed }} failed)
           </template>
         </p>
       </div>


### PR DESCRIPTION
## Summary
- track when incomplete comics were last synchronized with Metron
- add a configurable cooldown before retrying still-incomplete comics
- expose failed scan counts in settings

## Validation
- go test ./...
- npm run build