### PR TITLE
Add user action auditing and last-login tracking

### DIFF
--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -2539,8 +2539,9 @@ func setupMountedAuthTestDB(t *testing.T) *sqlx.DB {
 					email_verified_at TEXT NOT NULL DEFAULT '2026-01-01T00:00:00Z',
 					password_hash TEXT NOT NULL DEFAULT '',
 				is_default INTEGER NOT NULL DEFAULT 0,
-				is_admin INTEGER NOT NULL DEFAULT 0,
-			created_at TEXT NOT NULL DEFAULT ''
+			is_admin INTEGER NOT NULL DEFAULT 0,
+		created_at TEXT NOT NULL DEFAULT '',
+		last_login_at TEXT NOT NULL DEFAULT ''
 		);
 		CREATE TABLE app_settings (
 			key TEXT PRIMARY KEY,

--- a/backend/internal/api/audit.go
+++ b/backend/internal/api/audit.go
@@ -1,0 +1,90 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/jmoiron/sqlx"
+)
+
+type AuditEvent struct {
+	ID         int    `json:"id"         db:"id"`
+	UserID     *int   `json:"userId"     db:"user_id"`
+	UserName   string `json:"userName"   db:"user_name"`
+	Method     string `json:"method"     db:"method"`
+	Path       string `json:"path"       db:"path"`
+	StatusCode int    `json:"statusCode" db:"status_code"`
+	OccurredAt string `json:"occurredAt" db:"occurred_at"`
+}
+
+type AuditEventListInput struct {
+	UserID int `query:"userId" minimum:"0"`
+	Limit  int `query:"limit" minimum:"1" maximum:"500" default:"100"`
+}
+
+type AuditEventListOutput struct{ Body []AuditEvent }
+
+// AuditMiddleware records successful state-changing API requests. Reads and
+// failed mutations are intentionally excluded so the table represents changes
+// accepted by the server rather than general HTTP traffic.
+func AuditMiddleware(db *sqlx.DB) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !auditMutationMethod(r.Method) {
+				next.ServeHTTP(w, r)
+				return
+			}
+			wrapped := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+			next.ServeHTTP(wrapped, r)
+			status := wrapped.Status()
+			if status == 0 {
+				status = http.StatusOK
+			}
+			if status >= http.StatusBadRequest {
+				return
+			}
+			var userID any
+			if id, err := currentUserID(r.Context()); err == nil {
+				userID = id
+			}
+			_, _ = db.ExecContext(context.WithoutCancel(r.Context()), `
+				INSERT INTO audit_events (user_id, method, path, status_code)
+				VALUES (?, ?, ?, ?)
+			`, userID, r.Method, r.URL.Path, status)
+		})
+	}
+}
+
+func auditMutationMethod(method string) bool {
+	switch method {
+	case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+		return true
+	default:
+		return false
+	}
+}
+
+func listAuditEvents(ctx context.Context, db *sqlx.DB, input *AuditEventListInput) (*AuditEventListOutput, error) {
+	if _, err := requireAdminUser(ctx, db); err != nil {
+		return nil, err
+	}
+	limit := input.Limit
+	if limit <= 0 || limit > 500 {
+		limit = 100
+	}
+	query := `SELECT ae.id, ae.user_id, COALESCE(u.name, '') AS user_name, ae.method, ae.path, ae.status_code, ae.occurred_at FROM audit_events ae LEFT JOIN users u ON u.id = ae.user_id`
+	args := []any{}
+	if input.UserID > 0 {
+		query += ` WHERE ae.user_id = ?`
+		args = append(args, input.UserID)
+	}
+	query += ` ORDER BY ae.id DESC LIMIT ?`
+	args = append(args, limit)
+	events := []AuditEvent{}
+	if err := db.SelectContext(ctx, &events, query, args...); err != nil {
+		return nil, huma.Error500InternalServerError("failed to fetch audit events")
+	}
+	return &AuditEventListOutput{Body: events}, nil
+}

