### PR TITLE
feat: add reading order sections

### DIFF
--- a/backend/internal/api/metron_import_helpers_test.go
+++ b/backend/internal/api/metron_import_helpers_test.go
@@ -166,6 +166,13 @@ func newMetronImportTestDB(t *testing.T) *sqlx.DB {
 			PRIMARY KEY (parent_reading_order_id, child_reading_order_id),
 			CHECK (parent_reading_order_id <> child_reading_order_id)
 		);
+		CREATE TABLE reading_order_sections (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
+			position INTEGER NOT NULL DEFAULT 0,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT ''
+		);
 
 		CREATE TABLE metron_sync_states (
 			resource_type TEXT NOT NULL,

--- a/backend/internal/api/models_reading_orders.go
+++ b/backend/internal/api/models_reading_orders.go
@@ -40,9 +40,11 @@ type ReadingOrderComicPayload struct {
 }
 
 type ReadingOrderEntryPayload struct {
-	Type           string `json:"type"           enum:"comic,readingOrder" doc:"Entry type." example:"comic"`
+	Type           string `json:"type"           enum:"comic,readingOrder,section" doc:"Entry type." example:"comic"`
 	ComicID        int    `json:"comicId,omitempty"        doc:"Local comic identifier for comic entries." example:"42"`
 	ReadingOrderID int    `json:"readingOrderId,omitempty" doc:"Child reading-order identifier for nested reading-order entries." example:"7"`
+	Title          string `json:"title,omitempty"          doc:"Section title for section entries." example:"Main story"`
+	Description    string `json:"description,omitempty"    doc:"Optional section description for section entries." example:"Read these issues before the tie-ins."`
 	Comment        string `json:"comment,omitempty"        doc:"Optional note for comic or nested reading-order entries." example:"Read after issue 5"`
 	Tags           string `json:"tags,omitempty"           doc:"Comma-separated tags for comic entries." example:"Main Story"`
 }
@@ -53,11 +55,18 @@ type ReadingOrderComic struct {
 	Tags    string `json:"tags"    db:"tags"    doc:"Comma-separated entry tags synced from Metron or added locally." example:"Main Story"`
 }
 
+type ReadingOrderSection struct {
+	Title       string `json:"title"       db:"title"       doc:"Section title." example:"Main story"`
+	Description string `json:"description" db:"description" doc:"Optional context shown below the section title."`
+}
+
 type ReadingOrderEntry struct {
-	Type         string             `json:"type" doc:"Entry type." example:"comic"`
-	Comic        *ReadingOrderComic `json:"comic,omitempty" doc:"Comic entry payload when type is comic."`
-	ReadingOrder *ReadingOrder      `json:"readingOrder,omitempty" doc:"Referenced reading order when type is readingOrder."`
-	Comment      string             `json:"comment,omitempty" doc:"Per-entry note for nested reading-order entries." example:"Read this crossover here"`
+	Type         string               `json:"type" doc:"Entry type." enum:"comic,readingOrder,section" example:"comic"`
+	Comic        *ReadingOrderComic   `json:"comic,omitempty" doc:"Comic entry payload when type is comic."`
+	ReadingOrder *ReadingOrder        `json:"readingOrder,omitempty" doc:"Referenced reading order when type is readingOrder."`
+	Section      *ReadingOrderSection `json:"section,omitempty" doc:"Section heading when type is section."`
+	Comics       []ReadingOrderComic  `json:"comics,omitempty" doc:"Expanded comics when type is readingOrder."`
+	Comment      string               `json:"comment,omitempty" doc:"Per-entry note for nested reading-order entries." example:"Read this crossover here"`
 }
 
 type ReadingOrderDetail struct {
@@ -156,6 +165,6 @@ type SetReadingOrderComicsInput struct {
 		ComicIDs        []int                      `json:"comicIds,omitempty"        doc:"Comic IDs in reading order. Use comics to include comments." example:"[42,43]"`
 		Comics          []ReadingOrderComicPayload `json:"comics,omitempty"          doc:"Comics in reading order with optional per-entry comments."`
 		ReadingOrderIDs []int                      `json:"readingOrderIds,omitempty" doc:"Child reading-order IDs referenced by this reading order." example:"[7,8]"`
-		Entries         []ReadingOrderEntryPayload `json:"entries,omitempty"         doc:"Ordered comic and child reading-order entries."`
+		Entries         []ReadingOrderEntryPayload `json:"entries,omitempty"         doc:"Ordered comic, child reading-order, and section entries."`
 	}
 }

--- a/backend/internal/api/readingorders_detail.go
+++ b/backend/internal/api/readingorders_detail.go
@@ -103,7 +103,8 @@ func fetchReadingOrderDetail(ctx context.Context, db *sqlx.DB, ro ReadingOrder) 
 	}
 	comics := []ReadingOrderComic{}
 	childOrders := []ReadingOrder{}
-	for _, entry := range entries {
+	for i := range entries {
+		entry := &entries[i]
 		if entry.Type == "comic" && entry.Comic != nil {
 			comics = append(comics, *entry.Comic)
 			continue
@@ -129,6 +130,7 @@ func fetchReadingOrderDetail(ctx context.Context, db *sqlx.DB, ro ReadingOrder) 
 				childComics[i].Comment = source + " - " + childComics[i].Comment
 			}
 		}
+		entry.Comics = childComics
 		comics = append(comics, childComics...)
 	}
 
