### PR TITLE
Fix dashboard comic scan after Metron sync migration

### DIFF
--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -166,6 +166,7 @@ func TestUserStatisticsAndAchievements(t *testing.T) {
 			cover_date TEXT NOT NULL DEFAULT '',
 			cover_image TEXT NOT NULL DEFAULT '',
 			description TEXT NOT NULL DEFAULT '',
+			metron_synced_at TEXT NOT NULL DEFAULT '',
 			metron_issue_id INTEGER
 		);
 		CREATE TABLE user_comics (
@@ -374,7 +375,8 @@ func TestDashboardNextComicAdvancesAfterRead(t *testing.T) {
 			publisher TEXT NOT NULL,
 			cover_date TEXT NOT NULL DEFAULT '',
 			cover_image TEXT NOT NULL DEFAULT '',
-			description TEXT NOT NULL DEFAULT ''
+			description TEXT NOT NULL DEFAULT '',
+			metron_synced_at TEXT NOT NULL DEFAULT ''
 		);
 		CREATE TABLE user_comics (
 			comic_id INTEGER NOT NULL REFERENCES comics(id) ON DELETE CASCADE,

--- a/backend/internal/api/dashboard.go
+++ b/backend/internal/api/dashboard.go
@@ -2,6 +2,8 @@ package api
 
 import (
 	"context"
+	"fmt"
+	"log"
 	"net/http"
 	"sort"
 	"time"
@@ -51,10 +53,12 @@ func getDashboard(ctx context.Context, db *sqlx.DB) (*DashboardOutput, error) {
 
 	items, err := dashboardItems(ctx, db, userID)
 	if err != nil {
+		log.Printf("failed to fetch dashboard for user %d: %v", userID, err)
 		return nil, huma.Error500InternalServerError("failed to fetch dashboard")
 	}
 	achievements, err := dashboardAchievements(ctx, db, userID)
 	if err != nil {
+		log.Printf("failed to fetch dashboard achievements for user %d: %v", userID, err)
 		return nil, huma.Error500InternalServerError("failed to fetch dashboard achievements")
 	}
 
@@ -68,15 +72,18 @@ func getDashboard(ctx context.Context, db *sqlx.DB) (*DashboardOutput, error) {
 
 func dashboardItems(ctx context.Context, db *sqlx.DB, userID int) ([]DashboardItem, error) {
 	items := []DashboardItem{}
-	for _, loader := range []func(context.Context, *sqlx.DB, int) ([]DashboardItem, error){
-		dashboardReadingOrders,
-		dashboardArcs,
-		dashboardCharacters,
-		dashboardSeries,
+	for _, loader := range []struct {
+		name string
+		load func(context.Context, *sqlx.DB, int) ([]DashboardItem, error)
+	}{
+		{name: "reading orders", load: dashboardReadingOrders},
+		{name: "arcs", load: dashboardArcs},
+		{name: "characters", load: dashboardCharacters},
+		{name: "series", load: dashboardSeries},
 	} {
-		loaded, err := loader(ctx, db, userID)
+		loaded, err := loader.load(ctx, db, userID)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("load %s: %w", loader.name, err)
 		}
 		items = append(items, loaded...)
 	}

--- a/backend/internal/api/models.go
+++ b/backend/internal/api/models.go
@@ -7,16 +7,17 @@ type Comic struct {
 	MetronIssueID *int `json:"metronIssueId,omitempty" db:"metron_issue_id" doc:"Linked Metron issue identifier, when this comic was imported or matched." example:"123456"`
 	SeriesID      *int `json:"seriesId,omitempty"      db:"series_id"       doc:"Local series identifier for this comic's series, when available." example:"5"`
 
-	Title       string `json:"title"       db:"-"           doc:"Generated display title built from series, seriesYear, and issue." example:"Batman (2011) #6"`
-	Series      string `json:"series"      db:"series"      doc:"Series name." example:"Batman"`
-	SeriesYear  int    `json:"seriesYear"  db:"series_year" doc:"Series start year or volume year used in the generated title." minimum:"0" example:"2011"`
-	Issue       string `json:"issue"       db:"issue"       doc:"Issue number." example:"6.LR"`
-	Publisher   string `json:"publisher"   db:"publisher"   doc:"Publisher name." example:"DC Comics"`
-	CoverDate   string `json:"coverDate"   db:"cover_date"  doc:"Cover date as provided by the source." example:"2012-04-01"`
-	CoverImage  string `json:"coverImage"  db:"cover_image" doc:"Absolute URL for the cover image." format:"uri" example:"https://static.metron.cloud/media/issue/cover.jpg"`
-	Description string `json:"description" db:"description" doc:"Issue synopsis or notes."`
-	Read        bool   `json:"read"        db:"read"        doc:"Whether the comic has been read." example:"false"`
-	Skipped     bool   `json:"skipped"     db:"skipped"     doc:"Whether the comic has been skipped." example:"false"`
+	Title          string `json:"title"       db:"-"           doc:"Generated display title built from series, seriesYear, and issue." example:"Batman (2011) #6"`
+	Series         string `json:"series"      db:"series"      doc:"Series name." example:"Batman"`
+	SeriesYear     int    `json:"seriesYear"  db:"series_year" doc:"Series start year or volume year used in the generated title." minimum:"0" example:"2011"`
+	Issue          string `json:"issue"       db:"issue"       doc:"Issue number." example:"6.LR"`
+	Publisher      string `json:"publisher"   db:"publisher"   doc:"Publisher name." example:"DC Comics"`
+	CoverDate      string `json:"coverDate"   db:"cover_date"  doc:"Cover date as provided by the source." example:"2012-04-01"`
+	CoverImage     string `json:"coverImage"  db:"cover_image" doc:"Absolute URL for the cover image." format:"uri" example:"https://static.metron.cloud/media/issue/cover.jpg"`
+	Description    string `json:"description" db:"description" doc:"Issue synopsis or notes."`
+	MetronSyncedAt string `json:"-" db:"metron_synced_at"`
+	Read           bool   `json:"read"        db:"read"        doc:"Whether the comic has been read." example:"false"`
+	Skipped        bool   `json:"skipped"     db:"skipped"     doc:"Whether the comic has been skipped." example:"false"`
 }
 
 type ComicPayload struct {


### PR DESCRIPTION
## Summary
- map the internal comic Metron sync timestamp for SQL scans
- add production-schema coverage to dashboard fixtures
- log the failing dashboard loader while keeping client errors generic

## Root cause
Migration 012 added comics.metron_synced_at, but Comic did not provide a matching database field. Queries using SELECT c.* failed in sqlx when started reading orders contained comics.

## Verification
- focused dashboard and statistics tests
- go build ./...
- git diff --check