### PR TITLE
refactor: unify loading states

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -14,6 +14,7 @@ import ComicDetailView from '@/features/comics/components/ComicDetailView.vue'
 import ComicListView from '@/features/comics/components/ComicListView.vue'
 import DashboardView from '@/features/dashboard/components/DashboardView.vue'
 import ErrorToast from '@/shared/components/feedback/ErrorToast.vue'
+import LoadingState from '@/shared/components/feedback/LoadingState.vue'
 import MetronImport from '@/features/metron/components/MetronImport.vue'
 import MetronImportMonitor from '@/features/metron/components/MetronImportMonitor.vue'
 import ProgressView from '@/features/account/components/ProgressView.vue'
@@ -186,6 +187,7 @@ const {
 } = useSeries({
   activeView,
   viewMode,
+  loading,
   error,
   loadPagedList,
   metronImportJobs,
@@ -209,6 +211,7 @@ const {
 } = useCharacters({
   activeView,
   viewMode,
+  loading,
   error,
   loadPagedList,
   metronImportJobs,
@@ -232,6 +235,7 @@ const {
 } = useArcs({
   activeView,
   viewMode,
+  loading,
   error,
   saving,
   loadComics: (...args) => loadComics(...args),
@@ -265,6 +269,7 @@ const {
 } = useReadingOrders({
   activeView,
   viewMode,
+  loading,
   error,
   saving,
   loadComics: (...args) => loadComics(...args),
@@ -295,6 +300,7 @@ const {
 } = useComics({
   activeView,
   viewMode,
+  loading,
   error,
   saving,
   loadPagedList,
@@ -336,20 +342,7 @@ const toolbarTotalCount = computed(() => {
   if (activeView.value === 'account' || activeView.value === 'progress') return 1
   return 0
 })
-const loadingLabel = computed(() => {
-  if (activeView.value === 'dashboard') return 'Loading dashboard...'
-  if (activeView.value === 'readingOrders') return 'Loading orders...'
-  if (activeView.value === 'arcs') return 'Loading arcs...'
-  if (activeView.value === 'comics') return 'Loading comics...'
-  if (activeView.value === 'series') return 'Loading series...'
-  if (activeView.value === 'characters') return 'Loading characters...'
-  if (activeView.value === 'metron') return 'Loading Metron...'
-  if (activeView.value === 'users') return 'Loading users...'
-  if (activeView.value === 'account') return 'Loading account...'
-  if (activeView.value === 'progress') return 'Loading progress...'
-  return 'Loading...'
-})
-const showBlockingLoading = computed(() => loading.value && activeView.value !== 'series')
+const showBlockingLoading = computed(() => loading.value)
 const seriesListLoading = computed(() => Boolean(pageState.value.series?.refreshing))
 const metronPermissions = computed(() => userStatus.value?.metronPermissions || {})
 const canMetronSearch = computed(() => hasMetronScope('search'))
@@ -803,10 +796,7 @@ onUnmounted(() => {
         @dismiss="dismissMetronJob"
       />
 
-      <div v-if="showBlockingLoading" class="loading-panel" role="status" aria-live="polite">
-        <span class="loading-spinner" aria-hidden="true"></span>
-        <strong>{{ loadingLabel }}</strong>
-      </div>
+      <LoadingState v-if="showBlockingLoading" />
 
       <MetronImport
         v-else-if="activeView === 'metron'"

--- a/ui/src/features/account/components/ProgressView.vue
+++ b/ui/src/features/account/components/ProgressView.vue
@@ -1,4 +1,6 @@
 <script setup>
+import LoadingState from '@/shared/components/feedback/LoadingState.vue'
+
 defineProps({
   statisticsView: {
     type: Object,
@@ -43,7 +45,7 @@ function achievementTimestampLabel(achievement) {
 
 <template>
   <section class="browse-view progress-view">
-    <div v-if="loading && !statisticsView" class="empty-state">Loading progress...</div>
+    <LoadingState v-if="loading && !statisticsView" />
     <div v-else-if="error" class="empty-state">
       {{ error }}
     </div>

--- a/ui/src/features/arcs/useArcs.js
+++ b/ui/src/features/arcs/useArcs.js
@@ -10,7 +10,15 @@ import {
 } from '@/api/client.js'
 import { arcComicsPayload, arcFormFromDetail, arcPayload, emptyArc } from '@/features/arcs/model.js'
 
-export function useArcs({ activeView, viewMode, error, saving, loadComics, loadPagedList }) {
+export function useArcs({
+  activeView,
+  viewMode,
+  loading,
+  error,
+  saving,
+  loadComics,
+  loadPagedList,
+}) {
   const arcs = ref([])
   const selectedArc = ref(null)
   const quickSavingArcID = ref(null)
@@ -27,13 +35,18 @@ export function useArcs({ activeView, viewMode, error, saving, loadComics, loadP
 
   async function openArc(arc) {
     if (!arc?.id) return
-    error.value = ''
-    activeView.value = 'arcs'
-    selectedArc.value = null
-    viewMode.value = 'detail'
-    const detail = await getArc(arc.id)
-    selectedArc.value = detail
-    arcForm.value = arcFormFromDetail(detail)
+    loading.value = true
+    try {
+      error.value = ''
+      activeView.value = 'arcs'
+      selectedArc.value = null
+      viewMode.value = 'detail'
+      const detail = await getArc(arc.id)
+      selectedArc.value = detail
+      arcForm.value = arcFormFromDetail(detail)
+    } finally {
+      loading.value = false
+    }
   }
 
   async function toggleArcFavorite(arc) {

--- a/ui/src/features/auth/components/AuthenticationView.vue
+++ b/ui/src/features/auth/components/AuthenticationView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import ErrorToast from '@/shared/components/feedback/ErrorToast.vue'
+import LoadingState from '@/shared/components/feedback/LoadingState.vue'
 
 defineProps({
   loading: Boolean,
@@ -44,11 +45,7 @@ defineEmits([
 
 <template>
   <main v-if="loading" class="auth-shell">
-    <section class="auth-panel" role="status" aria-live="polite">
-      <span class="loading-spinner" aria-hidden="true"></span>
-      <h1>ComicHero</h1>
-      <p>Loading user setup...</p>
-    </section>
+    <LoadingState />
   </main>
 
   <main v-else-if="setupRequired" class="auth-shell">

--- a/ui/src/features/characters/useCharacters.js
+++ b/ui/src/features/characters/useCharacters.js
@@ -12,6 +12,7 @@ import { formatProgress } from '@/features/reading-orders/model.js'
 export function useCharacters({
   activeView,
   viewMode,
+  loading,
   error,
   loadPagedList,
   metronImportJobs,
@@ -25,12 +26,17 @@ export function useCharacters({
 
   const visibleCharacters = computed(() => characters.value)
   async function openCharacter(character) {
-    error.value = ''
-    activeView.value = 'characters'
-    selectedCharacter.value = null
-    viewMode.value = 'detail'
-    const detail = await getCharacter(character.id)
-    selectedCharacter.value = detail
+    loading.value = true
+    try {
+      error.value = ''
+      activeView.value = 'characters'
+      selectedCharacter.value = null
+      viewMode.value = 'detail'
+      const detail = await getCharacter(character.id)
+      selectedCharacter.value = detail
+    } finally {
+      loading.value = false
+    }
   }
 
   async function toggleCharacterFavorite(character) {

--- a/ui/src/features/comics/useComics.js
+++ b/ui/src/features/comics/useComics.js
@@ -14,6 +14,7 @@ import { comicPayload, emptyComic } from '@/features/comics/model.js'
 export function useComics({
   activeView,
   viewMode,
+  loading,
   error,
   saving,
   loadPagedList,
@@ -40,14 +41,19 @@ export function useComics({
   }
 
   async function openComic(comic) {
-    error.value = ''
-    activeView.value = 'comics'
-    selectedComic.value = null
-    viewMode.value = 'detail'
-    resetMetronMetadata()
-    const detail = await getComic(comic.id)
-    selectedComic.value = detail
-    comicForm.value = { ...detail }
+    loading.value = true
+    try {
+      error.value = ''
+      activeView.value = 'comics'
+      selectedComic.value = null
+      viewMode.value = 'detail'
+      resetMetronMetadata()
+      const detail = await getComic(comic.id)
+      selectedComic.value = detail
+      comicForm.value = { ...detail }
+    } finally {
+      loading.value = false
+    }
   }
 
   async function openOrderComic(comic) {

--- a/ui/src/features/dashboard/components/DashboardView.vue
+++ b/ui/src/features/dashboard/components/DashboardView.vue
@@ -2,6 +2,7 @@
 import { computed } from 'vue'
 import { assetURL } from '@/api/client.js'
 import { formatProgress } from '@/features/reading-orders/model.js'
+import LoadingState from '@/shared/components/feedback/LoadingState.vue'
 
 const props = defineProps({
   dashboard: {
@@ -77,10 +78,7 @@ function achievementProgress(achievement) {
       </article>
     </div>
 
-    <div v-if="loading && !dashboard" class="empty-panel">
-      <span class="loading-spinner" aria-hidden="true"></span>
-      <p>Loading dashboard...</p>
-    </div>
+    <LoadingState v-if="loading && !dashboard" />
 
     <div v-else-if="items.length" class="dashboard-grid">
       <article v-for="item in items" :key="`${item.type}:${item.id}`" class="dashboard-card">

--- a/ui/src/features/metron/components/MetronReadingListDialog.vue
+++ b/ui/src/features/metron/components/MetronReadingListDialog.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { assetURL } from '@/api/client.js'
+import LoadingState from '@/shared/components/feedback/LoadingState.vue'
 
 defineProps({
   readingList: {
@@ -63,7 +64,7 @@ function formatDate(value) {
           :alt="readingList.name || 'Reading list image'"
         />
         <div class="metron-detail-copy">
-          <p v-if="loading" class="muted">Loading reading-list details...</p>
+          <LoadingState v-if="loading" compact />
           <p v-else-if="error" class="error-text">{{ error }}</p>
           <p v-else>{{ readingList?.description || 'No description from Metron.' }}</p>
           <dl class="metron-detail-facts">

--- a/ui/src/features/reading-orders/useReadingOrders.js
+++ b/ui/src/features/reading-orders/useReadingOrders.js
@@ -23,6 +23,7 @@ import {
 export function useReadingOrders({
   activeView,
   viewMode,
+  loading,
   error,
   saving,
   loadComics,
@@ -44,13 +45,18 @@ export function useReadingOrders({
   }
 
   async function openReadingOrder(order) {
-    error.value = ''
-    activeView.value = 'readingOrders'
-    selectedOrder.value = null
-    viewMode.value = 'detail'
-    const detail = await getReadingOrder(order.id)
-    selectedOrder.value = detail
-    orderForm.value = readingOrderFormFromDetail(detail)
+    loading.value = true
+    try {
+      error.value = ''
+      activeView.value = 'readingOrders'
+      selectedOrder.value = null
+      viewMode.value = 'detail'
+      const detail = await getReadingOrder(order.id)
+      selectedOrder.value = detail
+      orderForm.value = readingOrderFormFromDetail(detail)
+    } finally {
+      loading.value = false
+    }
   }
 
   async function refreshSelectedReadingOrderDetail() {

--- a/ui/src/features/series/components/SeriesBrowseView.vue
+++ b/ui/src/features/series/components/SeriesBrowseView.vue
@@ -4,6 +4,7 @@ import BrowseListTools from '@/shared/components/browse/BrowseListTools.vue'
 import BrowseEntityRow from '@/shared/components/browse/BrowseEntityRow.vue'
 import BrowseListSection from '@/shared/components/browse/BrowseListSection.vue'
 import BrowseRowStats from '@/shared/components/browse/BrowseRowStats.vue'
+import LoadingState from '@/shared/components/feedback/LoadingState.vue'
 import { ENGAGEMENT_FILTER_OPTIONS } from '@/shared/browseOptions.js'
 import { formatProgress } from '@/features/reading-orders/model.js'
 
@@ -101,15 +102,7 @@ function seriesPublisherLabel(series) {
           @update:direction="$emit('update:direction', $event)"
         />
       </div>
-      <div
-        v-if="loading && !series.length"
-        class="inline-loading-panel"
-        role="status"
-        aria-live="polite"
-      >
-        <span class="loading-spinner small" aria-hidden="true"></span>
-        <strong>Loading series...</strong>
-      </div>
+      <LoadingState v-if="loading && !series.length" />
       <div v-else-if="series.length" class="sectioned-list">
         <BrowseListSection :title="sectionTitle" :items="series">
           <template #item="{ item }">

--- a/ui/src/features/series/useSeries.js
+++ b/ui/src/features/series/useSeries.js
@@ -11,6 +11,7 @@ import {
 export function useSeries({
   activeView,
   viewMode,
+  loading,
   error,
   loadPagedList,
   metronImportJobs,
@@ -25,11 +26,16 @@ export function useSeries({
 
   async function openSeries(item) {
     if (!item?.id) return
-    error.value = ''
-    activeView.value = 'series'
-    selectedSeries.value = null
-    viewMode.value = 'detail'
-    selectedSeries.value = await getSeries(item.id)
+    loading.value = true
+    try {
+      error.value = ''
+      activeView.value = 'series'
+      selectedSeries.value = null
+      viewMode.value = 'detail'
+      selectedSeries.value = await getSeries(item.id)
+    } finally {
+      loading.value = false
+    }
   }
 
   async function toggleSeriesFavorite(item) {

--- a/ui/src/features/settings/components/AppSettingsView.vue
+++ b/ui/src/features/settings/components/AppSettingsView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { reactive, watch } from 'vue'
+import LoadingState from '@/shared/components/feedback/LoadingState.vue'
 
 const props = defineProps({
   metronComicScan: { type: Object, default: null },
@@ -415,6 +416,6 @@ function registrationModeLabel(mode) {
         </button>
       </div>
     </section>
-    <div v-else class="empty-panel">Loading app settings...</div>
+    <LoadingState v-else />
   </section>
 </template>

--- a/ui/src/shared/components/feedback/LoadingState.vue
+++ b/ui/src/shared/components/feedback/LoadingState.vue
@@ -1,0 +1,23 @@
+<script setup>
+defineProps({
+  compact: {
+    type: Boolean,
+    default: false,
+  },
+})
+</script>
+
+<template>
+  <div
+    class="loading-state"
+    :class="{ compact }"
+    role="status"
+    aria-live="polite"
+    aria-label="Loading"
+  >
+    <span class="loading-state-content">
+      <span class="loading-spinner" aria-hidden="true"></span>
+      <strong>Loading</strong>
+    </span>
+  </div>
+</template>

--- a/ui/src/styles/loading.css
+++ b/ui/src/styles/loading.css
@@ -1,25 +1,26 @@
 /* Loading, empty, and screen-reader-only status helpers. */
 
-.loading-panel {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  width: min(420px, 100%);
-  border: 1px solid var(--line-strong);
-  border-radius: 8px;
-  background: var(--panel-bg);
+.loading-state {
+  display: grid;
+  place-items: center;
+  width: 100%;
+  min-height: min(520px, calc(100dvh - 180px));
   color: var(--label-ink);
-  padding: 16px;
-  font-size: 0.95rem;
 }
 
-.inline-loading-panel {
+.loading-state.compact {
+  min-height: 160px;
+}
+
+.loading-state-content {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 8px;
-  min-height: 52px;
-  color: var(--muted);
-  font-size: 0.9rem;
+  gap: 12px;
+}
+
+.loading-state-content strong {
+  font-size: 0.95rem;
 }
 
 .loading-spinner {


### PR DESCRIPTION
## Summary

- add a shared centered spinner and Loading label for blocking content loads
- use the same loading screen for authentication, browse initialization, dashboard, progress, settings, and Metron reading-list details
- cover reading-order, arc, comic, series, and character detail fetches that previously rendered empty content while loading
- retain compact non-blocking indicators for pagination, searches, saves, imports, and refresh actions

## Testing

- [x] `npm run format` from `ui`
- [x] `npm run lint` from `ui`
- [x] `npm run test` from `ui`
- [x] `npm run build` from `ui`

## Notes

The loading audit distinguishes initial/detail content fetches from user-triggered background operations so existing content is not unnecessarily hidden.