### PR TITLE
Add persistent HTTP access logs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ PORT=8080
 DB_PATH=./data/comicorder.db
 STATIC_DIR=./public
 COVER_CACHE_DIR=./public/covers
+ACCESS_LOG_PATH=./data/access.log
 METRON_BASE_URL=https://metron.cloud/api
 METRON_USERNAME=
 METRON_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ The backend reads environment variables from the process environment and, when p
 | `DB_PATH`         | `./data/comicorder.db`     | SQLite database path.                               |
 | `STATIC_DIR`      | _(embedded)_                | Optional: serve the frontend from this directory instead of the copy embedded in the binary. Useful for local frontend development. |
 | `COVER_CACHE_DIR` | `./public/covers`          | Directory where downloaded cover images are cached. |
+| `ACCESS_LOG_PATH` | `./data/access.log`         | Append-only JSON Lines HTTP access log. Set to an empty value to disable file logging. |
 | `COOKIE_SECURE`   | auto-detected              | Sets the `Secure` flag on session cookies. Auto-detected from the request (direct TLS, or `X-Forwarded-Proto: https` from a reverse proxy) unless explicitly set to `true` or `false`. |
 | `APP_BASE_URL`    | `http://localhost:8080`    | Public base URL used in account email links. Set this to your HTTPS origin for public instances. |
 | `SMTP_HOST`       | empty                      | SMTP host for sending account emails such as verification and password reset. If unset, links are logged instead of sent. |
@@ -176,6 +177,12 @@ When the backend is running, Huma exposes interactive API documentation at:
 ```text
 http://localhost:8080/api/docs
 ```
+
+## Access logs
+
+ComicHero writes every HTTP request to `ACCESS_LOG_PATH` as one JSON object per line. Entries include the timestamp, method, path (without its query string), response status, duration, response size, remote address, forwarded address, and user agent. This format can be consumed by log-analysis tools and fail2ban filters. Query strings are omitted to avoid recording invite or password-reset tokens.
+
+The standard container stores the log at `/data/access.log`, alongside other persistent application data. ComicHero appends to the file but does not rotate it; configure the host's log rotation tooling according to your retention requirements.
 
 ## Roadmap
 

--- a/backend/access_log.go
+++ b/backend/access_log.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+)
+
+type accessLogger struct {
+	file *os.File
+	mu   sync.Mutex
+}
+
+type accessLogEntry struct {
+	Timestamp    string `json:"timestamp"`
+	Method       string `json:"method"`
+	Path         string `json:"path"`
+	Status       int    `json:"status"`
+	DurationMS   int64  `json:"durationMs"`
+	Bytes        int    `json:"bytes"`
+	RemoteAddr   string `json:"remoteAddr"`
+	ForwardedFor string `json:"forwardedFor,omitempty"`
+	UserAgent    string `json:"userAgent,omitempty"`
+}
+
+func newAccessLogger(path string) (*accessLogger, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return &accessLogger{}, nil
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640)
+	if err != nil {
+		return nil, err
+	}
+	return &accessLogger{file: file}, nil
+}
+
+func (l *accessLogger) Close() error {
+	if l == nil || l.file == nil {
+		return nil
+	}
+	return l.file.Close()
+}
+
+func (l *accessLogger) Middleware(next http.Handler) http.Handler {
+	if l == nil || l.file == nil {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		started := time.Now()
+		wrapped := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
+		next.ServeHTTP(wrapped, r)
+		status := wrapped.Status()
+		if status == 0 {
+			status = http.StatusOK
+		}
+		entry := accessLogEntry{
+			Timestamp:    started.UTC().Format(time.RFC3339Nano),
+			Method:       r.Method,
+			Path:         r.URL.Path,
+			Status:       status,
+			DurationMS:   time.Since(started).Milliseconds(),
+			Bytes:        wrapped.BytesWritten(),
+			RemoteAddr:   r.RemoteAddr,
+			ForwardedFor: r.Header.Get("X-Forwarded-For"),
+			UserAgent:    r.UserAgent(),
+		}
+		encoded, err := json.Marshal(entry)
+		if err != nil {
+			return
+		}
+		l.mu.Lock()
+		_, _ = l.file.Write(append(encoded, '\n'))
+		l.mu.Unlock()
+	})
+}

--- a/backend/access_log_test.go
+++ b/backend/access_log_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"bufio"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestAccessLoggerPersistsRequestsWithoutQueryStrings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "logs", "access.log")
+	logger, err := newAccessLogger(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	handler := logger.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	req := httptest.NewRequest(http.MethodPost, "/api/auth/reset-password?token=secret", nil)
+	req.RemoteAddr = "192.0.2.10:1234"
+	req.Header.Set("X-Forwarded-For", "198.51.100.2")
+	handler.ServeHTTP(httptest.NewRecorder(), req)
+	if err := logger.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	var entry accessLogEntry
+	if !bufio.NewScanner(file).Scan() {
+		t.Fatal("access log is empty")
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.NewDecoder(file).Decode(&entry); err != nil {
+		t.Fatal(err)
+	}
+	if entry.Path != "/api/auth/reset-password" || entry.Status != http.StatusUnauthorized || entry.RemoteAddr != "192.0.2.10:1234" || entry.ForwardedFor != "198.51.100.2" {
+		t.Fatalf("access log entry = %+v", entry)
+	}
+}
+
+func TestAccessLoggerCanBeDisabled(t *testing.T) {
+	logger, err := newAccessLogger("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if logger.file != nil {
+		t.Fatal("empty access log path should disable file logging")
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -36,6 +36,16 @@ func main() {
 	router := chi.NewRouter()
 	router.Use(middleware.Logger)
 	router.Use(middleware.Recoverer)
+	accessLogPath := "./data/access.log"
+	if configuredPath, configured := os.LookupEnv("ACCESS_LOG_PATH"); configured {
+		accessLogPath = configuredPath
+	}
+	accessLog, err := newAccessLogger(accessLogPath)
+	if err != nil {
+		log.Fatalf("failed to open access log: %v", err)
+	}
+	defer accessLog.Close()
+	router.Use(accessLog.Middleware)
 
 	apiRouter := chi.NewRouter()
 	apiRouter.Use(api.UserMiddleware(database))

--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,7 @@ services:
       PORT: "8080"
       DB_PATH: /data/comicorder.db
       COVER_CACHE_DIR: /data/covers
+      ACCESS_LOG_PATH: /data/access.log
       METRON_BASE_URL: https://metron.cloud/api
       METRON_USERNAME: ${METRON_USERNAME:-}
       METRON_PASSWORD: ${METRON_PASSWORD:-}


### PR DESCRIPTION
## Summary
- append every HTTP request to a persistent JSON Lines file
- record timestamp, method, path, status, duration, response bytes, socket address, forwarded address, and user agent
- omit query strings so invite and password-reset tokens are never persisted
- default to ./data/access.log and /data/access.log in Docker Compose
- allow file logging to be disabled with an explicitly empty ACCESS_LOG_PATH
- document external rotation and fail2ban/log-analysis usage

## Why a file
Operational request logs need to be tailed, rotated, shipped, and parsed by host tools independently of SQLite. The structured user-action audit trail remains a separate database-backed feature in #31.

## Validation
- go test ./...