### PR TITLE
style: remove duplicate page headings

### DIFF
--- a/ui/src/app/components/AppToolbar.vue
+++ b/ui/src/app/components/AppToolbar.vue
@@ -16,13 +16,16 @@ defineProps({
 const route = useRoute()
 const eyebrow = computed(() => route.meta.eyebrow || 'ComicHero')
 const title = computed(() => route.meta.title || 'ComicHero')
+const showEyebrow = computed(
+  () => eyebrow.value.trim().toLocaleLowerCase() !== title.value.trim().toLocaleLowerCase(),
+)
 const showSummary = computed(() => Boolean(route.meta.showCount))
 </script>
 
 <template>
   <header class="toolbar sticky-toolbar">
     <div>
-      <p class="eyebrow">{{ eyebrow }}</p>
+      <p v-if="showEyebrow" class="eyebrow">{{ eyebrow }}</p>
       <h2>{{ title }}</h2>
       <p v-if="showSummary" class="toolbar-summary">
         Showing {{ resultCount }} of {{ totalCount }}


### PR DESCRIPTION
## Summary

- hide the page eyebrow when it repeats the page title
- retain meaningful category labels when the eyebrow and title differ
- apply the behavior through the shared application toolbar

## Testing

- [ ] go test ./... from backend (frontend-only change)
- [x] npm --prefix ui run build
- [x] npm --prefix ui run lint
- [x] npm --prefix ui run test

## Notes

No environment files, databases, cached covers, or personal reading-order data are included.