--- a/backend/internal/api/audit_test.go
+++ b/backend/internal/api/audit_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/jmoiron/sqlx"
+)
+
+func TestAuditMiddlewareRecordsOnlySuccessfulMutations(t *testing.T) {
+	db, err := sqlx.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	db.SetMaxOpenConns(1)
+	defer db.Close()
+	if _, err := db.Exec(`CREATE TABLE audit_events (id INTEGER PRIMARY KEY, user_id INTEGER, method TEXT, path TEXT, status_code INTEGER, occurred_at TEXT DEFAULT CURRENT_TIMESTAMP)`); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := AuditMiddleware(db)(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/failed" {
+			http.Error(w, "failed", http.StatusBadRequest)
+			return
+		}
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	for _, request := range []struct {
+		method string
+		path   string
+	}{{http.MethodGet, "/comics"}, {http.MethodPatch, "/failed"}, {http.MethodPost, "/readingOrders"}} {
+		req := httptest.NewRequest(request.method, request.path, nil)
+		req = req.WithContext(context.WithValue(req.Context(), contextUserIDKey{}, 7))
+		handler.ServeHTTP(httptest.NewRecorder(), req)
+	}
+
+	var events []AuditEvent
+	if err := db.Select(&events, `SELECT id, user_id, method, path, status_code, occurred_at, '' AS user_name FROM audit_events`); err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 || events[0].UserID == nil || *events[0].UserID != 7 || events[0].Method != http.MethodPost || events[0].Path != "/readingOrders" {
+		t.Fatalf("audit events = %#v; want one successful POST by user 7", events)
+	}
+}