@@ -207,11 +209,23 @@ func fetchReadingOrderEntries(ctx context.Context, db *sqlx.DB, readingOrderID i
 	`, visibilityUserID, visibilityUserID, userID, readingOrderID, visibilityUserID, visibilityUserID); err != nil {
 		return nil, huma.Error500InternalServerError("failed to fetch child reading orders")
 	}
+	sections := []struct {
+		ReadingOrderSection
+		Position int `db:"position"`
+	}{}
+	if err := db.SelectContext(ctx, &sections, `
+		SELECT title, description, position
+		FROM reading_order_sections
+		WHERE reading_order_id = ?
+		ORDER BY position
+	`, readingOrderID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to fetch reading order sections")
+	}
 
 	positioned := make([]struct {
 		position int
 		entry    ReadingOrderEntry
-	}, 0, len(comics)+len(children))
+	}, 0, len(comics)+len(children)+len(sections))
 	for i := range comics {
 		comic := comics[i].ReadingOrderComic
 		positioned = append(positioned, struct {
@@ -236,6 +250,19 @@ func fetchReadingOrderEntries(ctx context.Context, db *sqlx.DB, readingOrderID i
 				Type:         "readingOrder",
 				ReadingOrder: &child,
 				Comment:      children[i].Comment,
+			},
+		})
+	}
+	for i := range sections {
+		section := sections[i].ReadingOrderSection
+		positioned = append(positioned, struct {
+			position int
+			entry    ReadingOrderEntry
+		}{
+			position: sections[i].Position,
+			entry: ReadingOrderEntry{
+				Type:    "section",
+				Section: &section,
 			},
 		})
 	}

--- a/backend/internal/api/readingorders_entries.go
+++ b/backend/internal/api/readingorders_entries.go
@@ -57,6 +57,11 @@ func setReadingOrderComicsWithAuth(ctx context.Context, db *sqlx.DB, input *SetR
 	`, input.ID); err != nil {
 		return nil, huma.Error500InternalServerError("failed to clear child reading orders")
 	}
+	if _, err := tx.ExecContext(ctx, `
+		DELETE FROM reading_order_sections WHERE reading_order_id = ?
+	`, input.ID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to clear sections")
+	}
 
 	for i, entry := range entries {
 		position := i + 1
@@ -74,6 +79,13 @@ func setReadingOrderComicsWithAuth(ctx context.Context, db *sqlx.DB, input *SetR
 				VALUES (?, ?, ?, ?)
 			`, input.ID, entry.ReadingOrderID, position, entry.Comment); err != nil {
 				return nil, huma.Error500InternalServerError("failed to insert child reading order")
+			}
+		case "section":
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO reading_order_sections (reading_order_id, position, title, description)
+				VALUES (?, ?, ?, ?)
+			`, input.ID, position, entry.Title, entry.Description); err != nil {
+				return nil, huma.Error500InternalServerError("failed to insert section")
 			}
 		}
 	}
