### PR TITLE
feat: add ComicVine IDs to comics

### DIFF
--- a/backend/internal/api/characters.go
+++ b/backend/internal/api/characters.go
@@ -492,27 +492,11 @@ func importMetronCharacterAppearancesWithProgressOptions(ctx context.Context, db
 
 func importMetronCharacterAppearanceIssueWithOptions(ctx context.Context, db *sqlx.DB, client *metron.Client, covers *CoverCache, issue metron.Issue, options MetronImportOptions) (Comic, error) {
 	options = resolveMetronImportOptions(options)
-	if options.Mode != "full" && !options.Force && issue.ID > 0 {
-		if id, ok, err := existingComicIDByMetronIssueID(ctx, db, issue.ID); err != nil {
-			return Comic{}, err
-		} else if ok {
-			if err := linkComicToMetronIssueSeries(ctx, db, id, issue); err != nil {
-				return Comic{}, err
-			}
-			return getComicRow(ctx, db, id)
-		}
-	}
-
 	if options.Mode != "full" && !options.Force {
-		if id, ok, err := existingComicIDByMetronIssueMatch(ctx, db, issue); err != nil {
+		if id, ok, err := existingComicIDForMetronIssue(ctx, db, issue); err != nil {
 			return Comic{}, err
 		} else if ok {
-			if issue.ID > 0 {
-				if err := attachMetronIssueID(ctx, db, id, issue.ID); err != nil {
-					return Comic{}, err
-				}
-			}
-			if err := linkComicToMetronIssueSeries(ctx, db, id, issue); err != nil {
+			if err := linkComicToMetronIssueIdentity(ctx, db, id, issue); err != nil {
 				return Comic{}, err
 			}
 			return getComicRow(ctx, db, id)

--- a/backend/internal/api/metron_comic_scanner.go
+++ b/backend/internal/api/metron_comic_scanner.go
@@ -249,7 +249,7 @@ func (s *metronComicScanner) run(ctx context.Context, settings MetronComicScanSe
 		ID       int `db:"id"`
 		MetronID int `db:"metron_issue_id"`
 	}
-	query := `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (TRIM(publisher) = '' OR TRIM(cover_image) = '' OR TRIM(cover_date) = '' OR TRIM(description) = '')`
+	query := `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (comic_vine_id IS NULL OR TRIM(publisher) = '' OR TRIM(cover_image) = '' OR TRIM(cover_date) = '' OR TRIM(description) = '')`
 	args := []any{}
 	if settings.RecheckCooldownDays > 0 {
 		cutoff := time.Now().Add(-time.Duration(settings.RecheckCooldownDays) * 24 * time.Hour).UTC().Format(time.RFC3339)
@@ -343,7 +343,7 @@ func enrichIncompleteComicFromMetron(ctx context.Context, db *sqlx.DB, covers *C
 		}
 	}
 	syncedAt := time.Now().UTC().Format(time.RFC3339)
-	_, err := db.ExecContext(ctx, `UPDATE comics SET publisher = CASE WHEN TRIM(publisher) = '' THEN ? ELSE publisher END, cover_date = CASE WHEN TRIM(cover_date) = '' THEN ? ELSE cover_date END, cover_image = CASE WHEN TRIM(cover_image) = '' THEN ? ELSE cover_image END, description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END, metron_synced_at = ? WHERE id = ?`, issue.Publisher, issue.CoverDate, cover, issue.Description, syncedAt, comicID)
+	_, err := db.ExecContext(ctx, `UPDATE comics SET comic_vine_id = COALESCE(comic_vine_id, ?), publisher = CASE WHEN TRIM(publisher) = '' THEN ? ELSE publisher END, cover_date = CASE WHEN TRIM(cover_date) = '' THEN ? ELSE cover_date END, cover_image = CASE WHEN TRIM(cover_image) = '' THEN ? ELSE cover_image END, description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END, metron_synced_at = ? WHERE id = ?`, nullablePositiveID(issue.ComicVineID), issue.Publisher, issue.CoverDate, cover, issue.Description, syncedAt, comicID)
 	if err != nil {
 		return err
 	}

--- a/backend/internal/api/metron_comic_scanner_test.go
+++ b/backend/internal/api/metron_comic_scanner_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Lofter1/ComicHero/backend/internal/metron"
 	"github.com/jmoiron/sqlx"
 	_ "modernc.org/sqlite"
 )
@@ -91,6 +92,7 @@ func TestMetronComicScanCooldownExcludesRecentlySyncedComics(t *testing.T) {
 		description TEXT NOT NULL DEFAULT '',
 		read INTEGER NOT NULL DEFAULT 0,
 		metron_issue_id INTEGER,
+		comic_vine_id INTEGER,
 		metron_synced_at TEXT NOT NULL DEFAULT ''
 	)`); err != nil {
 		t.Fatal(err)
@@ -102,18 +104,23 @@ func TestMetronComicScanCooldownExcludesRecentlySyncedComics(t *testing.T) {
 
 	// Row A: publisher filled, description permanently blank (Metron has none),
 	// synced an hour ago -> still "incomplete" but should be skipped by the cooldown.
-	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, metron_synced_at)
-		VALUES ('A', 'Marvel', '1964-01-01', '/covers/a.jpg', '', 1, ?)`, recentlySynced); err != nil {
+	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, comic_vine_id, metron_synced_at)
+		VALUES ('A', 'Marvel', '1964-01-01', '/covers/a.jpg', '', 1, 101, ?)`, recentlySynced); err != nil {
 		t.Fatal(err)
 	}
 	// Row B: never synced -> should always be selected.
-	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, metron_synced_at)
-		VALUES ('B', '', '', '', '', 2, '')`); err != nil {
+	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, comic_vine_id, metron_synced_at)
+		VALUES ('B', '', '', '', '', 2, NULL, '')`); err != nil {
 		t.Fatal(err)
 	}
 	// Row C: synced 40 days ago, past the 30-day cooldown -> should be selected again.
-	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, metron_synced_at)
-		VALUES ('C', 'DC', '1980-01-01', '/covers/c.jpg', '', 3, ?)`, longAgoSynced); err != nil {
+	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, comic_vine_id, metron_synced_at)
+		VALUES ('C', 'DC', '1980-01-01', '/covers/c.jpg', '', 3, 103, ?)`, longAgoSynced); err != nil {
+		t.Fatal(err)
+	}
+	// Row D: all legacy metadata is complete, but the Comic Vine ID is missing.
+	if _, err := db.Exec(`INSERT INTO comics (series, publisher, cover_date, cover_image, description, metron_issue_id, comic_vine_id, metron_synced_at)
+		VALUES ('D', 'Image', '2020-01-01', '/covers/d.jpg', 'Complete', 4, NULL, '')`); err != nil {
 		t.Fatal(err)
 	}
 
@@ -122,7 +129,7 @@ func TestMetronComicScanCooldownExcludesRecentlySyncedComics(t *testing.T) {
 		ID       int `db:"id"`
 		MetronID int `db:"metron_issue_id"`
 	}
-	query := `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (TRIM(publisher) = '' OR TRIM(cover_image) = '' OR TRIM(cover_date) = '' OR TRIM(description) = '') AND (metron_synced_at = '' OR metron_synced_at <= ?) ORDER BY id`
+	query := `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (comic_vine_id IS NULL OR TRIM(publisher) = '' OR TRIM(cover_image) = '' OR TRIM(cover_date) = '' OR TRIM(description) = '') AND (metron_synced_at = '' OR metron_synced_at <= ?) ORDER BY id`
 	if err := db.Select(&rows, query, cutoff); err != nil {
 		t.Fatal(err)
 	}
@@ -139,6 +146,37 @@ func TestMetronComicScanCooldownExcludesRecentlySyncedComics(t *testing.T) {
 	}
 	if !got[3] {
 		t.Fatal("comic synced past the cooldown window should be selected again")
+	}
+	if !got[4] {
+		t.Fatal("comic missing only a Comic Vine ID should be selected")
+	}
+}
+
+func TestEnrichIncompleteComicStoresComicVineID(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	ctx := testUserContext()
+	if _, err := db.Exec(`
+		INSERT INTO comics (series, series_year, issue, publisher, metron_issue_id)
+		VALUES ('Series', 2026, '1', 'Publisher', 77)
+	`); err != nil {
+		t.Fatalf("seed comic: %v", err)
+	}
+	if err := enrichIncompleteComicFromMetron(ctx, db, nil, 1, metron.Issue{
+		ID:          77,
+		ComicVineID: 9988,
+		Series:      "Series",
+		SeriesYear:  2026,
+		Issue:       "1",
+		Publisher:   "Publisher",
+	}); err != nil {
+		t.Fatalf("enrich comic: %v", err)
+	}
+	var comicVineID int
+	if err := db.Get(&comicVineID, `SELECT comic_vine_id FROM comics WHERE id = 1`); err != nil {
+		t.Fatalf("read Comic Vine ID: %v", err)
+	}
+	if comicVineID != 9988 {
+		t.Fatalf("Comic Vine ID = %d; want 9988", comicVineID)
 	}
 }
 

--- a/backend/internal/api/metron_comics.go
+++ b/backend/internal/api/metron_comics.go
@@ -121,51 +121,45 @@ func importMetronComic(ctx context.Context, db *sqlx.DB, client *metron.Client, 
 
 func importMetronComicWithOptions(ctx context.Context, db *sqlx.DB, client *metron.Client, covers *CoverCache, issue metron.Issue, options MetronImportOptions) (*ComicDetailOutput, error) {
 	options = resolveMetronImportOptions(options)
-	if issue.ID > 0 {
-		if id, ok, err := existingComicIDByMetronIssueID(ctx, db, issue.ID); err != nil {
-			return nil, err
-		} else if ok {
-			if options.Force {
-				return updateComicFromMetron(ctx, db, client, covers, id, issue)
-			}
-			if err := syncMetronIssueArcsWithOptions(ctx, db, client, id, issue, options); err != nil {
-				return nil, err
-			}
-			if options.includesCharacters() {
-				if err := syncMetronIssueCharactersWithOptions(ctx, db, client, covers, id, issue, options); err != nil {
-					return nil, err
-				}
-			}
-			return getComic(ctx, db, id)
-		}
-	}
-
-	if id, ok, err := existingComicIDByMetronIssueMatch(ctx, db, issue); err != nil {
+	if id, ok, err := existingComicIDForMetronIssue(ctx, db, issue); err != nil {
 		return nil, err
 	} else if ok {
-		if issue.ID > 0 {
-			if err := attachMetronIssueID(ctx, db, id, issue.ID); err != nil {
-				return nil, err
-			}
-		}
-		if err := linkComicToMetronIssueSeries(ctx, db, id, issue); err != nil {
-			return nil, err
-		}
-		if options.Force {
-			return updateComicFromMetron(ctx, db, client, covers, id, issue)
-		}
-		if err := syncMetronIssueArcsWithOptions(ctx, db, client, id, issue, options); err != nil {
-			return nil, err
-		}
-		if options.includesCharacters() {
-			if err := syncMetronIssueCharactersWithOptions(ctx, db, client, covers, id, issue, options); err != nil {
-				return nil, err
-			}
-		}
-		return getComic(ctx, db, id)
+		return reuseComicForMetronIssue(ctx, db, client, covers, id, issue, options)
 	}
 
 	return createMetronComicWithOptions(ctx, db, client, covers, issue, options)
+}
+
+func reuseComicForMetronIssue(ctx context.Context, db *sqlx.DB, client *metron.Client, covers *CoverCache, comicID int, issue metron.Issue, options MetronImportOptions) (*ComicDetailOutput, error) {
+	if err := linkComicToMetronIssueIdentity(ctx, db, comicID, issue); err != nil {
+		return nil, err
+	}
+	if options.Force {
+		return updateComicFromMetron(ctx, db, client, covers, comicID, issue)
+	}
+	if err := syncMetronIssueArcsWithOptions(ctx, db, client, comicID, issue, options); err != nil {
+		return nil, err
+	}
+	if options.includesCharacters() {
+		if err := syncMetronIssueCharactersWithOptions(ctx, db, client, covers, comicID, issue, options); err != nil {
+			return nil, err
+		}
+	}
+	return getComic(ctx, db, comicID)
+}
+
+func linkComicToMetronIssueIdentity(ctx context.Context, db *sqlx.DB, comicID int, issue metron.Issue) error {
+	if issue.ID > 0 {
+		if err := attachMetronIssueID(ctx, db, comicID, issue.ID); err != nil {
+			return err
+		}
+	}
+	if issue.ComicVineID > 0 {
+		if err := attachComicVineID(ctx, db, comicID, issue.ComicVineID); err != nil {
+			return err
+		}
+	}
+	return linkComicToMetronIssueSeries(ctx, db, comicID, issue)
 }
 
 func importMetronComicSweep(ctx context.Context, db *sqlx.DB, client *metron.Client, covers *CoverCache, issue metron.Issue, options MetronImportOptions, fetchIssueDetail bool) (*ComicDetailOutput, error) {
@@ -268,6 +262,33 @@ func existingComicIDByMetronIssueID(ctx context.Context, db *sqlx.DB, metronID i
 	return id, true, nil
 }
 
+func existingComicIDForMetronIssue(ctx context.Context, db *sqlx.DB, issue metron.Issue) (int, bool, error) {
+	if issue.ID > 0 {
+		if id, ok, err := existingComicIDByMetronIssueID(ctx, db, issue.ID); err != nil || ok {
+			return id, ok, err
+		}
+	}
+	if issue.ComicVineID > 0 {
+		if id, ok, err := existingComicIDByComicVineID(ctx, db, issue.ComicVineID); err != nil || ok {
+			return id, ok, err
+		}
+	}
+	return existingComicIDByMetronIssueMatch(ctx, db, issue)
+}
+
+func existingComicIDByComicVineID(ctx context.Context, db *sqlx.DB, comicVineID int) (int, bool, error) {
+	var id int
+	if err := db.GetContext(ctx, &id, `
+		SELECT id FROM comics WHERE comic_vine_id = ?
+	`, comicVineID); err != nil {
+		if err != sql.ErrNoRows {
+			return 0, false, huma.Error500InternalServerError("failed to check Comic Vine comic")
+		}
+		return 0, false, nil
+	}
+	return id, true, nil
+}
+
 func existingComicIDByMetronIssueMatch(ctx context.Context, db *sqlx.DB, issue metron.Issue) (int, bool, error) {
 	var id int
 	if err := db.GetContext(ctx, &id, `
@@ -299,7 +320,7 @@ func comicHasRequestedMetronData(ctx context.Context, db *sqlx.DB, comicID int, 
 		}
 		return false, huma.Error500InternalServerError("failed to check imported comic")
 	}
-	if options.includesComics() && (comic.Description == "" || comic.CoverImage == "") {
+	if options.includesComics() && (comic.Description == "" || comic.CoverImage == "" || comic.ComicVineID == nil) {
 		return false, nil
 	}
 	if options.includesSeries() {
@@ -344,6 +365,15 @@ func attachMetronIssueID(ctx context.Context, db *sqlx.DB, comicID, metronID int
 	return nil
 }
 
+func attachComicVineID(ctx context.Context, db *sqlx.DB, comicID, comicVineID int) error {
+	if _, err := db.ExecContext(ctx, `
+		UPDATE comics SET comic_vine_id = ? WHERE id = ? AND comic_vine_id IS NULL
+	`, comicVineID, comicID); err != nil {
+		return huma.Error500InternalServerError("failed to link comic to Comic Vine")
+	}
+	return nil
+}
+
 func linkComicToMetronIssueSeries(ctx context.Context, db *sqlx.DB, comicID int, issue metron.Issue) error {
 	seriesID, err := ensureMetronIssueSeriesRow(ctx, db, issue)
 	if err != nil {
@@ -375,8 +405,8 @@ func createMetronComicWithOptions(ctx context.Context, db *sqlx.DB, client *metr
 	}
 
 	result, err := db.ExecContext(ctx, `
-		INSERT INTO comics (series_id, series, series_year, issue, publisher, cover_date, cover_image, description, metron_issue_id)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+		INSERT INTO comics (series_id, series, series_year, issue, publisher, cover_date, cover_image, description, metron_issue_id, comic_vine_id)
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`, nullableSeriesID(seriesID),
 		payload.Series,
 		payload.SeriesYear,
@@ -386,6 +416,7 @@ func createMetronComicWithOptions(ctx context.Context, db *sqlx.DB, client *metr
 		payload.CoverImage,
 		payload.Description,
 		nullableMetronID(issue.ID),
+		nullablePositiveID(issue.ComicVineID),
 	)
 	if err != nil {
 		return nil, huma.Error500InternalServerError("failed to import Metron comic")
@@ -426,7 +457,7 @@ func updateComicFromMetron(ctx context.Context, db *sqlx.DB, client *metron.Clie
 
 	result, err := db.ExecContext(ctx, `
 		UPDATE comics
-		SET series_id = ?, series = ?, series_year = ?, issue = ?, publisher = ?, cover_date = ?, cover_image = ?, description = ?, metron_issue_id = ?
+		SET series_id = ?, series = ?, series_year = ?, issue = ?, publisher = ?, cover_date = ?, cover_image = ?, description = ?, metron_issue_id = COALESCE(?, metron_issue_id), comic_vine_id = COALESCE(?, comic_vine_id)
 		WHERE id = ?
 	`, nullableSeriesID(seriesID),
 		payload.Series,
@@ -437,6 +468,7 @@ func updateComicFromMetron(ctx context.Context, db *sqlx.DB, client *metron.Clie
 		payload.CoverImage,
 		payload.Description,
 		nullableMetronID(issue.ID),
+		nullablePositiveID(issue.ComicVineID),
 		comicID,
 	)
 	if err != nil {

--- a/backend/internal/api/metron_import_comics_test.go
+++ b/backend/internal/api/metron_import_comics_test.go
@@ -15,11 +15,12 @@ func TestImportMetronComicReusesExistingMetronComic(t *testing.T) {
 	ctx := testUserContext()
 	db := newMetronImportTestDB(t)
 	issue := metron.Issue{
-		ID:         101,
-		Series:     "Series",
-		SeriesYear: 2026,
-		Issue:      "1",
-		Publisher:  "Publisher",
+		ID:          101,
+		ComicVineID: 9001,
+		Series:      "Series",
+		SeriesYear:  2026,
+		Issue:       "1",
+		Publisher:   "Publisher",
 	}
 
 	first, err := importMetronComic(ctx, db, nil, nil, issue)
@@ -36,6 +37,45 @@ func TestImportMetronComicReusesExistingMetronComic(t *testing.T) {
 
 	var count int
 	if err := db.GetContext(ctx, &count, `SELECT COUNT(*) FROM comics`); err != nil {
+		t.Fatalf("count comics: %v", err)
+	}
+	if count != 1 {
+		t.Fatalf("comic count = %d; want 1", count)
+	}
+	if first.Body.ComicVineID == nil || *first.Body.ComicVineID != 9001 {
+		t.Fatalf("Comic Vine ID = %#v; want 9001", first.Body.ComicVineID)
+	}
+}
+
+func TestImportMetronComicReusesComicVineMatchAndAttachesMetronID(t *testing.T) {
+	ctx := testUserContext()
+	db := newMetronImportTestDB(t)
+	if _, err := db.Exec(`
+		INSERT INTO comics (series, series_year, issue, publisher, comic_vine_id)
+		VALUES ('Older local title', 1999, '7', '', 81234)
+	`); err != nil {
+		t.Fatalf("seed Comic Vine comic: %v", err)
+	}
+
+	comic, err := importMetronComic(ctx, db, nil, nil, metron.Issue{
+		ID:          404,
+		ComicVineID: 81234,
+		Series:      "Canonical title",
+		SeriesYear:  2026,
+		Issue:       "1",
+		Publisher:   "Publisher",
+	})
+	if err != nil {
+		t.Fatalf("import: %v", err)
+	}
+	if comic.Body.ID != 1 {
+		t.Fatalf("comic ID = %d; want existing comic 1", comic.Body.ID)
+	}
+	if comic.Body.MetronIssueID == nil || *comic.Body.MetronIssueID != 404 {
+		t.Fatalf("Metron issue ID = %#v; want 404", comic.Body.MetronIssueID)
+	}
+	var count int
+	if err := db.Get(&count, `SELECT COUNT(*) FROM comics`); err != nil {
 		t.Fatalf("count comics: %v", err)
 	}
 	if count != 1 {

--- a/backend/internal/api/metron_import_helpers_test.go
+++ b/backend/internal/api/metron_import_helpers_test.go
@@ -62,11 +62,16 @@ func newMetronImportTestDB(t *testing.T) *sqlx.DB {
 			cover_image TEXT NOT NULL DEFAULT '',
 			description TEXT NOT NULL DEFAULT '',
 			read INTEGER NOT NULL DEFAULT 0,
-			metron_issue_id INTEGER
+			metron_issue_id INTEGER,
+			comic_vine_id INTEGER,
+			metron_synced_at TEXT NOT NULL DEFAULT ''
 		);
 		CREATE UNIQUE INDEX idx_comics_metron_issue_id
 		ON comics(metron_issue_id)
 		WHERE metron_issue_id IS NOT NULL;
+		CREATE UNIQUE INDEX idx_comics_comic_vine_id
+		ON comics(comic_vine_id)
+		WHERE comic_vine_id IS NOT NULL;
 
 		CREATE TABLE users (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/backend/internal/api/metron_quota.go
+++ b/backend/internal/api/metron_quota.go
@@ -70,6 +70,10 @@ func withMetronRateLimit[T interface {
 }
 
 func nullableMetronID(id int) any {
+	return nullablePositiveID(id)
+}
+
+func nullablePositiveID(id int) any {
 	if id <= 0 {
 		return nil
 	}

--- a/backend/internal/api/metron_series.go
+++ b/backend/internal/api/metron_series.go
@@ -69,33 +69,11 @@ func importMetronSeriesWithProgressOptions(ctx context.Context, db *sqlx.DB, cli
 			return nil, err
 		}
 
-		if options.Mode != "full" && !options.Force && issue.ID > 0 {
-			if id, ok, err := existingComicIDByMetronIssueID(ctx, db, issue.ID); err != nil {
-				return nil, err
-			} else if ok {
-				if err := linkComicToMetronIssueSeries(ctx, db, id, issue); err != nil {
-					return nil, err
-				}
-				comic, err := getComicRow(ctx, db, id)
-				if err != nil {
-					return nil, err
-				}
-				comics = append(comics, comic)
-				progress(i+1, total, "Importing series issues...")
-				continue
-			}
-		}
-
 		if options.Mode != "full" && !options.Force {
-			if id, ok, err := existingComicIDByMetronIssueMatch(ctx, db, issue); err != nil {
+			if id, ok, err := existingComicIDForMetronIssue(ctx, db, issue); err != nil {
 				return nil, err
 			} else if ok {
-				if issue.ID > 0 {
-					if err := attachMetronIssueID(ctx, db, id, issue.ID); err != nil {
-						return nil, err
-					}
-				}
-				if err := linkComicToMetronIssueSeries(ctx, db, id, issue); err != nil {
+				if err := linkComicToMetronIssueIdentity(ctx, db, id, issue); err != nil {
 					return nil, err
 				}
 				comic, err := getComicRow(ctx, db, id)

--- a/backend/internal/api/models_comics.go
+++ b/backend/internal/api/models_comics.go
@@ -1,9 +1,10 @@
 package api
 
 type Comic struct {
-	ID            int  `json:"id"                      db:"id"              doc:"Local comic identifier." example:"42"`
-	MetronIssueID *int `json:"metronIssueId,omitempty" db:"metron_issue_id" doc:"Linked Metron issue identifier, when this comic was imported or matched." example:"123456"`
-	SeriesID      *int `json:"seriesId,omitempty"      db:"series_id"       doc:"Local series identifier for this comic's series, when available." example:"5"`
+	ID            int  `json:"id"                       db:"id"               doc:"Local comic identifier." example:"42"`
+	MetronIssueID *int `json:"metronIssueId,omitempty"  db:"metron_issue_id"  doc:"Linked Metron issue identifier, when this comic was imported or matched." example:"123456"`
+	ComicVineID   *int `json:"comicVineId,omitempty"    db:"comic_vine_id"    doc:"Linked Comic Vine issue identifier, when known." example:"987654"`
+	SeriesID      *int `json:"seriesId,omitempty"       db:"series_id"        doc:"Local series identifier for this comic's series, when available." example:"5"`
 
 	Title          string `json:"title"       db:"-"           doc:"Generated display title built from series, seriesYear, and issue." example:"Batman (2011) #6"`
 	Series         string `json:"series"      db:"series"      doc:"Series name." example:"Batman"`

--- a/backend/internal/api/models_reading_orders.go
+++ b/backend/internal/api/models_reading_orders.go
@@ -109,14 +109,14 @@ type ReadingOrderCBLUnmatchedBook struct {
 	Number   string `json:"number"   doc:"CBL book number attribute." example:"6"`
 	Volume   string `json:"volume"   doc:"CBL book volume attribute." example:"2011"`
 	Year     string `json:"year"     doc:"CBL book year attribute." example:"2012"`
-	Reason   string `json:"reason"   doc:"Reason this CBL book could not be matched to a local comic." example:"no local comic matched"`
+	Reason   string `json:"reason"   doc:"Reason this malformed or ambiguous CBL book could not be matched or created." example:"multiple local comics matched"`
 }
 
 type ReadingOrderCBLImportResult struct {
 	ReadingOrder   ReadingOrderDetail             `json:"readingOrder"   doc:"Created reading order with matched local comics."`
-	MatchedCount   int                            `json:"matchedCount"   doc:"Number of CBL books matched to local comics." example:"12"`
-	UnmatchedCount int                            `json:"unmatchedCount" doc:"Number of CBL books that could not be matched." example:"2"`
-	Unmatched      []ReadingOrderCBLUnmatchedBook `json:"unmatched"      doc:"CBL books that were left out because no local comic matched."`
+	MatchedCount   int                            `json:"matchedCount"   doc:"Number of CBL books matched to or created as local comics." example:"12"`
+	UnmatchedCount int                            `json:"unmatchedCount" doc:"Number of malformed or ambiguous CBL books that could not be imported." example:"2"`
+	Unmatched      []ReadingOrderCBLUnmatchedBook `json:"unmatched"      doc:"Malformed or ambiguous CBL books that could not be matched or created."`
 }
 
 type ReadingOrderCBLImportOutput struct {

--- a/backend/internal/api/readingorders_cbl.go
+++ b/backend/internal/api/readingorders_cbl.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"database/sql"
 	"encoding/xml"
 	"fmt"
 	"path/filepath"
@@ -12,6 +13,8 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/jmoiron/sqlx"
 )
+
+const cblNoLocalComicMatch = "no local comic matched"
 
 type cblReadingList struct {
 	XMLName   xml.Name  `xml:"ReadingList"`
@@ -57,6 +60,12 @@ func importReadingOrderCBL(ctx context.Context, db *sqlx.DB, input *ReadingOrder
 		comic, reason, err := matchCBLBook(ctx, db, book)
 		if err != nil {
 			return nil, err
+		}
+		if comic == nil && reason == cblNoLocalComicMatch {
+			comic, err = createComicFromCBLBook(ctx, db, book)
+			if err != nil {
+				return nil, err
+			}
 		}
 		if comic == nil {
 			unmatched = append(unmatched, cblUnmatchedBook(i+1, book, reason))
@@ -106,8 +115,11 @@ func exportReadingOrderCBL(ctx context.Context, db *sqlx.DB, id int) (*ReadingOr
 		if year := comicCBLYear(comic); year != "" {
 			book.Year = year
 		}
+		if comic.ComicVineID != nil && *comic.ComicVineID > 0 {
+			book.Databases = append(book.Databases, cblDatabase{Name: "comicvine", Issue: strconv.Itoa(*comic.ComicVineID)})
+		}
 		if comic.MetronIssueID != nil && *comic.MetronIssueID > 0 {
-			book.Databases = []cblDatabase{{Name: "metron", Issue: strconv.Itoa(*comic.MetronIssueID)}}
+			book.Databases = append(book.Databases, cblDatabase{Name: "metron", Issue: strconv.Itoa(*comic.MetronIssueID)})
 		}
 		books = append(books, book)
 	}
@@ -131,6 +143,17 @@ func exportReadingOrderCBL(ctx context.Context, db *sqlx.DB, id int) (*ReadingOr
 }
 
 func matchCBLBook(ctx context.Context, db *sqlx.DB, book cblBook) (*Comic, string, error) {
+	comicVineID, hasComicVineID := cblComicVineID(book)
+	if hasComicVineID {
+		comic, found, err := fetchCBLComicByComicVineID(ctx, db, comicVineID)
+		if err != nil {
+			return nil, "", err
+		}
+		if found {
+			return comic, "", nil
+		}
+	}
+
 	series := strings.TrimSpace(book.Series)
 	number := strings.TrimSpace(book.Number)
 	if series == "" || number == "" {
@@ -140,16 +163,19 @@ func matchCBLBook(ctx context.Context, db *sqlx.DB, book cblBook) (*Comic, strin
 	volume, hasVolume := parseCBLPositiveInt(book.Volume)
 	year, hasYear := parseCBLPositiveInt(book.Year)
 
+	var comic *Comic
+	var reason string
+	var err error
 	switch {
 	case hasVolume:
-		return fetchCBLComicMatch(ctx, db, `
+		comic, reason, err = fetchCBLComicMatch(ctx, db, `
 			SELECT * FROM comics
 			WHERE LOWER(series) = LOWER(?) AND LOWER(issue) = LOWER(?) AND series_year = ?
 			ORDER BY id
 			LIMIT 2
 		`, series, number, volume)
 	case hasYear:
-		return fetchCBLComicMatch(ctx, db, `
+		comic, reason, err = fetchCBLComicMatch(ctx, db, `
 			SELECT * FROM comics
 			WHERE LOWER(series) = LOWER(?) AND LOWER(issue) = LOWER(?)
 				AND (series_year = ? OR substr(cover_date, 1, 4) = ?)
@@ -157,13 +183,33 @@ func matchCBLBook(ctx context.Context, db *sqlx.DB, book cblBook) (*Comic, strin
 			LIMIT 2
 		`, series, number, year, strconv.Itoa(year))
 	default:
-		return fetchCBLComicMatch(ctx, db, `
+		comic, reason, err = fetchCBLComicMatch(ctx, db, `
 			SELECT * FROM comics
 			WHERE LOWER(series) = LOWER(?) AND LOWER(issue) = LOWER(?)
 			ORDER BY id
 			LIMIT 2
 		`, series, number)
 	}
+	if err != nil || comic == nil || !hasComicVineID {
+		return comic, reason, err
+	}
+	if err := attachComicVineID(ctx, db, comic.ID, comicVineID); err != nil {
+		return nil, "", err
+	}
+	comic.ComicVineID = &comicVineID
+	return comic, "", nil
+}
+
+func fetchCBLComicByComicVineID(ctx context.Context, db *sqlx.DB, comicVineID int) (*Comic, bool, error) {
+	var comic Comic
+	if err := db.GetContext(ctx, &comic, `SELECT * FROM comics WHERE comic_vine_id = ?`, comicVineID); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, false, nil
+		}
+		return nil, false, huma.Error500InternalServerError("failed to match CBL Comic Vine ID")
+	}
+	hydrateComicTitle(&comic)
+	return &comic, true, nil
 }
 
 func fetchCBLComicMatch(ctx context.Context, db *sqlx.DB, query string, args ...any) (*Comic, string, error) {
@@ -172,7 +218,7 @@ func fetchCBLComicMatch(ctx context.Context, db *sqlx.DB, query string, args ...
 		return nil, "", huma.Error500InternalServerError("failed to match CBL book")
 	}
 	if len(matches) == 0 {
-		return nil, "no local comic matched", nil
+		return nil, cblNoLocalComicMatch, nil
 	}
 	if len(matches) > 1 {
 		return nil, "multiple local comics matched", nil
@@ -181,9 +227,76 @@ func fetchCBLComicMatch(ctx context.Context, db *sqlx.DB, query string, args ...
 	return &matches[0], "", nil
 }
 
+func createComicFromCBLBook(ctx context.Context, db *sqlx.DB, book cblBook) (*Comic, error) {
+	series := strings.TrimSpace(book.Series)
+	number := strings.TrimSpace(book.Number)
+	if series == "" || number == "" {
+		return nil, nil
+	}
+
+	seriesYear, _ := parseCBLPositiveInt(book.Volume)
+	if seriesYear == 0 {
+		seriesYear, _ = parseCBLPositiveInt(book.Year)
+	}
+	seriesID, err := ensureSeriesRow(ctx, db, series, seriesYear)
+	if err != nil {
+		return nil, err
+	}
+	comicVineID, _ := cblComicVineID(book)
+	result, err := db.ExecContext(ctx, `
+		INSERT INTO comics (series_id, series, series_year, issue, publisher, cover_date, cover_image, description, comic_vine_id)
+		VALUES (?, ?, ?, ?, '', '', '', '', ?)
+	`, nullableSeriesID(seriesID), series, seriesYear, number, nullablePositiveID(comicVineID))
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to create comic from CBL")
+	}
+	id, err := result.LastInsertId()
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to get CBL comic id")
+	}
+	comic := Comic{
+		ID:          int(id),
+		SeriesID:    intPointerOrNil(seriesID),
+		Series:      series,
+		SeriesYear:  seriesYear,
+		Issue:       number,
+		ComicVineID: intPointerOrNil(comicVineID),
+	}
+	hydrateComicTitle(&comic)
+	return &comic, nil
+}
+
+func cblComicVineID(book cblBook) (int, bool) {
+	for _, database := range book.Databases {
+		name := strings.Map(func(r rune) rune {
+			if unicode.IsLetter(r) || unicode.IsDigit(r) {
+				return unicode.ToLower(r)
+			}
+			return -1
+		}, database.Name)
+		if name != "cv" && name != "cvdb" && name != "comicvine" && name != "comicvinedb" && name != "comicvinedatabase" {
+			continue
+		}
+		parts := strings.FieldsFunc(database.Issue, func(r rune) bool { return !unicode.IsDigit(r) })
+		for i := len(parts) - 1; i >= 0; i-- {
+			if id, ok := parseCBLPositiveInt(parts[i]); ok {
+				return id, true
+			}
+		}
+	}
+	return 0, false
+}
+
+func intPointerOrNil(value int) *int {
+	if value <= 0 {
+		return nil
+	}
+	return &value
+}
+
 func cblUnmatchedBook(position int, book cblBook, reason string) ReadingOrderCBLUnmatchedBook {
 	if reason == "" {
-		reason = "no local comic matched"
+		reason = cblNoLocalComicMatch
 	}
 	return ReadingOrderCBLUnmatchedBook{
 		Position: position,

--- a/backend/internal/api/readingorders_routes.go
+++ b/backend/internal/api/readingorders_routes.go
@@ -25,7 +25,7 @@ func RegisterReadingOrderRoutes(api huma.API, db *sqlx.DB, covers *CoverCache) {
 		OperationID:   "importReadingOrderCBL",
 		Tags:          []string{tagReadingOrders},
 		Summary:       "Import a CBL reading order",
-		Description:   "Creates a reading order from CBL XML by matching CBL book entries to local comics by series, issue number, and volume or year.",
+		Description:   "Creates a reading order from CBL XML. Books are matched by Comic Vine issue ID first, then by series, issue number, and volume or year; valid books without a local match are created.",
 		Method:        http.MethodPost,
 		Path:          "/readingOrders/cbl/import",
 		DefaultStatus: 201,

--- a/backend/internal/api/readingorders_test.go
+++ b/backend/internal/api/readingorders_test.go
@@ -470,14 +470,14 @@ func TestReadingOrderCoverUploadResizesAndDeletesUnusedOldCover(t *testing.T) {
 	assertCoverMaxDimension(t, coverPath(t, covers, updated.Body.Image), 450)
 }
 
-func TestReadingOrderCBLImportMatchesLocalComicsAndReportsUnmatched(t *testing.T) {
+func TestReadingOrderCBLImportPrefersComicVineThenFallsBackAndCreatesMissingComics(t *testing.T) {
 	ctx := testUserContext()
 	db := setupReadingOrderCBLTestDB(t)
 
 	if _, err := db.Exec(`
-		INSERT INTO comics (series, series_year, issue, publisher, cover_date)
-		VALUES ('Frank Miller''s RoboCop', 2003, '1', 'Avatar Press', '2003-07-01'),
-			('Frank Miller''s RoboCop', 2003, '2', 'Avatar Press', '2003-08-01');
+		INSERT INTO comics (series, series_year, issue, publisher, cover_date, comic_vine_id)
+		VALUES ('Frank Miller''s RoboCop', 2003, '1', 'Avatar Press', '2003-07-01', 111),
+			('Frank Miller''s RoboCop', 2003, '2', 'Avatar Press', '2003-08-01', NULL);
 	`); err != nil {
 		t.Fatalf("seed comics: %v", err)
 	}
@@ -487,11 +487,13 @@ func TestReadingOrderCBLImportMatchesLocalComicsAndReportsUnmatched(t *testing.T
 	input.Body.Content = `<?xml version="1.0" encoding="utf-8"?>
 <ReadingList>
 	<Name>RoboCop Publication Order</Name>
-	<NumIssues>3</NumIssues>
+	<NumIssues>5</NumIssues>
 	<Books>
-		<Book Series="Frank Miller&apos;s RoboCop" Number="1" Volume="2003" Year="2003" />
-		<Book Series="Frank Miller&apos;s RoboCop" Number="2" Volume="2003" Year="2003" />
-		<Book Series="Missing Series" Number="1" Volume="2003" Year="2003" />
+		<Book Series="Wrong metadata" Number="99" Volume="1999"><Database Name="cv" Issue="4000-111" /></Book>
+		<Book Series="Frank Miller&apos;s RoboCop" Number="2" Volume="2003" Year="2003"><Database Name="Comic Vine" Issue="222" /></Book>
+		<Book Series="Missing Series" Number="1" Volume="2003" Year="2003"><Database Name="comicvine" Issue="333" /></Book>
+		<Book Series="No CV Series" Number="5" Volume="2024" Year="2024" />
+		<Book Number="4" Volume="2003" Year="2003" />
 	</Books>
 	<Matchers />
 </ReadingList>`
@@ -504,17 +506,24 @@ func TestReadingOrderCBLImportMatchesLocalComicsAndReportsUnmatched(t *testing.T
 	if result.Body.ReadingOrder.Name != "RoboCop Publication Order" {
 		t.Fatalf("name = %q; want CBL name", result.Body.ReadingOrder.Name)
 	}
-	if result.Body.MatchedCount != 2 || result.Body.UnmatchedCount != 1 {
-		t.Fatalf("matched/unmatched = %d/%d; want 2/1", result.Body.MatchedCount, result.Body.UnmatchedCount)
+	if result.Body.MatchedCount != 4 || result.Body.UnmatchedCount != 1 {
+		t.Fatalf("matched/unmatched = %d/%d; want 4/1", result.Body.MatchedCount, result.Body.UnmatchedCount)
 	}
-	if len(result.Body.ReadingOrder.Comics) != 2 {
-		t.Fatalf("imported comics = %d; want 2", len(result.Body.ReadingOrder.Comics))
+	if len(result.Body.ReadingOrder.Comics) != 4 {
+		t.Fatalf("imported comics = %d; want 4", len(result.Body.ReadingOrder.Comics))
 	}
-	if result.Body.ReadingOrder.Comics[0].Issue != "1" || result.Body.ReadingOrder.Comics[1].Issue != "2" {
-		t.Fatalf("imported issue order = %#v; want 1 then 2", result.Body.ReadingOrder.Comics)
+	if result.Body.ReadingOrder.Comics[0].ID != 1 || result.Body.ReadingOrder.Comics[1].ID != 2 || result.Body.ReadingOrder.Comics[2].ID != 3 || result.Body.ReadingOrder.Comics[3].ID != 4 {
+		t.Fatalf("imported comic IDs = %#v; want existing 1, existing 2, then new 3 and 4", result.Body.ReadingOrder.Comics)
 	}
-	if len(result.Body.Unmatched) != 1 || result.Body.Unmatched[0].Series != "Missing Series" {
-		t.Fatalf("unmatched = %#v; want Missing Series", result.Body.Unmatched)
+	if len(result.Body.Unmatched) != 1 || result.Body.Unmatched[0].Reason != "missing series or issue number" {
+		t.Fatalf("unmatched = %#v; want malformed book", result.Body.Unmatched)
+	}
+	var comicVineIDs []int
+	if err := db.Select(&comicVineIDs, `SELECT COALESCE(comic_vine_id, 0) FROM comics ORDER BY id`); err != nil {
+		t.Fatalf("read Comic Vine IDs: %v", err)
+	}
+	if len(comicVineIDs) != 4 || comicVineIDs[0] != 111 || comicVineIDs[1] != 222 || comicVineIDs[2] != 333 || comicVineIDs[3] != 0 {
+		t.Fatalf("Comic Vine IDs = %#v; want 111, 222, 333, 0", comicVineIDs)
 	}
 }
 
@@ -552,11 +561,12 @@ func TestReadingOrderCBLExportBuildsFlatCBLXML(t *testing.T) {
 	db := setupReadingOrderCBLTestDB(t)
 
 	metronID := 98765
+	comicVineID := 54321
 	if _, err := db.Exec(`
-		INSERT INTO comics (series, series_year, issue, publisher, cover_date, metron_issue_id)
-		VALUES ('Batman & Robin', 2011, '1', 'DC Comics', '2011-09-01', ?),
-			('Batman & Robin', 2011, '2', 'DC Comics', '2011-10-01', NULL);
-	`, metronID); err != nil {
+		INSERT INTO comics (series, series_year, issue, publisher, cover_date, metron_issue_id, comic_vine_id)
+		VALUES ('Batman & Robin', 2011, '1', 'DC Comics', '2011-09-01', ?, ?),
+			('Batman & Robin', 2011, '2', 'DC Comics', '2011-10-01', NULL, NULL);
+	`, metronID, comicVineID); err != nil {
 		t.Fatalf("seed comics: %v", err)
 	}
 
@@ -583,6 +593,7 @@ func TestReadingOrderCBLExportBuildsFlatCBLXML(t *testing.T) {
 		`<Name>Batman &amp; Robin</Name>`,
 		`<NumIssues>2</NumIssues>`,
 		`Series="Batman &amp; Robin" Number="1" Volume="2011" Year="2011"`,
+		`<Database Name="comicvine" Issue="54321"></Database>`,
 		`<Database Name="metron" Issue="98765"></Database>`,
 	} {
 		if !strings.Contains(result.Body.Content, fragment) {
@@ -632,6 +643,12 @@ func setupReadingOrderCBLTestDB(t *testing.T) *sqlx.DB {
 			updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
 			PRIMARY KEY (reading_order_id, user_id)
 		);
+		CREATE TABLE series (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			series_year INTEGER NOT NULL DEFAULT 0
+		);
+		CREATE UNIQUE INDEX idx_series_name_year ON series(name, series_year);
 		CREATE TABLE comics (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			series_id INTEGER REFERENCES series(id) ON DELETE SET NULL,
@@ -643,8 +660,12 @@ func setupReadingOrderCBLTestDB(t *testing.T) *sqlx.DB {
 			cover_image TEXT NOT NULL DEFAULT '',
 			description TEXT NOT NULL DEFAULT '',
 			read INTEGER NOT NULL DEFAULT 0,
-			metron_issue_id INTEGER
+			metron_issue_id INTEGER,
+			comic_vine_id INTEGER
 		);
+		CREATE UNIQUE INDEX idx_comics_comic_vine_id
+		ON comics(comic_vine_id)
+		WHERE comic_vine_id IS NOT NULL;
 			CREATE TABLE users (
 				id INTEGER PRIMARY KEY AUTOINCREMENT,
 					name TEXT NOT NULL UNIQUE,

--- a/backend/internal/db/db_test.go
+++ b/backend/internal/db/db_test.go
@@ -46,6 +46,9 @@ func TestOpenAppliesComicGeneratedTitleMigration(t *testing.T) {
 	if !columns["series_id"] {
 		t.Fatal("comics table missing series_id column")
 	}
+	if !columns["comic_vine_id"] {
+		t.Fatal("comics table missing comic_vine_id column")
+	}
 	var busyTimeout int
 	if err := database.QueryRow(`PRAGMA busy_timeout`).Scan(&busyTimeout); err != nil {
 		t.Fatalf("busy timeout: %v", err)
@@ -88,6 +91,7 @@ func TestOpenAppliesComicGeneratedTitleMigration(t *testing.T) {
 		"idx_comics_series_id_issue",
 		"idx_comics_series_year_publisher",
 		"idx_comics_series_year_cover",
+		"idx_comics_comic_vine_id",
 	} {
 		if !indexes[name] {
 			t.Fatalf("comics table missing index %s", name)

--- a/backend/internal/db/migrations/016_comic_vine_ids.sql
+++ b/backend/internal/db/migrations/016_comic_vine_ids.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+ALTER TABLE comics ADD COLUMN comic_vine_id INTEGER;
+CREATE UNIQUE INDEX idx_comics_comic_vine_id
+ON comics(comic_vine_id)
+WHERE comic_vine_id IS NOT NULL;
+
+-- +goose Down
+DROP INDEX IF EXISTS idx_comics_comic_vine_id;
+ALTER TABLE comics DROP COLUMN comic_vine_id;

--- a/backend/internal/metron/client_test.go
+++ b/backend/internal/metron/client_test.go
@@ -127,7 +127,7 @@ func TestListReadingListsFetchesEveryUnfilteredPage(t *testing.T) {
 func TestClientPreservesMetronIssueNumberSuffix(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Write([]byte(`{"id":18030,"series":{"name":"The Amazing Spider-Man","year_began":2018},"number":"50.LR","cover_date":"2020-12-01"}`))
+		w.Write([]byte(`{"id":18030,"cv_id":987654,"series":{"name":"The Amazing Spider-Man","year_began":2018},"number":"50.LR","cover_date":"2020-12-01"}`))
 	}))
 	defer server.Close()
 
@@ -138,6 +138,9 @@ func TestClientPreservesMetronIssueNumberSuffix(t *testing.T) {
 	}
 	if issue.Issue != "50.LR" || issue.Number != "50.LR" {
 		t.Fatalf("issue number = %q/%q, want 50.LR/50.LR", issue.Issue, issue.Number)
+	}
+	if issue.ComicVineID != 987654 {
+		t.Fatalf("Comic Vine ID = %d, want 987654", issue.ComicVineID)
 	}
 }
 

--- a/backend/internal/metron/mapping.go
+++ b/backend/internal/metron/mapping.go
@@ -17,6 +17,7 @@ func issueFromMap(raw map[string]any) Issue {
 
 	return Issue{
 		ID:           intValue(raw, "id"),
+		ComicVineID:  intValue(raw, "cv_id", "comic_vine_id", "comicVineId"),
 		Title:        firstString(raw, "title", "name"),
 		StoryNames:   stringList(raw, "name", "story_names", "storyNames"),
 		SeriesID:     firstInt(intValue(raw, "series_id"), intValue(series, "id")),

--- a/backend/internal/metron/types.go
+++ b/backend/internal/metron/types.go
@@ -7,6 +7,7 @@ import (
 
 type Issue struct {
 	ID           int               `json:"id"          doc:"Metron issue identifier." example:"123456"`
+	ComicVineID  int               `json:"comicVineId" doc:"Comic Vine issue identifier returned by Metron, when known." example:"987654"`
 	Title        string            `json:"title"       doc:"Issue title." example:"The Court of Owls"`
 	StoryNames   []string          `json:"storyNames"  doc:"Story titles returned by Metron."`
 	SeriesID     int               `json:"seriesId"    doc:"Metron series identifier for this issue." example:"405"`

--- a/ui/src/features/comics/components/ComicDetailView.vue
+++ b/ui/src/features/comics/components/ComicDetailView.vue
@@ -160,6 +160,10 @@ function seriesLabel(comic) {
             <strong>{{ selectedComic.coverDate || 'Unknown' }}</strong>
             <small>Cover Date</small>
           </span>
+          <span v-if="selectedComic.comicVineId">
+            <strong>{{ selectedComic.comicVineId }}</strong>
+            <small>Comic Vine ID</small>
+          </span>
         </div>
 
         <div


### PR DESCRIPTION
## Summary

- persist unique ComicVine issue IDs supplied by Metron and expose them on comic details
- treat missing ComicVine IDs as incomplete comic data and enrich them through the automated Metron job
- make CBL imports prefer ComicVine IDs, fall back to existing metadata matching, learn missing IDs, and create valid books that are not in the library
- include ComicVine IDs when exporting reading orders as CBL

## Testing

- [x] `go test ./...` from `backend`
- [x] `go vet ./...` from `backend`
- [x] `go build ./...` from `backend`
- [x] `npm run format` from `ui`
- [x] `npm run lint` from `ui`
- [x] `npm run test` from `ui`
- [x] `npm run build` from `ui`

## Notes

Adds migration `016_comic_vine_ids.sql` with a nullable, uniquely indexed `comic_vine_id` column.