### PR TITLE
Notify users when a ComicHero update is available

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,7 @@ STATIC_DIR=./public
 COVER_CACHE_DIR=./public/covers
 ACCESS_LOG_PATH=./data/access.log
 SHOW_VERSION=true
+CHECK_FOR_UPDATES=true
 METRON_BASE_URL=https://metron.cloud/api
 METRON_USERNAME=
 METRON_PASSWORD=

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ ComicHero reads the process environment and `.env` files in the current or paren
 | `ACCESS_LOG_PATH` | `./data/access.log` | Append-only JSON Lines HTTP access log. Set it explicitly to an empty value to disable file logging. |
 | `STATIC_DIR` | embedded frontend | Optional directory from which to serve frontend files instead of the embedded build. |
 | `SHOW_VERSION` | `true` | Show the running ComicHero version below the sidebar branding. Set to `false` to hide it. |
+| `CHECK_FOR_UPDATES` | `true` | Check GitHub for a newer stable release and show an in-app notice when one is available. |
 | `METRON_BASE_URL` | `https://metron.cloud/api` | Metron API base URL. |
 | `METRON_USERNAME` | empty | Metron username used for search, import, and maintenance jobs. |
 | `METRON_PASSWORD` | empty | Metron password. |

--- a/backend/internal/api/api_test.go
+++ b/backend/internal/api/api_test.go
@@ -1474,7 +1474,7 @@ func TestDocsConfigAndRouteMetadata(t *testing.T) {
 	RegisterArcRoutes(api, nil)
 	RegisterDashboardRoutes(api, nil)
 	RegisterStatisticsRoutes(api, nil)
-	RegisterSystemRoutes(api, "test", true)
+	RegisterSystemRoutes(api, "test", true, nil)
 	RegisterMetronRoutes(api, nil, metron.New(metron.Config{}), nil, newMetronImportJobStore())
 
 	openAPI := api.OpenAPI()

--- a/backend/internal/api/system.go
+++ b/backend/internal/api/system.go
@@ -2,21 +2,90 @@ package api
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2"
 )
 
 type SystemInfo struct {
-	Version     string `json:"version" doc:"Version of the running ComicHero build." example:"v1.5.1"`
-	ShowVersion bool   `json:"showVersion" doc:"Whether clients should display the running version."`
+	Version         string `json:"version" doc:"Version of the running ComicHero build." example:"v1.5.1"`
+	ShowVersion     bool   `json:"showVersion" doc:"Whether clients should display the running version."`
+	LatestVersion   string `json:"latestVersion,omitempty" doc:"Latest published stable ComicHero version." example:"v1.6.0"`
+	UpdateAvailable bool   `json:"updateAvailable" doc:"Whether a newer stable ComicHero release is available."`
+	ReleaseURL      string `json:"releaseUrl,omitempty" doc:"Page for the latest stable ComicHero release."`
 }
 
 type SystemInfoOutput struct {
 	Body SystemInfo
 }
 