@@ -146,6 +158,7 @@ func readingOrderEntryItems(input *SetReadingOrderComicsInput) []ReadingOrderEnt
 
 func normalizeReadingOrderEntry(entry ReadingOrderEntryPayload) ReadingOrderEntryPayload {
 	entry.Type = strings.TrimSpace(entry.Type)
+	entry.Title = strings.TrimSpace(entry.Title)
 	if entry.Type == "" {
 		if entry.ReadingOrderID > 0 {
 			entry.Type = "readingOrder"
@@ -167,8 +180,12 @@ func validateReadingOrderEntries(entries []ReadingOrderEntryPayload) error {
 			if entry.ReadingOrderID <= 0 {
 				return huma.Error400BadRequest("reading order entry requires readingOrderId")
 			}
+		case "section":
+			if entry.Title == "" {
+				return huma.Error400BadRequest("section entry requires title")
+			}
 		default:
-			return huma.Error400BadRequest("reading order entry type must be comic or readingOrder")
+			return huma.Error400BadRequest("reading order entry type must be comic, readingOrder, or section")
 		}
 	}
 	return nil

--- a/backend/internal/api/readingorders_mutations.go
+++ b/backend/internal/api/readingorders_mutations.go
@@ -197,6 +197,16 @@ func copyReadingOrder(ctx context.Context, db *sqlx.DB, id int) (*ReadingOrderDe
 			`, copiedID, entry.ReadingOrder.ID, position, entry.Comment); err != nil {
 				return nil, huma.Error500InternalServerError("failed to copy child reading order")
 			}
+		case "section":
+			if entry.Section == nil {
+				continue
+			}
+			if _, err := tx.ExecContext(ctx, `
+				INSERT INTO reading_order_sections (reading_order_id, position, title, description)
+				VALUES (?, ?, ?, ?)
+			`, copiedID, position, entry.Section.Title, entry.Section.Description); err != nil {
+				return nil, huma.Error500InternalServerError("failed to copy reading order section")
+			}
 		}
 	}
 

--- a/backend/internal/api/readingorders_routes.go
+++ b/backend/internal/api/readingorders_routes.go
@@ -149,7 +149,7 @@ func RegisterReadingOrderRoutes(api huma.API, db *sqlx.DB, covers *CoverCache) {
 		OperationID: "setReadingOrderComics",
 		Tags:        []string{tagReadingOrders},
 		Summary:     "Set reading order comics",
-		Description: "Replaces every comic entry in a reading order. Entry order is the submitted array order, duplicate comic IDs are allowed, and the comics form supports per-entry comments.",
+		Description: "Replaces every entry in a reading order. Entry order is the submitted array order and may contain comics, nested reading orders, and named sections.",
 		Method:      http.MethodPut,
 		Path:        "/readingOrders/{id}/comics",
 		Errors:      errsWrite,

--- a/backend/internal/api/readingorders_test.go
+++ b/backend/internal/api/readingorders_test.go
@@ -41,6 +41,20 @@ func TestReadingOrderHelpers(t *testing.T) {
 	if order := readingOrderListOrder("rating", "desc"); order != "ORDER BY rating DESC, ro.name DESC" {
 		t.Fatalf("rating order = %q", order)
 	}
+
+	section := normalizeReadingOrderEntry(ReadingOrderEntryPayload{
+		Type:  "section",
+		Title: "  Main story  ",
+	})
+	if section.Title != "Main story" {
+		t.Fatalf("normalized section title = %q; want Main story", section.Title)
+	}
+	if err := validateReadingOrderEntries([]ReadingOrderEntryPayload{section}); err != nil {
+		t.Fatalf("validate section: %v", err)
+	}
+	if err := validateReadingOrderEntries([]ReadingOrderEntryPayload{{Type: "section"}}); err == nil {
+		t.Fatal("validate untitled section = nil; want an error")
+	}
 }
 
 func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
@@ -128,6 +142,13 @@ func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
 			PRIMARY KEY (parent_reading_order_id, child_reading_order_id),
 			CHECK (parent_reading_order_id <> child_reading_order_id)
 		);
+		CREATE TABLE reading_order_sections (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
+			position INTEGER NOT NULL DEFAULT 0,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT ''
+		);
 		INSERT INTO comics (series, series_year, issue, publisher)
 		VALUES ('Parent', 2026, '1', 'Publisher'),
 			('Child', 2026, '2', 'Publisher'),
@@ -153,8 +174,10 @@ func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
 
 	parentInput := &SetReadingOrderComicsInput{ID: parent.Body.ID}
 	parentInput.Body.Entries = []ReadingOrderEntryPayload{
+		{Type: "section", Title: "Opening", Description: "Start with the setup."},
 		{Type: "comic", ComicID: 1},
 		{Type: "readingOrder", ReadingOrderID: child.Body.ID, Comment: "Crossover break"},
+		{Type: "section", Title: "Finale"},
 		{Type: "comic", ComicID: 3},
 	}
 	detail, err := setReadingOrderComics(ctx, db, parentInput)
@@ -162,11 +185,17 @@ func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
 		t.Fatalf("set parent entries: %v", err)
 	}
 
-	if len(detail.Body.Entries) != 3 || detail.Body.Entries[1].Type != "readingOrder" {
-		t.Fatalf("entries = %#v; want nested reading order in the middle", detail.Body.Entries)
+	if len(detail.Body.Entries) != 5 || detail.Body.Entries[0].Type != "section" || detail.Body.Entries[2].Type != "readingOrder" {
+		t.Fatalf("entries = %#v; want sections around ordered comic entries", detail.Body.Entries)
 	}
-	if detail.Body.Entries[1].Comment != "Crossover break" {
-		t.Fatalf("nested order note = %q; want Crossover break", detail.Body.Entries[1].Comment)
+	if detail.Body.Entries[0].Section == nil || detail.Body.Entries[0].Section.Title != "Opening" || detail.Body.Entries[0].Section.Description != "Start with the setup." {
+		t.Fatalf("opening section = %#v", detail.Body.Entries[0].Section)
+	}
+	if detail.Body.Entries[2].Comment != "Crossover break" {
+		t.Fatalf("nested order note = %q; want Crossover break", detail.Body.Entries[2].Comment)
+	}
+	if len(detail.Body.Entries[2].Comics) != 1 || detail.Body.Entries[2].Comics[0].Issue != "2" {
+		t.Fatalf("nested expanded comics = %#v; want issue 2", detail.Body.Entries[2].Comics)
 	}
 	if len(detail.Body.Comics) != 3 {
 		t.Fatalf("expanded comics = %d; want 3", len(detail.Body.Comics))
@@ -196,10 +225,12 @@ func TestCopyReadingOrderCreatesCurrentUserOwnedCopy(t *testing.T) {
 			(11, 'Nested list', 'Nested notes', '', 0, 2);
 		INSERT INTO reading_order_comics (reading_order_id, comic_id, position, note, tags)
 		VALUES
-			(10, 1, 1, 'Start here', 'Main'),
+			(10, 1, 2, 'Start here', 'Main'),
 			(11, 2, 1, 'Nested comic', 'Tie-in');
 		INSERT INTO reading_order_children (parent_reading_order_id, child_reading_order_id, position, note)
-		VALUES (10, 11, 2, 'Then this');
+		VALUES (10, 11, 3, 'Then this');
+		INSERT INTO reading_order_sections (reading_order_id, position, title, description)
+		VALUES (10, 1, 'First phase', 'Read the setup first');
 	`); err != nil {
 		t.Fatalf("seed copy source: %v", err)
 	}
@@ -227,20 +258,23 @@ func TestCopyReadingOrderCreatesCurrentUserOwnedCopy(t *testing.T) {
 	if !copied.Body.CanEdit {
 		t.Fatal("copied canEdit = false; want current user to edit their copy")
 	}
-	if len(copied.Body.Entries) != 2 {
-		t.Fatalf("copied entries = %d; want 2", len(copied.Body.Entries))
+	if len(copied.Body.Entries) != 3 {
+		t.Fatalf("copied entries = %d; want 3", len(copied.Body.Entries))
 	}
-	if copied.Body.Entries[0].Comic == nil || copied.Body.Entries[0].Comic.ID != 1 {
-		t.Fatalf("first copied entry = %#v; want comic 1", copied.Body.Entries[0])
+	if copied.Body.Entries[0].Section == nil || copied.Body.Entries[0].Section.Title != "First phase" || copied.Body.Entries[0].Section.Description != "Read the setup first" {
+		t.Fatalf("first copied entry = %#v; want section", copied.Body.Entries[0])
 	}
-	if copied.Body.Entries[0].Comic.Comment != "Start here" || copied.Body.Entries[0].Comic.Tags != "Main" {
-		t.Fatalf("first copied comic note/tags = %q/%q", copied.Body.Entries[0].Comic.Comment, copied.Body.Entries[0].Comic.Tags)
+	if copied.Body.Entries[1].Comic == nil || copied.Body.Entries[1].Comic.ID != 1 {
+		t.Fatalf("second copied entry = %#v; want comic 1", copied.Body.Entries[1])
 	}
-	if copied.Body.Entries[1].ReadingOrder == nil || copied.Body.Entries[1].ReadingOrder.ID != 11 {
-		t.Fatalf("second copied entry = %#v; want nested order 11", copied.Body.Entries[1])
+	if copied.Body.Entries[1].Comic.Comment != "Start here" || copied.Body.Entries[1].Comic.Tags != "Main" {
+		t.Fatalf("copied comic note/tags = %q/%q", copied.Body.Entries[1].Comic.Comment, copied.Body.Entries[1].Comic.Tags)
 	}
-	if copied.Body.Entries[1].Comment != "Then this" {
-		t.Fatalf("copied nested note = %q; want Then this", copied.Body.Entries[1].Comment)
+	if copied.Body.Entries[2].ReadingOrder == nil || copied.Body.Entries[2].ReadingOrder.ID != 11 {
+		t.Fatalf("third copied entry = %#v; want nested order 11", copied.Body.Entries[2])
+	}
+	if copied.Body.Entries[2].Comment != "Then this" {
+		t.Fatalf("copied nested note = %q; want Then this", copied.Body.Entries[2].Comment)
 	}
 }
 
@@ -643,6 +677,13 @@ func setupReadingOrderCBLTestDB(t *testing.T) *sqlx.DB {
 			note TEXT NOT NULL DEFAULT '',
 			PRIMARY KEY (parent_reading_order_id, child_reading_order_id),
 			CHECK (parent_reading_order_id <> child_reading_order_id)
+		);
+		CREATE TABLE reading_order_sections (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
+			position INTEGER NOT NULL DEFAULT 0,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT ''
 		);
 	`); err != nil {
 		t.Fatalf("create schema: %v", err)

--- a/backend/internal/api/statistics_dashboard_test.go
+++ b/backend/internal/api/statistics_dashboard_test.go
@@ -295,6 +295,13 @@ func TestDashboardNextComicAdvancesAfterRead(t *testing.T) {
 			position INTEGER NOT NULL DEFAULT 0,
 			note TEXT NOT NULL DEFAULT ''
 		);
+		CREATE TABLE reading_order_sections (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			reading_order_id INTEGER NOT NULL,
+			position INTEGER NOT NULL DEFAULT 0,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT ''
+		);
 		CREATE TABLE arcs (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			name TEXT NOT NULL,

--- a/backend/internal/api/users_helpers_test.go
+++ b/backend/internal/api/users_helpers_test.go
@@ -86,6 +86,13 @@ func setupMountedAuthTestDB(t *testing.T) *sqlx.DB {
 			note TEXT NOT NULL DEFAULT '',
 			PRIMARY KEY (parent_reading_order_id, child_reading_order_id, position)
 		);
+		CREATE TABLE reading_order_sections (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
+			position INTEGER NOT NULL DEFAULT 0,
+			title TEXT NOT NULL,
+			description TEXT NOT NULL DEFAULT ''
+		);
 		CREATE TABLE user_sessions (
 			token TEXT PRIMARY KEY,
 			user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,

--- a/backend/internal/db/db_test.go
+++ b/backend/internal/db/db_test.go
@@ -142,6 +142,24 @@ func TestOpenAppliesComicGeneratedTitleMigration(t *testing.T) {
 	if userRatingTableCount != 1 {
 		t.Fatalf("reading_order_ratings table count = %d; want 1", userRatingTableCount)
 	}
+
+	sectionsExist, err := tableExists(database, "reading_order_sections")
+	if err != nil {
+		t.Fatalf("check reading order sections table: %v", err)
+	}
+	if !sectionsExist {
+		t.Fatal("reading_order_sections table missing")
+	}
+	var sectionIndexCount int
+	if err := database.Get(&sectionIndexCount, `
+		SELECT COUNT(*) FROM sqlite_master
+		WHERE type = 'index' AND name = 'idx_reading_order_sections_order_position'
+	`); err != nil {
+		t.Fatalf("check reading order sections index: %v", err)
+	}
+	if sectionIndexCount != 1 {
+		t.Fatalf("reading order sections index count = %d; want 1", sectionIndexCount)
+	}
 }
 
 func TestEnsureUserLoginSchemaUpgradesMergedMigrationDrift(t *testing.T) {

--- a/backend/internal/db/migrations/015_reading_order_sections.sql
+++ b/backend/internal/db/migrations/015_reading_order_sections.sql
@@ -1,0 +1,14 @@
+-- +goose Up
+CREATE TABLE reading_order_sections (
+    id               INTEGER PRIMARY KEY AUTOINCREMENT,
+    reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
+    position         INTEGER NOT NULL DEFAULT 0,
+    title            TEXT    NOT NULL,
+    description      TEXT    NOT NULL DEFAULT ''
+);
+CREATE INDEX idx_reading_order_sections_order_position
+ON reading_order_sections(reading_order_id, position);
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_reading_order_sections_order_position;
+DROP TABLE IF EXISTS reading_order_sections;

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint src",
     "format": "prettier --check src",
     "format:fix": "prettier --write src",
-    "test": "node --test src/router/appRouteState.test.js",
+    "test": "node --test src/router/appRouteState.test.js src/features/reading-orders/model.test.js",
     "dev": "vite --host 127.0.0.1 --clearScreen false",
     "build": "vite build",
     "preview": "vite preview --host 127.0.0.1"

--- a/ui/src/features/comics/components/ComicListView.vue
+++ b/ui/src/features/comics/components/ComicListView.vue
@@ -65,6 +65,10 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
+  showSections: {
+    type: Boolean,
+    default: false,
+  },
   initialSort: {
     type: String,
     default: 'series',
@@ -117,6 +121,7 @@ const visibleLimit = ref(props.localPageSize)
 const loadMoreSentinel = ref(null)
 const autoLoadSupported = ref(false)
 const comicOptionsOpen = ref(false)
+const collapsedSections = ref(new Set())
 
 let loadMoreObserver = null
 
@@ -306,6 +311,30 @@ const canLoadMoreLocal = computed(
 const showManualLoadMore = computed(
   () => (canLoadMoreLocal.value || canLoadMoreServer.value) && !autoLoadSupported.value,
 )
+const sectionHeadingsVisible = computed(
+  () => props.showSections && sortModel.value === 'readingOrder',
+)
+
+function showSectionBefore(comic, index) {
+  if (!sectionHeadingsVisible.value || !comic.section?.title) return false
+  return index === 0 || visibleComics.value[index - 1]?.section?.key !== comic.section.key
+}
+
+function isSectionCollapsed(comic) {
+  return sectionHeadingsVisible.value && collapsedSections.value.has(comic.section?.key)
+}
+
+function toggleSection(section) {
+  if (!section?.key) return
+
+  const next = new Set(collapsedSections.value)
+  if (next.has(section.key)) {
+    next.delete(section.key)
+  } else {
+    next.add(section.key)
+  }
+  collapsedSections.value = next
+}
 
 function normalizeSort(sort) {
   if (sort === 'readingOrder' && !props.showReadingOrderSort) return 'series'
@@ -580,19 +609,40 @@ watch([visibleComics, canLoadMoreLocal, canLoadMoreServer], () => {
 
     <template v-if="visibleComics.length">
       <div class="issue-list">
-        <IssueListItem
-          v-for="(comic, index) in visibleComics"
-          :key="`${comic.id}-${index}`"
-          :comic="comic"
-          :selected="selectedComicId === comic.id"
-          :quick-saving="quickSavingComicId === comic.id"
-          :show-cover="showCover"
-          :show-comment="showComment"
-          :read-only="readOnly"
-          @open="$emit('open-comic', $event)"
-          @toggle-read="$emit('toggle-read', $event)"
-          @toggle-skipped="$emit('toggle-skipped', $event)"
-        />
+        <template v-for="(comic, index) in visibleComics" :key="`${comic.id}-${index}`">
+          <button
+            v-if="showSectionBefore(comic, index)"
+            class="reading-order-section-heading"
+            :class="{
+              'nested-reading-order-heading': comic.section.kind === 'readingOrder',
+            }"
+            type="button"
+            :aria-expanded="!isSectionCollapsed(comic)"
+            :aria-label="`${isSectionCollapsed(comic) ? 'Expand' : 'Collapse'} ${comic.section.label || 'section'} ${comic.section.title}`"
+            @click="toggleSection(comic.section)"
+          >
+            <span class="reading-order-section-heading-content">
+              <span class="eyebrow">{{ comic.section.label || 'Section' }}</span>
+              <strong>{{ comic.section.title }}</strong>
+              <span v-if="comic.section.description" class="section-description">
+                {{ comic.section.description }}
+              </span>
+            </span>
+            <span class="section-collapse-icon" aria-hidden="true">⌄</span>
+          </button>
+          <IssueListItem
+            v-if="!isSectionCollapsed(comic)"
+            :comic="comic"
+            :selected="selectedComicId === comic.id"
+            :quick-saving="quickSavingComicId === comic.id"
+            :show-cover="showCover"
+            :show-comment="showComment"
+            :read-only="readOnly"
+            @open="$emit('open-comic', $event)"
+            @toggle-read="$emit('toggle-read', $event)"
+            @toggle-skipped="$emit('toggle-skipped', $event)"
+          />
+        </template>
       </div>
 
       <div

--- a/ui/src/features/reading-orders/components/ReadingOrderDetailView.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrderDetailView.vue
@@ -4,7 +4,11 @@ import MarkdownIt from 'markdown-it'
 import DetailNavigation from '@/shared/components/detail/DetailNavigation.vue'
 import { assetURL } from '@/api/client.js'
 import ComicListView from '@/features/comics/components/ComicListView.vue'
-import { formatProgress, formatRating } from '@/features/reading-orders/model.js'
+import {
+  formatProgress,
+  formatRating,
+  readingOrderDisplayComics,
+} from '@/features/reading-orders/model.js'
 
 const props = defineProps({
   selectedOrder: {
@@ -66,6 +70,8 @@ const renderedDescription = computed(() => {
   const description = props.selectedOrder?.description?.trim()
   return description ? markdown.render(description) : '<p>No description</p>'
 })
+
+const displayComics = computed(() => readingOrderDisplayComics(props.selectedOrder))
 </script>
 
 <template>
@@ -216,11 +222,12 @@ const renderedDescription = computed(() => {
         <ComicListView
           class="preview-list"
           title="Comics"
-          :comics="selectedOrder.comics"
+          :comics="displayComics"
           :selected-comic-id="selectedComicId"
           :quick-saving-comic-id="quickSavingComicId"
           initial-sort="readingOrder"
           show-reading-order-sort
+          show-sections
           show-comment
           show-cover
           :read-only="readOnly"

--- a/ui/src/features/reading-orders/components/ReadingOrderEditor.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrderEditor.vue
@@ -27,6 +27,8 @@ const comicSearchResults = ref([])
 const comicSearchLoading = ref(false)
 const comicSearchError = ref('')
 const readingOrderSearch = ref('')
+const sectionTitle = ref('')
+const sectionDescription = ref('')
 const activeAddType = ref('comic')
 const expandedEntryKeys = ref(new Set())
 
@@ -168,6 +170,7 @@ function insertEntryAt(entry, index) {
 }
 
 function entryKey(entry, index) {
+  if (entry.type === 'section') return `section:${index}`
   const id = entry.type === 'readingOrder' ? entry.readingOrderId : entry.comicId
   return `${entry.type}:${id}:${index}`
 }
@@ -225,6 +228,19 @@ function newChildOrderEntry(order) {
     description: order.description || '',
     comment: '',
   }
+}
+
+function addSection() {
+  const title = sectionTitle.value.trim()
+  if (!title) return
+
+  addNewEntryToEnd({
+    type: 'section',
+    title,
+    description: sectionDescription.value.trim(),
+  })
+  sectionTitle.value = ''
+  sectionDescription.value = ''
 }
 
 function addNewEntryToEnd(entry) {
@@ -291,12 +307,14 @@ function removeEntry(index) {
 }
 
 function entryLabel(entry) {
+  if (entry.type === 'section') return entry.title || 'Untitled section'
   if (entry.type === 'readingOrder') return entry.title || 'Unknown reading order'
 
   return entry.title || comicLabel(props.comics, entry.comicId)
 }
 
 function entryTypeLabel(entry) {
+  if (entry.type === 'section') return 'Section'
   return entry.type === 'readingOrder' ? 'Reading order' : 'Issue'
 }
 
@@ -403,6 +421,13 @@ function endDrag() {
             >
               Reading Orders
             </button>
+            <button
+              type="button"
+              :class="{ active: activeAddType === 'section' }"
+              @click="activeAddType = 'section'"
+            >
+              Sections
+            </button>
           </div>
 
           <div v-if="activeAddType === 'comic'" class="comic-add-panel">
@@ -497,6 +522,33 @@ function endDrag() {
           <div v-else-if="activeAddType === 'readingOrder'" class="empty-state">
             No reading orders available to include.
           </div>
+
+          <div v-if="activeAddType === 'section'" class="section-add-panel">
+            <label>
+              Section title
+              <input
+                v-model="sectionTitle"
+                placeholder="Main story"
+                @keydown.enter.prevent="addSection"
+              />
+            </label>
+            <label>
+              Description
+              <textarea
+                v-model="sectionDescription"
+                rows="3"
+                placeholder="Optional context for this section"
+              />
+            </label>
+            <button
+              type="button"
+              class="primary-button"
+              :disabled="!sectionTitle.trim()"
+              @click="addSection"
+            >
+              Add Section
+            </button>
+          </div>
         </section>
       </div>
 
@@ -531,6 +583,7 @@ function endDrag() {
               :class="{
                 dragging: draggedIndex === index,
                 'nested-order-entry': entry.type === 'readingOrder',
+                'section-order-entry': entry.type === 'section',
                 expanded: isEntryExpanded(entry, index),
               }"
             >
@@ -592,30 +645,54 @@ function endDrag() {
               </button>
 
               <div v-if="isEntryExpanded(entry, index)" class="entry-edit-panel">
-                <label class="comment-input-label">
-                  Note
-                  <textarea
-                    :value="entry.comment"
-                    rows="3"
-                    aria-label="Entry comment"
-                    :placeholder="
-                      entry.type === 'readingOrder'
-                        ? 'Optional note for this reading order'
-                        : 'Optional note for this spot'
-                    "
-                    @input="updateEntry(index, { comment: $event.target.value })"
-                  />
-                </label>
+                <template v-if="entry.type === 'section'">
+                  <label class="comment-input-label">
+                    Section title
+                    <input
+                      :value="entry.title"
+                      required
+                      aria-label="Section title"
+                      @input="updateEntry(index, { title: $event.target.value })"
+                    />
+                  </label>
+                  <label class="comment-input-label">
+                    Description
+                    <textarea
+                      :value="entry.description"
+                      rows="3"
+                      aria-label="Section description"
+                      placeholder="Optional context for this section"
+                      @input="updateEntry(index, { description: $event.target.value })"
+                    />
+                  </label>
+                </template>
 
-                <label v-if="entry.type !== 'readingOrder'" class="comment-input-label">
-                  Tags
-                  <input
-                    :value="entry.tags"
-                    aria-label="Entry tags"
-                    placeholder="Tags"
-                    @input="updateEntry(index, { tags: $event.target.value })"
-                  />
-                </label>
+                <template v-else>
+                  <label class="comment-input-label">
+                    Note
+                    <textarea
+                      :value="entry.comment"
+                      rows="3"
+                      aria-label="Entry comment"
+                      :placeholder="
+                        entry.type === 'readingOrder'
+                          ? 'Optional note for this reading order'
+                          : 'Optional note for this spot'
+                      "
+                      @input="updateEntry(index, { comment: $event.target.value })"
+                    />
+                  </label>
+
+                  <label v-if="entry.type !== 'readingOrder'" class="comment-input-label">
+                    Tags
+                    <input
+                      :value="entry.tags"
+                      aria-label="Entry tags"
+                      placeholder="Tags"
+                      @input="updateEntry(index, { tags: $event.target.value })"
+                    />
+                  </label>
+                </template>
               </div>
             </div>
           </template>

--- a/ui/src/features/reading-orders/model.js
+++ b/ui/src/features/reading-orders/model.js
@@ -15,6 +15,14 @@ export function emptyReadingOrder() {
 
 export function readingOrderFormFromDetail(detail) {
   const entries = (detail.entries || []).map((entry) => {
+    if (entry.type === 'section' && entry.section) {
+      return {
+        type: 'section',
+        title: entry.section.title || '',
+        description: entry.section.description || '',
+      }
+    }
+
     if (entry.type === 'readingOrder' && entry.readingOrder) {
       return {
         type: 'readingOrder',
@@ -76,6 +84,14 @@ export function readingOrderComicsPayload(order) {
   return {
     entries: sourceEntries
       .map((entry) => {
+        if (entry.type === 'section') {
+          return {
+            type: 'section',
+            title: String(entry.title || '').trim(),
+            description: entry.description || '',
+          }
+        }
+
         if (entry.type === 'readingOrder') {
           return {
             type: 'readingOrder',
@@ -92,6 +108,7 @@ export function readingOrderComicsPayload(order) {
         }
       })
       .filter((entry) => {
+        if (entry.type === 'section') return Boolean(entry.title)
         return entry.type === 'readingOrder' ? entry.readingOrderId > 0 : entry.comicId > 0
       }),
     readingOrderIds: (sourceEntries.length
@@ -102,7 +119,7 @@ export function readingOrderComicsPayload(order) {
       .map((entry) => Number(entry.readingOrderId))
       .filter((id) => id > 0),
     comics: (sourceEntries.length
-      ? sourceEntries.filter((entry) => entry.type !== 'readingOrder')
+      ? sourceEntries.filter((entry) => entry.type === 'comic')
       : order.comics
     )
       .filter((comic) => Number(comic.comicId) > 0)
@@ -112,6 +129,63 @@ export function readingOrderComicsPayload(order) {
         tags: comic.tags,
       })),
   }
+}
+
+export function readingOrderDisplayComics(order) {
+  const flattened = order?.comics || []
+  const entries = order?.entries || []
+  if (!entries.length) return flattened
+
+  const currentState = new Map(
+    flattened.map((comic) => [comic.id, { read: comic.read, skipped: comic.skipped }]),
+  )
+  const display = []
+  let section = null
+  let sectionIndex = 0
+  let entryIndex = 0
+
+  const appendComics = (comics, group) => {
+    for (const comic of comics) {
+      const state = currentState.get(comic.id)
+      display.push({
+        ...comic,
+        read: state?.read ?? comic.read,
+        skipped: state?.skipped ?? comic.skipped,
+        section: group,
+      })
+    }
+  }
+
+  for (const entry of entries) {
+    entryIndex += 1
+
+    if (entry.type === 'section') {
+      sectionIndex += 1
+      section = {
+        key: `order-${order?.id || 'draft'}-section-${sectionIndex}`,
+        kind: 'section',
+        label: 'Section',
+        title: entry.section?.title || '',
+        description: entry.section?.description || '',
+      }
+      continue
+    }
+
+    if (entry.type === 'readingOrder') {
+      appendComics(entry.comics || [], {
+        key: `order-${order?.id || 'draft'}-nested-${entryIndex}`,
+        kind: 'readingOrder',
+        label: 'Reading order',
+        title: entry.readingOrder?.name || 'Nested reading order',
+        description: entry.comment || entry.readingOrder?.description || '',
+      })
+      continue
+    }
+
+    appendComics(entry.comic ? [entry.comic] : [], section)
+  }
+
+  return display.length === flattened.length ? display : flattened
 }
 
 export function formatProgress(progress) {

--- a/ui/src/features/reading-orders/model.test.js
+++ b/ui/src/features/reading-orders/model.test.js
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  readingOrderComicsPayload,
+  readingOrderDisplayComics,
+  readingOrderFormFromDetail,
+} from './model.js'
+
+test('maps section entries between API detail and editor payloads', () => {
+  const form = readingOrderFormFromDetail({
+    id: 7,
+    name: 'Event',
+    description: '',
+    favorite: false,
+    isPublic: true,
+    entries: [
+      { type: 'section', section: { title: ' Main story ', description: 'Begin here.' } },
+      { type: 'comic', comic: { id: 42, title: 'Issue 1', comment: '', tags: '' } },
+    ],
+    comics: [{ id: 42, title: 'Issue 1' }],
+  })
+
+  assert.deepEqual(form.entries[0], {
+    type: 'section',
+    title: ' Main story ',
+    description: 'Begin here.',
+  })
+  assert.deepEqual(readingOrderComicsPayload(form).entries[0], {
+    type: 'section',
+    title: 'Main story',
+    description: 'Begin here.',
+  })
+})
+
+test('drops untitled sections from the save payload', () => {
+  const payload = readingOrderComicsPayload({
+    entries: [
+      { type: 'section', title: '   ', description: 'Unused' },
+      { type: 'comic', comicId: 2, comment: '', tags: '' },
+    ],
+  })
+
+  assert.deepEqual(payload.entries, [{ type: 'comic', comicId: 2, comment: '', tags: '' }])
+})
+
+test('groups nested reading-order issues separately and then resumes the parent section', () => {
+  const display = readingOrderDisplayComics({
+    id: 7,
+    comics: [
+      { id: 1, read: true, skipped: false },
+      { id: 2, read: false, skipped: true },
+      { id: 3, read: false, skipped: false },
+    ],
+    entries: [
+      { type: 'section', section: { title: 'Setup', description: 'Before the event.' } },
+      { type: 'comic', comic: { id: 1, read: false, skipped: false } },
+      {
+        type: 'readingOrder',
+        readingOrder: { id: 9, name: 'Tie-ins', description: 'A child order.' },
+        comment: 'Read these stories next.',
+        comics: [{ id: 2, read: false, skipped: false }],
+      },
+      { type: 'comic', comic: { id: 3, read: false, skipped: false } },
+    ],
+  })
+
+  assert.equal(display.length, 3)
+  assert.equal(display[0].section.label, 'Section')
+  assert.equal(display[0].section.title, 'Setup')
+  assert.equal(display[1].section.label, 'Reading order')
+  assert.equal(display[1].section.title, 'Tie-ins')
+  assert.equal(display[1].section.description, 'Read these stories next.')
+  assert.equal(display[2].section.title, 'Setup')
+  assert.equal(display[0].read, true)
+  assert.equal(display[1].skipped, true)
+})

--- a/ui/src/styles/detail-forms.css
+++ b/ui/src/styles/detail-forms.css
@@ -139,8 +139,21 @@
 
 .add-entry-tabs {
   display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
+  grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 8px;
+}
+
+.section-add-panel {
+  display: grid;
+  gap: 10px;
+  border: 1px solid var(--line-strong);
+  border-radius: 8px;
+  background: var(--surface-soft);
+  padding: 12px;
+}
+
+.section-add-panel .primary-button {
+  justify-self: start;
 }
 
 .add-entry-tabs button {

--- a/ui/src/styles/list-views.css
+++ b/ui/src/styles/list-views.css
@@ -386,6 +386,7 @@
 }
 
 .section-collapse-icon {
+  margin-inline-end: 8px;
   font-size: 1.35rem;
   line-height: 1;
   transition: transform 160ms ease;

--- a/ui/src/styles/list-views.css
+++ b/ui/src/styles/list-views.css
@@ -340,6 +340,61 @@
   -webkit-box-orient: vertical;
 }
 
+.reading-order-section-heading {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  border-bottom: 2px solid color-mix(in srgb, var(--primary) 52%, var(--line));
+  border-top: 0;
+  border-right: 0;
+  border-left: 0;
+  border-radius: 0;
+  background: transparent;
+  color: inherit;
+  text-align: left;
+  padding: 18px 4px 10px;
+  cursor: pointer;
+}
+
+.reading-order-section-heading:first-child {
+  padding-top: 4px;
+}
+
+.reading-order-section-heading:hover {
+  background: color-mix(in srgb, var(--primary) 5%, transparent);
+}
+
+.reading-order-section-heading.nested-reading-order-heading {
+  border-bottom-color: color-mix(in srgb, var(--accent) 52%, var(--line));
+}
+
+.reading-order-section-heading-content {
+  display: grid;
+  gap: 4px;
+  min-width: 0;
+}
+
+.reading-order-section-heading-content strong {
+  font-size: 1.08rem;
+}
+
+.reading-order-section-heading .section-description {
+  color: var(--muted);
+  font-weight: 500;
+}
+
+.section-collapse-icon {
+  font-size: 1.35rem;
+  line-height: 1;
+  transition: transform 160ms ease;
+}
+
+.reading-order-section-heading[aria-expanded='false'] .section-collapse-icon {
+  transform: rotate(-90deg);
+}
+
 .comic-add-result strong {
   line-clamp: 2;
   -webkit-line-clamp: 2;

--- a/ui/src/styles/metron.css
+++ b/ui/src/styles/metron.css
@@ -3,6 +3,7 @@
 .metron-view {
   display: grid;
   gap: 20px;
+  padding-block-start: 16px;
 }
 
 .metron-modes {

--- a/ui/src/styles/reading-order-editor.css
+++ b/ui/src/styles/reading-order-editor.css
@@ -71,6 +71,11 @@
   background: color-mix(in srgb, var(--surface-soft) 82%, var(--accent));
 }
 
+.order-entry.section-order-entry .selected-order-comic {
+  border-color: color-mix(in srgb, var(--primary) 54%, var(--line));
+  background: color-mix(in srgb, var(--surface-soft) 78%, var(--primary));
+}
+
 .selected-order-comic {
   display: flex;
   flex-direction: column;
@@ -151,6 +156,10 @@
   grid-template-columns: 1fr;
 }
 
+.section-order-entry .entry-edit-panel {
+  grid-template-columns: minmax(180px, 0.6fr) minmax(0, 1fr);
+}
+
 .entry-type-pill {
   display: inline-grid;
   align-self: flex-start;
@@ -170,6 +179,12 @@
   border-color: color-mix(in srgb, var(--accent) 48%, var(--line));
   background: color-mix(in srgb, var(--surface-soft) 76%, var(--accent));
   color: var(--accent);
+}
+
+.section-order-entry .entry-type-pill {
+  border-color: color-mix(in srgb, var(--primary) 58%, var(--line));
+  background: var(--primary);
+  color: white;
 }
 
 .selected-order-comic strong,

--- a/ui/src/styles/responsive-mobile.css
+++ b/ui/src/styles/responsive-mobile.css
@@ -473,6 +473,10 @@
     grid-template-columns: 1fr;
   }
 
+  .section-order-entry .entry-edit-panel {
+    grid-template-columns: 1fr;
+  }
+
   .entry-edit-panel {
     grid-column: 1;
     grid-template-columns: 1fr;


### PR DESCRIPTION
## Summary

- add persistent named section entries that can be inserted, edited, removed, and reordered with reading-order issues
- render sections as collapsible groups in reading-order detail views
- render nested reading orders as collapsible section-like groups so their expanded issues remain attributable to the source order
- preserve sections when copying a reading order and validate section payloads in the API

## Testing

- [x] go test ./... from backend
- [x] go vet ./... from backend
- [x] go build ./... from backend
- [x] npm --prefix ui run lint
- [x] npm --prefix ui run test
- [x] npm --prefix ui run build

## Notes

Includes migration 015_reading_order_sections.sql. No environment files, databases, cached covers, or personal reading-order data are included.