--- a/backend/internal/api/models.go
+++ b/backend/internal/api/models.go
@@ -38,6 +38,7 @@ type User struct {
 	EmailVerifiedAt string `json:"emailVerifiedAt" db:"email_verified_at" doc:"When the user's email address was verified." example:"2026-07-10T10:30:00Z"`
 	IsAdmin         bool   `json:"isAdmin"         db:"is_admin"          doc:"Whether the user can manage user permissions." example:"false"`
 	CreatedAt       string `json:"createdAt"       db:"created_at"        doc:"When the user account was created." example:"2026-07-10T10:00:00Z"`
+	LastLoginAt     string `json:"lastLoginAt"     db:"last_login_at"     doc:"When the user most recently logged in successfully." example:"2026-07-10T11:00:00Z"`
 }
 
 type UserMetronPermissions struct {

--- a/backend/internal/api/user_permissions.go
+++ b/backend/internal/api/user_permissions.go
@@ -39,6 +39,7 @@ func listUsers(ctx context.Context, db *sqlx.DB) (*UserListOutput, error) {
 		EmailVerifiedAt string         `db:"email_verified_at"`
 		IsAdmin         bool           `db:"is_admin"`
 		CreatedAt       string         `db:"created_at"`
+		LastLoginAt     string         `db:"last_login_at"`
 		Allowed         sql.NullBool   `db:"allowed"`
 		Scopes          sql.NullString `db:"scopes"`
 		HourlyLimit     sql.NullInt64  `db:"hourly_limit"`
@@ -52,6 +53,7 @@ func listUsers(ctx context.Context, db *sqlx.DB) (*UserListOutput, error) {
 			u.email_verified_at,
 			u.is_admin,
 			u.created_at,
+			u.last_login_at,
 			p.allowed,
 			p.scopes,
 			p.hourly_limit
@@ -73,6 +75,7 @@ func listUsers(ctx context.Context, db *sqlx.DB) (*UserListOutput, error) {
 				EmailVerifiedAt: row.EmailVerifiedAt,
 				IsAdmin:         row.IsAdmin,
 				CreatedAt:       row.CreatedAt,
+				LastLoginAt:     row.LastLoginAt,
 			},
 			MetronPermissions: permissionsFromRow(row.IsAdmin, row.Allowed, row.Scopes, row.HourlyLimit),
 		})

--- a/backend/internal/api/users.go
+++ b/backend/internal/api/users.go
@@ -49,6 +49,13 @@ type contextPublicAccessKey struct{}
 
 func RegisterUserRoutes(api huma.API, db *sqlx.DB) {
 	huma.Register(api, huma.Operation{
+		OperationID: "listAuditEvents", Tags: []string{tagUsers}, Summary: "List user audit events",
+		Description: "Lists successful state-changing API requests, newest first. Admin users only.",
+		Method:      http.MethodGet, Path: "/audit-events", Errors: []int{401, 403, 500},
+	}, func(ctx context.Context, input *AuditEventListInput) (*AuditEventListOutput, error) {
+		return listAuditEvents(ctx, db, input)
+	})
+	huma.Register(api, huma.Operation{
 		OperationID: "getUserStatus",
 		Tags:        []string{tagUsers},
 		Summary:     "Get user setup and session status",
@@ -646,6 +653,9 @@ func loginUser(ctx context.Context, db *sqlx.DB, payload UserCredentialsPayload)
 	if err != nil {
 		return nil, err
 	}
+	if _, err := db.ExecContext(ctx, `UPDATE users SET last_login_at = CURRENT_TIMESTAMP WHERE id = ?`, row.ID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to record login")
+	}
 	return userStatusForUser(ctx, db, mode, row.ID, cookie)
 }
 
@@ -989,7 +999,7 @@ func ensureDefaultUser(ctx context.Context, db sqlx.ExtContext) (int, error) {
 func getUserByID(ctx context.Context, db *sqlx.DB, id int) (User, error) {
 	var user User
 	if err := db.GetContext(ctx, &user, `
-		SELECT id, name, email, email_verified_at <> '' AS email_verified, is_admin FROM users WHERE id = ?
+		SELECT id, name, email, email_verified_at <> '' AS email_verified, is_admin, created_at FROM users WHERE id = ?
 	`, id); err != nil {
 		if err == sql.ErrNoRows {
 			return User{}, huma.Error401Unauthorized("login required")

--- a/backend/internal/db/migrations/013_user_audit_log.sql
+++ b/backend/internal/db/migrations/013_user_audit_log.sql
@@ -1,0 +1,34 @@
+-- +goose Up
+ALTER TABLE users ADD COLUMN last_login_at TEXT NOT NULL DEFAULT '';
+
+CREATE TABLE audit_events (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id     INTEGER REFERENCES users(id) ON DELETE SET NULL,
+    method      TEXT NOT NULL,
+    path        TEXT NOT NULL,
+    status_code INTEGER NOT NULL,
+    occurred_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_audit_events_occurred_at ON audit_events(occurred_at DESC);
+CREATE INDEX idx_audit_events_user_occurred ON audit_events(user_id, occurred_at DESC);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_audit_events_user_occurred;
+DROP INDEX IF EXISTS idx_audit_events_occurred_at;
+DROP TABLE audit_events;
+
+CREATE TABLE users_without_last_login (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    name              TEXT NOT NULL UNIQUE,
+    email             TEXT NOT NULL DEFAULT '',
+    email_verified_at TEXT NOT NULL DEFAULT '',
+    password_hash     TEXT NOT NULL DEFAULT '',
+    is_default        INTEGER NOT NULL DEFAULT 0,
+    is_admin          INTEGER NOT NULL DEFAULT 0,
+    created_at        TEXT NOT NULL DEFAULT ''
+);
+INSERT INTO users_without_last_login SELECT id, name, email, email_verified_at, password_hash, is_default, is_admin, created_at FROM users;
+DROP TABLE users;
+ALTER TABLE users_without_last_login RENAME TO users;
+CREATE UNIQUE INDEX idx_users_email ON users(email) WHERE email <> '';

--- a/backend/main.go
+++ b/backend/main.go
@@ -39,6 +39,7 @@ func main() {
 
 	apiRouter := chi.NewRouter()
 	apiRouter.Use(api.UserMiddleware(database))
+	apiRouter.Use(api.AuditMiddleware(database))
 	router.Mount("/api", apiRouter)
 	router.Get("/healthz", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusNoContent)

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -39,6 +39,7 @@ import {
   getMetronComicDiscovery,
   getUserStatus,
   listUsers,
+  listAuditEvents,
   loginUser,
   metronComicScanEventsURL,
   metronComicDiscoveryEventsURL,
@@ -92,6 +93,7 @@ const passwordResetForm = ref({
   completed: false,
 })
 const userAdminRows = ref([])
+const auditEvents = ref([])
 const generatedInvite = ref(null)
 const accountSaving = ref(false)
 const accountDeleting = ref(false)
@@ -604,7 +606,9 @@ function preparePasswordResetFromRouteToken() {
 }
 
 async function loadUserAdminRows() {
-  userAdminRows.value = await listUsers()
+  const [users, events] = await Promise.all([listUsers(), listAuditEvents({ limit: 200 })])
+  userAdminRows.value = users
+  auditEvents.value = events
 }
 
 async function saveMetronComicScan(settings) {
@@ -1790,6 +1794,7 @@ onUnmounted(() => {
       <UserManagementView
         v-else-if="activeView === 'users'"
         :users="userAdminRows"
+        :audit-events="auditEvents"
         :saving-user-id="savingUserID"
         :saving-admin-user-id="savingAdminUserID"
         :deleting-user-id="deletingUserID"

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -359,6 +359,10 @@ export function deleteUser(id) {
   return request(`/users/${id}`, { method: 'DELETE' })
 }
 
+export function listAuditEvents(params = {}) {
+  return request(`/audit-events${queryString(params)}`)
+}
+
 export function deleteComic(id) {
   return request(`/comics/${id}`, { method: 'DELETE' })
 }

--- a/ui/src/components/UserManagementView.vue
+++ b/ui/src/components/UserManagementView.vue
@@ -13,6 +13,10 @@ const props = defineProps({
     type: Array,
     default: () => [],
   },
+  auditEvents: {
+    type: Array,
+    default: () => [],
+  },
   savingUserID: {
     type: Number,
     default: null,
@@ -181,6 +185,7 @@ function formatTimestamp(value) {
                   Email verified {{ formatTimestamp(entry.user.emailVerifiedAt) }}
                 </span>
                 <span v-else>Email not verified</span>
+                <span>Last login {{ formatTimestamp(entry.user.lastLoginAt) }}</span>
               </p>
             </div>
             <div class="user-summary-badges" aria-hidden="true">
@@ -286,5 +291,37 @@ function formatTimestamp(value) {
         </details>
       </div>
     </template>
+
+    <section class="detail-panel">
+      <header class="section-heading">
+        <p class="eyebrow">Audit log</p>
+        <h3>Recent changes</h3>
+      </header>
+      <p v-if="auditEvents.length === 0" class="empty-state">
+        No state-changing actions recorded yet.
+      </p>
+      <div v-else class="table-scroll">
+        <table>
+          <thead>
+            <tr>
+              <th>When</th>
+              <th>User</th>
+              <th>Action</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="event in auditEvents" :key="event.id">
+              <td>{{ formatTimestamp(event.occurredAt) }}</td>
+              <td>{{ event.userName || 'System / unauthenticated' }}</td>
+              <td>
+                <code>{{ event.method }} {{ event.path }}</code>
+              </td>
+              <td>{{ event.statusCode }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
   </section>
 </template>


### PR DESCRIPTION
## Summary
- persist successful state-changing API actions in SQLite
- exclude GET/HEAD reads and failed mutation requests from the audit trail
- associate audit events with the authenticated user when available
- record each user's latest successful login
- show last-login timestamps and the latest 200 audit events in admin user management
- provide an admin-only audit-events API with user filtering

## Why SQLite
Audit events are structured application data that benefit from user relationships and admin queries. Raw operational request logs are intentionally handled separately in a file-based logging PR.

## Validation
- go test ./...
- npm run lint
- npm run build