### PR TITLE
Add authorized deletion for library content

### DIFF
--- a/backend/internal/api/arcs.go
+++ b/backend/internal/api/arcs.go
@@ -79,7 +79,7 @@ func RegisterArcRoutes(api huma.API, db *sqlx.DB) {
 		OperationID:   "deleteArc",
 		Tags:          []string{tagArcs},
 		Summary:       "Delete an arc",
-		Description:   "Deletes an arc by ID and clears its comic-entry links.",
+		Description:   "Deletes an arc by ID and clears its comic-entry and user-preference links. Admin access is required.",
 		Method:        http.MethodDelete,
 		Path:          "/arcs/{id}",
 		DefaultStatus: 204,
@@ -288,6 +288,9 @@ func updateArc(ctx context.Context, db *sqlx.DB, id int, payload ArcPayload) (*A
 }
 
 func deleteArc(ctx context.Context, db *sqlx.DB, id int) (*struct{}, error) {
+	if _, err := requireAdminUser(ctx, db); err != nil {
+		return nil, err
+	}
 	result, err := db.ExecContext(ctx, `
 		DELETE FROM arcs WHERE id = ?
 	`, id)

--- a/backend/internal/api/characters.go
+++ b/backend/internal/api/characters.go
@@ -64,6 +64,33 @@ func RegisterCharacterRoutes(api huma.API, db *sqlx.DB) {
 			return getCharacter(ctx, db, input.ID)
 		})
 	}
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "deleteCharacter",
+		Tags:          []string{tagCharacters},
+		Summary:       "Delete a character",
+		Description:   "Deletes a character and its aliases, appearance links, and user preferences. Admin access is required.",
+		Method:        http.MethodDelete,
+		Path:          "/characters/{id}",
+		DefaultStatus: http.StatusNoContent,
+		Errors:        errsWrite,
+	}, func(ctx context.Context, input *CharacterInput) (*struct{}, error) {
+		return deleteCharacter(ctx, db, input.ID)
+	})
+}
+
+func deleteCharacter(ctx context.Context, db *sqlx.DB, id int) (*struct{}, error) {
+	if _, err := requireAdminUser(ctx, db); err != nil {
+		return nil, err
+	}
+	result, err := db.ExecContext(ctx, `DELETE FROM characters WHERE id = ?`, id)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to delete character")
+	}
+	if err := requireRowsAffected(result, "character not found"); err != nil {
+		return nil, err
+	}
+	return &struct{}{}, nil
 }
 
 func listCharacters(ctx context.Context, db *sqlx.DB, input *CharacterListInput) (*CharacterListOutput, error) {

--- a/backend/internal/api/comics.go
+++ b/backend/internal/api/comics.go
@@ -79,7 +79,7 @@ func RegisterComicRoutes(api huma.API, db *sqlx.DB, covers *CoverCache) {
 		OperationID:   "deleteComic",
 		Tags:          []string{tagComics},
 		Summary:       "Delete a comic",
-		Description:   "Deletes a comic by ID and removes it from reading orders.",
+		Description:   "Deletes a comic by ID and removes its reading-order, arc, character, and user-progress links. Admin access is required.",
 		Method:        http.MethodDelete,
 		Path:          "/comics/{id}",
 		DefaultStatus: 204,
@@ -508,6 +508,9 @@ func boolInt(value bool) int {
 }
 
 func deleteComic(ctx context.Context, db *sqlx.DB, id int) (*struct{}, error) {
+	if _, err := requireAdminUser(ctx, db); err != nil {
+		return nil, err
+	}
 	result, err := db.ExecContext(ctx, `DELETE FROM comics WHERE id = ?`, id)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("failed to delete comic")

--- a/backend/internal/api/content_deletion_test.go
+++ b/backend/internal/api/content_deletion_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func newContentDeletionTestDB(t *testing.T) *sqlx.DB {
+	t.Helper()
+	db, err := sqlx.Open("sqlite", ":memory:?_fk=true")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() { db.Close() })
+	if _, err := db.Exec(`
+		CREATE TABLE users (id INTEGER PRIMARY KEY, is_admin INTEGER NOT NULL DEFAULT 0);
+		CREATE TABLE series (id INTEGER PRIMARY KEY, name TEXT NOT NULL, series_year INTEGER NOT NULL DEFAULT 0);
+		CREATE TABLE comics (
+			id INTEGER PRIMARY KEY,
+			series TEXT NOT NULL DEFAULT '',
+			series_year INTEGER NOT NULL DEFAULT 0,
+			series_id INTEGER REFERENCES series(id) ON DELETE SET NULL
+		);
+		CREATE TABLE arcs (id INTEGER PRIMARY KEY);
+		CREATE TABLE characters (id INTEGER PRIMARY KEY);
+		CREATE TABLE reading_orders (
+			id INTEGER PRIMARY KEY,
+			author_user_id INTEGER REFERENCES users(id) ON DELETE SET NULL
+		);
+		INSERT INTO users (id, is_admin) VALUES (1, 1), (2, 0), (3, 0);
+		INSERT INTO series (id, name, series_year) VALUES (1, 'Series', 2020);
+		INSERT INTO comics (id, series, series_year, series_id) VALUES (1, 'Series', 2020, 1);
+		INSERT INTO arcs (id) VALUES (1);
+		INSERT INTO characters (id) VALUES (1);
+		INSERT INTO reading_orders (id, author_user_id) VALUES (1, 2), (2, 3);
+	`); err != nil {
+		t.Fatal(err)
+	}
+	return db
+}
+
+func deletionUserContext(userID int) context.Context {
+	return context.WithValue(context.Background(), contextUserIDKey{}, userID)
+}
+
+func TestContentDeletionRequiresAdmin(t *testing.T) {
+	for name, deleteContent := range map[string]func(context.Context, *sqlx.DB) error{
+		"comic":     func(ctx context.Context, db *sqlx.DB) error { _, err := deleteComic(ctx, db, 1); return err },
+		"arc":       func(ctx context.Context, db *sqlx.DB) error { _, err := deleteArc(ctx, db, 1); return err },
+		"character": func(ctx context.Context, db *sqlx.DB) error { _, err := deleteCharacter(ctx, db, 1); return err },
+		"series":    func(ctx context.Context, db *sqlx.DB) error { _, err := deleteSeries(ctx, db, 1); return err },
+	} {
+		t.Run(name, func(t *testing.T) {
+			db := newContentDeletionTestDB(t)
+			if err := deleteContent(deletionUserContext(2), db); err == nil {
+				t.Fatal("non-admin deletion returned nil error")
+			}
+			if err := deleteContent(deletionUserContext(1), db); err != nil {
+				t.Fatalf("admin deletion failed: %v", err)
+			}
+		})
+	}
+}
+
+func TestReadingOrderDeletionAllowsAuthorOrAdmin(t *testing.T) {
+	db := newContentDeletionTestDB(t)
+	if _, err := deleteReadingOrder(deletionUserContext(2), db, 2); err == nil {
+		t.Fatal("non-author deletion returned nil error")
+	}
+	if _, err := deleteReadingOrder(deletionUserContext(2), db, 1); err != nil {
+		t.Fatalf("author deletion failed: %v", err)
+	}
+	if _, err := deleteReadingOrder(deletionUserContext(1), db, 2); err != nil {
+		t.Fatalf("admin deletion failed: %v", err)
+	}
+}
+
+func TestSeriesDeletionAlsoDeletesLinkedComics(t *testing.T) {
+	db := newContentDeletionTestDB(t)
+	if _, err := deleteSeries(deletionUserContext(1), db, 1); err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	if err := db.Get(&count, `SELECT COUNT(*) FROM comics`); err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Fatalf("linked comic count = %d, want 0", count)
+	}
+}

--- a/backend/internal/api/series.go
+++ b/backend/internal/api/series.go
@@ -80,6 +80,50 @@ func RegisterSeriesRoutes(api huma.API, db *sqlx.DB, client *metron.Client, cove
 		}
 		return importLocalSeriesFromMetron(ctx, db, client, covers, importJobs, input.ID)
 	})
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "deleteSeries",
+		Tags:          []string{tagSeries},
+		Summary:       "Delete a series",
+		Description:   "Deletes a series and every comic linked to it. Related reading-order, arc, character, and user-progress links are removed by cascading foreign keys. Admin access is required.",
+		Method:        http.MethodDelete,
+		Path:          "/series/{id}",
+		DefaultStatus: http.StatusNoContent,
+		Errors:        errsWrite,
+	}, func(ctx context.Context, input *ComicSeriesInput) (*struct{}, error) {
+		return deleteSeries(ctx, db, input.ID)
+	})
+}
+
+func deleteSeries(ctx context.Context, db *sqlx.DB, id int) (*struct{}, error) {
+	if _, err := requireAdminUser(ctx, db); err != nil {
+		return nil, err
+	}
+	tx, err := db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to start series deletion")
+	}
+	defer tx.Rollback()
+	var series struct {
+		Name string `db:"name"`
+		Year int    `db:"series_year"`
+	}
+	if err := tx.GetContext(ctx, &series, `SELECT name, series_year FROM series WHERE id = ?`, id); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, huma.Error404NotFound("series not found")
+		}
+		return nil, huma.Error500InternalServerError("failed to find series")
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM comics WHERE series_id = ? OR (series = ? AND series_year = ?)`, id, series.Name, series.Year); err != nil {
+		return nil, huma.Error500InternalServerError("failed to delete series comics")
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM series WHERE id = ?`, id); err != nil {
+		return nil, huma.Error500InternalServerError("failed to delete series")
+	}
+	if err := tx.Commit(); err != nil {
+		return nil, huma.Error500InternalServerError("failed to commit series deletion")
+	}
+	return &struct{}{}, nil
 }
 
 func listSeries(ctx context.Context, db *sqlx.DB, input *ComicSeriesListInput) (*ComicSeriesListOutput, error) {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -179,6 +179,7 @@ const {
 const {
   selectedSeries,
   startSaving: seriesStartSaving,
+  deleting: seriesDeleting,
   visibleSeries,
   seriesBrowseSections,
   openSeries,
@@ -187,6 +188,7 @@ const {
   importSelectedSeriesFromMetron,
   seriesImportRunning,
   refreshSelectedSeriesDetail,
+  deleteSelectedSeries,
   loadSeries,
 } = useSeries({
   activeView,
@@ -201,6 +203,7 @@ const {
   selectedCharacter,
   quickSavingCharacterID,
   startSaving: characterStartSaving,
+  deleting: characterDeleting,
   visibleCharacters,
   characterBrowseSections,
   openCharacter,
@@ -209,6 +212,7 @@ const {
   importSelectedCharacterAppearances,
   characterImportRunning,
   refreshSelectedCharacterDetail,
+  deleteSelectedCharacter,
   loadCharacters,
 } = useCharacters({
   activeView,
@@ -232,6 +236,7 @@ const {
   toggleSelectedArcStarted,
   newArc,
   editArc,
+  deleteArc,
   loadArcs,
 } = useArcs({
   activeView,
@@ -291,6 +296,7 @@ const {
   openOrderComic,
   newComic,
   editComic,
+  deleteComic,
   toggleComicRead,
   toggleComicSkipped,
   resetMetronMetadata,
@@ -1913,8 +1919,11 @@ onUnmounted(() => {
         :quick-saving-arc-id="quickSavingArcID"
         :start-saving="arcStartSaving"
         :read-only="isReadOnlyGuest"
+        :can-delete="isAdmin"
+        :deleting="saving"
         @back="backToPreviousPage"
         @edit="editArc"
+        @delete="deleteArc"
         @toggle-favorite="toggleArcFavorite"
         @toggle-started="toggleSelectedArcStarted"
         @open-comic="openComic"
@@ -1951,10 +1960,13 @@ onUnmounted(() => {
         :import-running="seriesImportRunning(selectedSeries)"
         :start-saving="seriesStartSaving"
         :read-only="isReadOnlyGuest"
+        :can-delete="isAdmin"
+        :deleting="seriesDeleting"
         @back="backToPreviousPage"
         @toggle-favorite="toggleSeriesFavorite"
         @toggle-started="toggleSelectedSeriesStarted"
         @import-series="importSelectedSeriesFromMetron"
+        @delete="deleteSelectedSeries"
         @open-comic="openComic"
         @toggle-read="toggleComicRead"
         @toggle-skipped="toggleComicSkipped"
@@ -1990,10 +2002,13 @@ onUnmounted(() => {
         :import-running="characterImportRunning(selectedCharacter)"
         :start-saving="characterStartSaving"
         :read-only="isReadOnlyGuest"
+        :can-delete="isAdmin"
+        :deleting="characterDeleting"
         @back="backToPreviousPage"
         @toggle-favorite="toggleCharacterFavorite"
         @toggle-started="toggleSelectedCharacterStarted"
         @import-appearances="importSelectedCharacterAppearances"
+        @delete="deleteSelectedCharacter"
         @open-comic="openComic"
         @toggle-read="toggleComicRead"
         @toggle-skipped="toggleComicSkipped"
@@ -2029,6 +2044,8 @@ onUnmounted(() => {
         :metron-metadata-status="metronMetadataStatus"
         :metron-metadata-results="metronMetadataResults"
         :read-only="isReadOnlyGuest"
+        :can-delete="isAdmin"
+        :deleting="saving"
         @back="backToPreviousPage"
         @search-metron="searchSelectedComicMetron"
         @apply-metron="applyMetronMetadata"
@@ -2036,6 +2053,7 @@ onUnmounted(() => {
         @toggle-read="toggleComicRead"
         @toggle-skipped="toggleComicSkipped"
         @edit="editComic"
+        @delete="deleteComic"
         @open-character="openCharacter"
         @open-series="openSeries"
       />

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -191,6 +191,10 @@ export function getSeries(id) {
   return request(`/series/${id}`)
 }
 
+export function deleteSeries(id) {
+  return request(`/series/${id}`, { method: 'DELETE' })
+}
+
 export function updateSeriesFavorite(id, favorite) {
   return send(`/series/${id}/favorite`, 'PATCH', { favorite })
 }
@@ -205,6 +209,10 @@ export function importLocalSeriesFromMetron(id) {
 
 export function getCharacter(id) {
   return request(`/characters/${id}`)
+}
+
+export function deleteCharacter(id) {
+  return request(`/characters/${id}`, { method: 'DELETE' })
 }
 
 export function updateCharacterFavorite(id, favorite) {

--- a/ui/src/components/ArcDetailView.vue
+++ b/ui/src/components/ArcDetailView.vue
@@ -24,6 +24,8 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  canDelete: { type: Boolean, default: false },
+  deleting: { type: Boolean, default: false },
   startSaving: { type: Boolean, default: false },
 })
 
@@ -34,6 +36,7 @@ defineEmits([
   'open-comic',
   'toggle-read',
   'toggle-skipped',
+  'delete',
 ])
 </script>
 
@@ -42,6 +45,15 @@ defineEmits([
     <header class="detail-nav sticky-toolbar">
       <button class="secondary-button" type="button" @click="$emit('back')">Back</button>
       <div class="detail-nav-actions">
+        <button
+          v-if="selectedArc && canDelete"
+          class="danger-button"
+          type="button"
+          :disabled="deleting"
+          @click="$emit('delete')"
+        >
+          {{ deleting ? 'Deleting...' : 'Delete arc' }}
+        </button>
         <button
           v-if="selectedArc && !readOnly"
           type="button"

--- a/ui/src/components/CharacterDetailView.vue
+++ b/ui/src/components/CharacterDetailView.vue
@@ -28,6 +28,8 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  canDelete: { type: Boolean, default: false },
+  deleting: { type: Boolean, default: false },
   startSaving: { type: Boolean, default: false },
 })
 
@@ -39,6 +41,7 @@ defineEmits([
   'open-comic',
   'toggle-read',
   'toggle-skipped',
+  'delete',
 ])
 
 function characterProgress(character) {
@@ -51,6 +54,15 @@ function characterProgress(character) {
     <header class="detail-nav sticky-toolbar">
       <button class="secondary-button" type="button" @click="$emit('back')">Back</button>
       <div class="detail-nav-actions">
+        <button
+          v-if="selectedCharacter && canDelete"
+          class="danger-button"
+          type="button"
+          :disabled="deleting"
+          @click="$emit('delete')"
+        >
+          {{ deleting ? 'Deleting...' : 'Delete character' }}
+        </button>
         <button
           v-if="selectedCharacter && !readOnly"
           type="button"

--- a/ui/src/components/ComicDetailView.vue
+++ b/ui/src/components/ComicDetailView.vue
@@ -35,6 +35,8 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  canDelete: { type: Boolean, default: false },
+  deleting: { type: Boolean, default: false },
 })
 
 const emit = defineEmits([
@@ -46,6 +48,7 @@ const emit = defineEmits([
   'toggle-skipped',
   'open-character',
   'open-series',
+  'delete',
 ])
 
 const metronActionDisabled = computed(
@@ -75,6 +78,15 @@ function seriesLabel(comic) {
     <header class="detail-nav sticky-toolbar">
       <button class="secondary-button" type="button" @click="$emit('back')">Back</button>
       <div class="detail-nav-actions">
+        <button
+          v-if="selectedComic && canDelete"
+          class="danger-button"
+          type="button"
+          :disabled="deleting"
+          @click="$emit('delete')"
+        >
+          {{ deleting ? 'Deleting...' : 'Delete comic' }}
+        </button>
         <button
           v-if="selectedComic && !readOnly"
           class="read-toggle-button large"

--- a/ui/src/components/SeriesDetailView.vue
+++ b/ui/src/components/SeriesDetailView.vue
@@ -23,6 +23,8 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  canDelete: { type: Boolean, default: false },
+  deleting: { type: Boolean, default: false },
   startSaving: { type: Boolean, default: false },
 })
 
@@ -34,6 +36,7 @@ defineEmits([
   'open-comic',
   'toggle-read',
   'toggle-skipped',
+  'delete',
 ])
 
 function seriesYearLabel(series) {
@@ -51,6 +54,15 @@ function seriesPublisherLabel(series) {
     <header class="detail-nav sticky-toolbar">
       <button class="secondary-button" type="button" @click="$emit('back')">Back</button>
       <div class="detail-nav-actions">
+        <button
+          v-if="selectedSeries && canDelete"
+          class="danger-button"
+          type="button"
+          :disabled="deleting"
+          @click="$emit('delete')"
+        >
+          {{ deleting ? 'Deleting...' : 'Delete series' }}
+        </button>
         <button
           v-if="selectedSeries && !readOnly"
           type="button"

--- a/ui/src/composables/useCharacters.js
+++ b/ui/src/composables/useCharacters.js
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue'
 import {
+  deleteCharacter as removeCharacter,
   getCharacter,
   importMetronCharacterAppearances,
   listCharacters,
@@ -20,6 +21,7 @@ export function useCharacters({
   const selectedCharacter = ref(null)
   const quickSavingCharacterID = ref(null)
   const startSaving = ref(false)
+  const deleting = ref(false)
 
   const visibleCharacters = computed(() => characters.value)
   const favoriteVisibleCharacters = computed(() =>
@@ -133,6 +135,24 @@ export function useCharacters({
     }
   }
 
+  async function deleteSelectedCharacter() {
+    if (!selectedCharacter.value?.id || deleting.value) return
+    if (!confirm(`Delete ${selectedCharacter.value.name}? This cannot be undone.`)) return
+
+    deleting.value = true
+    error.value = ''
+    try {
+      await removeCharacter(selectedCharacter.value.id)
+      selectedCharacter.value = null
+      await loadCharacters({ force: true })
+      viewMode.value = 'browse'
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      deleting.value = false
+    }
+  }
+
   async function loadCharacters(options = {}) {
     await loadPagedList('characters', characters, listCharacters, options)
   }
@@ -142,6 +162,7 @@ export function useCharacters({
     selectedCharacter,
     quickSavingCharacterID,
     startSaving,
+    deleting,
     visibleCharacters,
     characterBrowseSections,
     openCharacter,
@@ -151,6 +172,7 @@ export function useCharacters({
     importSelectedCharacterAppearances,
     characterImportRunning,
     refreshSelectedCharacterDetail,
+    deleteSelectedCharacter,
     loadCharacters,
   }
 }

--- a/ui/src/composables/useSeries.js
+++ b/ui/src/composables/useSeries.js
@@ -1,5 +1,6 @@
 import { computed, ref } from 'vue'
 import {
+  deleteSeries as removeSeries,
   getSeries,
   importMetronSeries,
   listSeries,
@@ -18,6 +19,7 @@ export function useSeries({
   const series = ref([])
   const selectedSeries = ref(null)
   const startSaving = ref(false)
+  const deleting = ref(false)
 
   const visibleSeries = computed(() => series.value)
   const favoriteVisibleSeries = computed(() => series.value.filter((item) => item.favorite))
@@ -112,6 +114,30 @@ export function useSeries({
     }
   }
 
+  async function deleteSelectedSeries() {
+    if (!selectedSeries.value?.id || deleting.value) return
+    const comicCount = selectedSeries.value.entryCount || selectedSeries.value.comics?.length || 0
+    if (
+      !confirm(
+        `Delete ${selectedSeries.value.name} and its ${comicCount} linked comic${comicCount === 1 ? '' : 's'}? This cannot be undone.`,
+      )
+    )
+      return
+
+    deleting.value = true
+    error.value = ''
+    try {
+      await removeSeries(selectedSeries.value.id)
+      selectedSeries.value = null
+      await loadSeries({ force: true })
+      viewMode.value = 'browse'
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      deleting.value = false
+    }
+  }
+
   async function loadSeries(options = {}) {
     await loadPagedList('series', series, listSeries, options)
   }
@@ -120,6 +146,7 @@ export function useSeries({
     series,
     selectedSeries,
     startSaving,
+    deleting,
     visibleSeries,
     seriesBrowseSections,
     openSeries,
@@ -128,6 +155,7 @@ export function useSeries({
     importSelectedSeriesFromMetron,
     seriesImportRunning,
     refreshSelectedSeriesDetail,
+    deleteSelectedSeries,
     loadSeries,
   }
 }


### PR DESCRIPTION
## Summary
- require admin access to delete comics, arcs, characters, and series
- allow reading-order authors and admins to delete reading orders
- add character and series deletion endpoints
- add admin-only delete actions to comic, arc, character, and series detail views
- delete linked comics with a series so automatic series synchronization cannot recreate it
- add regression coverage for admin, author, and unauthorized deletion behavior

## Destructive behavior
Deleting a series also deletes its linked comics. The UI states the linked comic count in the confirmation prompt. Foreign-key cascades remove related reading-order, arc, character-appearance, and user-progress links.

## Validation
- go test ./...
- npm run lint
- npm run build

Closes #27