### PR TITLE
style: simplify dashboard heading

### DIFF
--- a/ui/src/features/dashboard/components/DashboardView.vue
+++ b/ui/src/features/dashboard/components/DashboardView.vue
@@ -46,7 +46,6 @@ function achievementProgress(achievement) {
   <section class="dashboard-view">
     <header class="dashboard-header">
       <div>
-        <p class="eyebrow">Dashboard</p>
         <h2>Continue reading</h2>
       </div>
       <button class="secondary-button" type="button" :disabled="loading" @click="$emit('refresh')">

--- a/ui/src/styles/dashboard.css
+++ b/ui/src/styles/dashboard.css
@@ -3,6 +3,7 @@
 .dashboard-view {
   display: grid;
   gap: 18px;
+  padding-top: 18px;
 }
 
 .dashboard-header,


### PR DESCRIPTION
## Summary

- remove the remaining repeated Dashboard label above Continue reading
- add breathing room between the shared page toolbar and dashboard content
- rely on the shared toolbar as the single page-level Dashboard heading

## Testing

- [x] `npm run lint` from `ui`
- [x] `npm run test` from `ui`
- [x] `npm run build` from `ui`

## Notes

The shared duplicate-eyebrow behavior was already fixed by PR #49 and is not repeated here.