### PR TITLE
Display the running ComicHero version

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ DB_PATH=./data/comicorder.db
 STATIC_DIR=./public
 COVER_CACHE_DIR=./public/covers
 ACCESS_LOG_PATH=./data/access.log
+SHOW_VERSION=true
 METRON_BASE_URL=https://metron.cloud/api
 METRON_USERNAME=
 METRON_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ ComicHero reads the process environment and `.env` files in the current or paren
 | `COVER_CACHE_DIR` | `./public/covers` | Storage directory for downloaded and optimized cover images. |
 | `ACCESS_LOG_PATH` | `./data/access.log` | Append-only JSON Lines HTTP access log. Set it explicitly to an empty value to disable file logging. |
 | `STATIC_DIR` | embedded frontend | Optional directory from which to serve frontend files instead of the embedded build. |
+| `SHOW_VERSION` | `true` | Show the running ComicHero version below the sidebar branding. Set to `false` to hide it. |
 | `METRON_BASE_URL` | `https://metron.cloud/api` | Metron API base URL. |
 | `METRON_USERNAME` | empty | Metron username used for search, import, and maintenance jobs. |
 | `METRON_PASSWORD` | empty | Metron password. |

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -1474,14 +1474,15 @@ func TestDocsConfigAndRouteMetadata(t *testing.T) {
 	RegisterArcRoutes(api, nil)
 	RegisterDashboardRoutes(api, nil)
 	RegisterStatisticsRoutes(api, nil)
+	RegisterSystemRoutes(api, "test", true)
 	RegisterMetronRoutes(api, nil, metron.New(metron.Config{}), nil, newMetronImportJobStore())
 
 	openAPI := api.OpenAPI()
 	if openAPI.Info.Description == "" {
 		t.Fatal("OpenAPI description is empty")
 	}
-	if len(openAPI.Tags) != 9 {
-		t.Fatalf("len(tags) = %d; want 9", len(openAPI.Tags))
+	if len(openAPI.Tags) != 10 {
+		t.Fatalf("len(tags) = %d; want 10", len(openAPI.Tags))
 	}
 
 	listComics := openAPI.Paths["/comics"].Get

--- a/backend/internal/api/docs.go
+++ b/backend/internal/api/docs.go
@@ -12,6 +12,7 @@ const (
 	tagMetron        = "Metron"
 	tagUsers         = "Users"
 	tagStatistics    = "Statistics"
+	tagSystem        = "System"
 )
 
 var (
@@ -37,6 +38,7 @@ func DocsConfig() huma.Config {
 		{Name: tagMetron, Description: "Search, inspect, and import metadata from Metron."},
 		{Name: tagUsers, Description: "Choose single-user or multi-user mode and manage login sessions."},
 		{Name: tagStatistics, Description: "Summarize per-user reading progress and achievements."},
+		{Name: tagSystem, Description: "Inspect public information about the running ComicHero build."},
 	}
 	return config
 }

--- a/backend/internal/api/system.go
+++ b/backend/internal/api/system.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+)
+
+type SystemInfo struct {
+	Version     string `json:"version" doc:"Version of the running ComicHero build." example:"v1.5.1"`
+	ShowVersion bool   `json:"showVersion" doc:"Whether clients should display the running version."`
+}
+
+type SystemInfoOutput struct {
+	Body SystemInfo
+}
+
+func RegisterSystemRoutes(api huma.API, version string, showVersion bool) {
+	huma.Register(api, huma.Operation{
+		OperationID: "getSystemInfo",
+		Tags:        []string{tagSystem},
+		Summary:     "Get system information",
+		Description: "Returns public information about the running ComicHero build.",
+		Method:      http.MethodGet,
+		Path:        "/system",
+	}, func(context.Context, *struct{}) (*SystemInfoOutput, error) {
+		return &SystemInfoOutput{Body: SystemInfo{
+			Version:     version,
+			ShowVersion: showVersion,
+		}}, nil
+	})
+}

--- a/backend/internal/api/system_test.go
+++ b/backend/internal/api/system_test.go
@@ -1,0 +1,32 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/danielgtaylor/huma/v2/adapters/humachi"
+	"github.com/go-chi/chi/v5"
+)
+
+func TestSystemInfo(t *testing.T) {
+	router := chi.NewRouter()
+	api := humachi.New(router, DocsConfig())
+	RegisterSystemRoutes(api, "v1.6.0", false)
+
+	request := httptest.NewRequest(http.MethodGet, "/system", nil)
+	response := httptest.NewRecorder()
+	router.ServeHTTP(response, request)
+
+	if response.Code != http.StatusOK {
+		t.Fatalf("status = %d; want %d", response.Code, http.StatusOK)
+	}
+	var body SystemInfo
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Version != "v1.6.0" || body.ShowVersion {
+		t.Fatalf("body = %#v; want version v1.6.0 with display disabled", body)
+	}
+}