-func RegisterSystemRoutes(api huma.API, version string, showVersion bool) {
+type LatestRelease struct {
+	Version string
+	URL     string
+}
+
+type ReleaseChecker interface {
+	Latest(context.Context) (LatestRelease, error)
+}
+
+type GitHubReleaseChecker struct {
+	client    *http.Client
+	url       string
+	cacheFor  time.Duration
+	mu        sync.Mutex
+	cached    LatestRelease
+	expiresAt time.Time
+}
+
+func NewGitHubReleaseChecker() *GitHubReleaseChecker {
+	return &GitHubReleaseChecker{
+		client:   &http.Client{Timeout: 5 * time.Second},
+		url:      "https://api.github.com/repos/Lofter1/ComicHero/releases/latest",
+		cacheFor: 6 * time.Hour,
+	}
+}
+
+func (checker *GitHubReleaseChecker) Latest(ctx context.Context) (LatestRelease, error) {
+	checker.mu.Lock()
+	defer checker.mu.Unlock()
+	if time.Now().Before(checker.expiresAt) {
+		return checker.cached, nil
+	}
+
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, checker.url, nil)
+	if err != nil {
+		return LatestRelease{}, err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	request.Header.Set("User-Agent", "ComicHero update checker")
+	response, err := checker.client.Do(request)
+	if err != nil {
+		return LatestRelease{}, err
+	}
+	defer response.Body.Close()
+	if response.StatusCode != http.StatusOK {
+		return LatestRelease{}, fmt.Errorf("GitHub releases returned %s", response.Status)
+	}
+	var body struct {
+		TagName string `json:"tag_name"`
+		HTMLURL string `json:"html_url"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&body); err != nil {
+		return LatestRelease{}, err
+	}
+	checker.cached = LatestRelease{Version: body.TagName, URL: body.HTMLURL}
+	checker.expiresAt = time.Now().Add(checker.cacheFor)
+	return checker.cached, nil
+}
+
+func RegisterSystemRoutes(api huma.API, version string, showVersion bool, releaseChecker ReleaseChecker) {
 	huma.Register(api, huma.Operation{
 		OperationID: "getSystemInfo",
 		Tags:        []string{tagSystem},
@@ -24,10 +93,50 @@ func RegisterSystemRoutes(api huma.API, version string, showVersion bool) {
 		Description: "Returns public information about the running ComicHero build.",
 		Method:      http.MethodGet,
 		Path:        "/system",
-	}, func(context.Context, *struct{}) (*SystemInfoOutput, error) {
-		return &SystemInfoOutput{Body: SystemInfo{
+	}, func(ctx context.Context, _ *struct{}) (*SystemInfoOutput, error) {
+		info := SystemInfo{
 			Version:     version,
 			ShowVersion: showVersion,
-		}}, nil
+		}
+		if releaseChecker != nil {
+			if latest, err := releaseChecker.Latest(ctx); err == nil {
+				info.LatestVersion = latest.Version
+				info.ReleaseURL = latest.URL
+				info.UpdateAvailable = newerVersion(version, latest.Version)
+			}
+		}
+		return &SystemInfoOutput{Body: info}, nil
 	})
+}
+
+func newerVersion(current, latest string) bool {
+	currentParts, currentOK := versionParts(current)
+	latestParts, latestOK := versionParts(latest)
+	if !currentOK || !latestOK {
+		return false
+	}
+	for index := range currentParts {
+		if latestParts[index] != currentParts[index] {
+			return latestParts[index] > currentParts[index]
+		}
+	}
+	return false
+}
+
+func versionParts(value string) ([3]int, bool) {
+	var result [3]int
+	value = strings.TrimPrefix(strings.TrimSpace(value), "v")
+	value = strings.SplitN(value, "-", 2)[0]
+	parts := strings.Split(value, ".")
+	if len(parts) != len(result) {
+		return result, false
+	}
+	for index, part := range parts {
+		number, err := strconv.Atoi(part)
+		if err != nil || number < 0 {
+			return result, false
+		}
+		result[index] = number
+	}
+	return result, true
 }

--- a/backend/internal/api/system_test.go
+++ b/backend/internal/api/system_test.go
@@ -1,19 +1,32 @@
 package api
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/danielgtaylor/huma/v2/adapters/humachi"
 	"github.com/go-chi/chi/v5"
 )
 
+type staticReleaseChecker struct {
+	release LatestRelease
+}
+
+func (checker staticReleaseChecker) Latest(context.Context) (LatestRelease, error) {
+	return checker.release, nil
+}
+
 func TestSystemInfo(t *testing.T) {
 	router := chi.NewRouter()
 	api := humachi.New(router, DocsConfig())
-	RegisterSystemRoutes(api, "v1.6.0", false)
+	RegisterSystemRoutes(api, "v1.6.0", false, staticReleaseChecker{release: LatestRelease{
+		Version: "v1.7.0",
+		URL:     "https://github.com/Lofter1/ComicHero/releases/tag/v1.7.0",
+	}})
 
 	request := httptest.NewRequest(http.MethodGet, "/system", nil)
 	response := httptest.NewRecorder()
@@ -28,5 +41,54 @@ func TestSystemInfo(t *testing.T) {
 	}
 	if body.Version != "v1.6.0" || body.ShowVersion {
 		t.Fatalf("body = %#v; want version v1.6.0 with display disabled", body)
+	}
+	if !body.UpdateAvailable || body.LatestVersion != "v1.7.0" || body.ReleaseURL == "" {
+		t.Fatalf("body = %#v; want v1.7.0 update information", body)
+	}
+}
+
+func TestNewerVersion(t *testing.T) {
+	tests := []struct {
+		current string
+		latest  string
+		want    bool
+	}{
+		{current: "v1.5.1", latest: "v1.6.0", want: true},
+		{current: "1.6.0", latest: "v1.6.0", want: false},
+		{current: "v2.0.0", latest: "v1.9.9", want: false},
+		{current: "dev", latest: "v1.6.0", want: false},
+	}
+	for _, test := range tests {
+		if got := newerVersion(test.current, test.latest); got != test.want {
+			t.Errorf("newerVersion(%q, %q) = %v; want %v", test.current, test.latest, got, test.want)
+		}
+	}
+}
+
+func TestGitHubReleaseCheckerCachesLatestRelease(t *testing.T) {
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		response.Header().Set("Content-Type", "application/json")
+		_, _ = response.Write([]byte(`{"tag_name":"v1.7.0","html_url":"https://example.com/v1.7.0"}`))
+	}))
+	defer server.Close()
+
+	checker := &GitHubReleaseChecker{
+		client:   server.Client(),
+		url:      server.URL,
+		cacheFor: time.Hour,
+	}
+	for range 2 {
+		release, err := checker.Latest(context.Background())
+		if err != nil {
+			t.Fatalf("latest release: %v", err)
+		}
+		if release.Version != "v1.7.0" || release.URL != "https://example.com/v1.7.0" {
+			t.Fatalf("release = %#v; want v1.7.0", release)
+		}
+	}
+	if requests != 1 {
+		t.Fatalf("requests = %d; want 1 cached request", requests)
 	}
 }

--- a/backend/main.go
+++ b/backend/main.go
@@ -56,7 +56,11 @@ func main() {
 	})
 
 	humaAPI := humachi.New(apiRouter, api.DocsConfig())
-	api.RegisterSystemRoutes(humaAPI, version, envBool("SHOW_VERSION", true))
+	var releaseChecker api.ReleaseChecker
+	if envBool("CHECK_FOR_UPDATES", true) {
+		releaseChecker = api.NewGitHubReleaseChecker()
+	}
+	api.RegisterSystemRoutes(humaAPI, version, envBool("SHOW_VERSION", true), releaseChecker)
 	covers := api.NewCoverCache(env("COVER_CACHE_DIR", "./public/covers"), "/covers")
 	if err := covers.EnsureDir(); err != nil {
 		log.Fatalf("failed to prepare cover cache: %v", err)

--- a/compose.yaml
+++ b/compose.yaml
@@ -14,6 +14,7 @@ services:
       COVER_CACHE_DIR: /data/covers
       ACCESS_LOG_PATH: /data/access.log
       SHOW_VERSION: ${SHOW_VERSION:-true}
+      CHECK_FOR_UPDATES: ${CHECK_FOR_UPDATES:-true}
       METRON_BASE_URL: https://metron.cloud/api
       METRON_USERNAME: ${METRON_USERNAME:-}
       METRON_PASSWORD: ${METRON_PASSWORD:-}

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -74,6 +74,7 @@ const authLoading = ref(true)
 const authSaving = ref(false)
 const userStatus = ref(null)
 const systemInfo = ref(null)
+const updateNoticeDismissed = ref(false)
 const authMode = ref('login')
 const loginRequested = ref(false)
 const setupForm = ref({ mode: 'single', name: '', email: '', password: '' })
@@ -1763,6 +1764,25 @@ onUnmounted(() => {
       <div v-if="error" class="toast error-toast" role="alert" aria-live="assertive">
         <span>{{ error }}</span>
         <button type="button" aria-label="Dismiss error" @click="clearError">Dismiss</button>
+      </div>
+
+      <div
+        v-if="systemInfo?.updateAvailable && !updateNoticeDismissed"
+        class="toast update-toast"
+        role="status"
+        aria-live="polite"
+      >
+        <span>
+          ComicHero {{ systemInfo.latestVersion }} is available.
+          <a :href="systemInfo.releaseUrl" target="_blank" rel="noreferrer">View release</a>
+        </span>
+        <button
+          type="button"
+          aria-label="Dismiss update notice"
+          @click="updateNoticeDismissed = true"
+        >
+          Dismiss
+        </button>
       </div>
 
       <MetronImportMonitor

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -3419,6 +3419,17 @@ textarea {
   font-weight: 800;
 }
 
+.update-toast {
+  border-color: var(--warning-border);
+  background: var(--warning-soft);
+  color: var(--warning-ink);
+}
+
+.update-toast a {
+  color: inherit;
+  font-weight: 800;
+}
+
 .dashboard-view {
   display: grid;
   gap: 18px;


### PR DESCRIPTION
## Summary
- check GitHub's latest stable release endpoint from the backend
- cache successful checks for six hours and fail silently when GitHub is unavailable
- compare semantic versions and show a dismissible release notice only for newer versions
- allow operators to disable outbound checks with CHECK_FOR_UPDATES=false

## Verification
- go test ./...
- npm run lint
- npm run build

## Dependency
Stacked on #37 because it extends the system endpoint introduced there.