--- a/backend/main.go
+++ b/backend/main.go
@@ -56,6 +56,7 @@ func main() {
 	})
 
 	humaAPI := humachi.New(apiRouter, api.DocsConfig())
+	api.RegisterSystemRoutes(humaAPI, version, envBool("SHOW_VERSION", true))
 	covers := api.NewCoverCache(env("COVER_CACHE_DIR", "./public/covers"), "/covers")
 	if err := covers.EnsureDir(); err != nil {
 		log.Fatalf("failed to prepare cover cache: %v", err)
@@ -160,6 +161,17 @@ func env(key, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+func envBool(key string, fallback bool) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(key))) {
+	case "1", "true", "yes", "on":
+		return true
+	case "0", "false", "no", "off":
+		return false
+	default:
+		return fallback
+	}
 }
 
 func loadEnvFiles(paths ...string) {

--- a/compose.yaml
+++ b/compose.yaml
@@ -13,6 +13,7 @@ services:
       DB_PATH: /data/comicorder.db
       COVER_CACHE_DIR: /data/covers
       ACCESS_LOG_PATH: /data/access.log
+      SHOW_VERSION: ${SHOW_VERSION:-true}
       METRON_BASE_URL: https://metron.cloud/api
       METRON_USERNAME: ${METRON_USERNAME:-}
       METRON_PASSWORD: ${METRON_PASSWORD:-}

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -37,6 +37,7 @@ import {
   getDashboard,
   getMetronComicScan,
   getMetronComicDiscovery,
+  getSystemInfo,
   getUserStatus,
   listUsers,
   listAuditEvents,
@@ -72,6 +73,7 @@ const error = ref('')
 const authLoading = ref(true)
 const authSaving = ref(false)
 const userStatus = ref(null)
+const systemInfo = ref(null)
 const authMode = ref('login')
 const loginRequested = ref(false)
 const setupForm = ref({ mode: 'single', name: '', email: '', password: '' })
@@ -1352,7 +1354,8 @@ onMounted(async () => {
     themeMediaQuery = window.matchMedia?.('(prefers-color-scheme: dark)')
     themeMediaQuery?.addEventListener('change', handleSystemThemeChange)
   }
-  await loadUserStatus()
+  const [, info] = await Promise.all([loadUserStatus(), getSystemInfo().catch(() => null)])
+  systemInfo.value = info
   if (route.name === 'verifyEmail') {
     await verifyEmailFromRouteToken()
   } else if (route.name === 'resetPassword') {
@@ -1744,6 +1747,7 @@ onUnmounted(() => {
       :read-only-guest="isReadOnlyGuest"
       :show-metron="canAccessMetronArea && !isReadOnlyGuest"
       :auth-saving="authSaving"
+      :version="systemInfo?.showVersion ? systemInfo.version : ''"
       @set-theme="setThemePreference"
       @login="requestLogin"
       @logout="signOut"

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -124,6 +124,10 @@ export function assetURL(path) {
   return `${base.origin}${path}`
 }
 
+export function getSystemInfo() {
+  return request('/system')
+}
+
 function pagedListResult(data, pagination) {
   const items = Array.isArray(data) ? data : []
   return {

--- a/ui/src/components/AppSidebar.vue
+++ b/ui/src/components/AppSidebar.vue
@@ -38,6 +38,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  version: {
+    type: String,
+    default: '',
+  },
 })
 
 const emit = defineEmits(['set-theme', 'login', 'logout'])
@@ -75,7 +79,10 @@ function toggleAccountMenu() {
 <template>
   <aside class="sidebar" :class="{ 'menu-open': menuOpen }">
     <div class="sidebar-header">
-      <h1>ComicHero</h1>
+      <div class="sidebar-branding">
+        <h1>ComicHero</h1>
+        <span v-if="version" class="version-tag">{{ version }}</span>
+      </div>
       <button
         type="button"
         class="mobile-menu-button"

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -401,6 +401,24 @@ button:disabled {
   gap: 12px;
 }
 
+.sidebar-branding {
+  display: grid;
+  justify-items: start;
+  gap: 6px;
+}
+
+.version-tag {
+  display: inline-flex;
+  border: 1px solid var(--line-strong);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--muted);
+  padding: 2px 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  line-height: 1.2;
+}
+
 .mobile-menu-button {
   display: none;
   place-items: center;


### PR DESCRIPTION
## Summary
- expose the linker-injected application version through the public system endpoint
- show a compact version tag below the sidebar branding
- allow operators to hide it with SHOW_VERSION=false

## Verification
- go test ./...
- npm run lint
- npm run build