### PR TITLE
feat: let admins merge duplicate comics

### DIFF
--- a/backend/internal/api/comics.go
+++ b/backend/internal/api/comics.go
@@ -87,6 +87,18 @@ func RegisterComicRoutes(api huma.API, db *sqlx.DB, covers *CoverCache) {
 	}, func(ctx context.Context, input *ComicInput) (*struct{}, error) {
 		return deleteComic(ctx, db, input.ID)
 	})
+
+	huma.Register(api, huma.Operation{
+		OperationID: "mergeComic",
+		Tags:        []string{tagComics},
+		Summary:     "Merge a duplicate comic",
+		Description: "Moves user state and all reading-order, arc, and character links from a duplicate comic into the retained comic, fills blank retained metadata, and deletes the duplicate. Admin access is required.",
+		Method:      http.MethodPost,
+		Path:        "/comics/{id}/merge",
+		Errors:      []int{400, 401, 403, 404, 422, 500},
+	}, func(ctx context.Context, input *MergeComicInput) (*ComicDetailOutput, error) {
+		return mergeComic(ctx, db, input.ID, input.Body.SourceID)
+	})
 }
 
 func listComics(ctx context.Context, db *sqlx.DB, input *ComicListInput) (*ComicListOutput, error) {

--- a/backend/internal/api/comics_merge.go
+++ b/backend/internal/api/comics_merge.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/jmoiron/sqlx"
+)
+
+type comicMergeRow struct {
+	ID             int    `db:"id"`
+	SeriesID       *int   `db:"series_id"`
+	Series         string `db:"series"`
+	SeriesYear     int    `db:"series_year"`
+	Issue          string `db:"issue"`
+	Publisher      string `db:"publisher"`
+	CoverDate      string `db:"cover_date"`
+	CoverImage     string `db:"cover_image"`
+	Description    string `db:"description"`
+	MetronIssueID  *int   `db:"metron_issue_id"`
+	ComicVineID    *int   `db:"comic_vine_id"`
+	MetronSyncedAt string `db:"metron_synced_at"`
+}
+
+func mergeComic(ctx context.Context, db *sqlx.DB, targetID, sourceID int) (*ComicDetailOutput, error) {
+	if _, err := requireAdminUser(ctx, db); err != nil {
+		return nil, err
+	}
+	if targetID <= 0 || sourceID <= 0 {
+		return nil, huma.Error400BadRequest("comic IDs must be positive")
+	}
+	if targetID == sourceID {
+		return nil, huma.Error400BadRequest("a comic cannot be merged into itself")
+	}
+
+	tx, err := db.BeginTxx(ctx, nil)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to start comic merge")
+	}
+	defer tx.Rollback()
+
+	target, err := getComicMergeRow(ctx, tx, targetID)
+	if err != nil {
+		return nil, err
+	}
+	source, err := getComicMergeRow(ctx, tx, sourceID)
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT INTO user_comics (comic_id, user_id, read, skipped, read_at)
+		SELECT ?, user_id, read, skipped, read_at
+		FROM user_comics
+		WHERE comic_id = ?
+		ON CONFLICT(comic_id, user_id) DO UPDATE SET
+			read = MAX(user_comics.read, excluded.read),
+			skipped = MAX(user_comics.skipped, excluded.skipped),
+			read_at = CASE
+				WHEN user_comics.read_at = '' THEN excluded.read_at
+				WHEN excluded.read_at = '' THEN user_comics.read_at
+				WHEN excluded.read_at > user_comics.read_at THEN excluded.read_at
+				ELSE user_comics.read_at
+			END
+	`, target.ID, source.ID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to merge comic user state")
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM user_comics WHERE comic_id = ?`, source.ID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to remove duplicate comic user state")
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		INSERT OR IGNORE INTO comic_characters (comic_id, character_id)
+		SELECT ?, character_id FROM comic_characters WHERE comic_id = ?
+	`, target.ID, source.ID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to merge comic characters")
+	}
+	if _, err := tx.ExecContext(ctx, `DELETE FROM comic_characters WHERE comic_id = ?`, source.ID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to remove duplicate comic characters")
+	}
+
+	for _, table := range []string{"reading_order_comics", "arc_comics"} {
+		if _, err := tx.ExecContext(ctx, `UPDATE `+table+` SET comic_id = ? WHERE comic_id = ?`, target.ID, source.ID); err != nil {
+			return nil, huma.Error500InternalServerError("failed to merge comic placements")
+		}
+	}
+
+	if _, err := tx.ExecContext(ctx, `DELETE FROM comics WHERE id = ?`, source.ID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to delete duplicate comic")
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE comics SET
+			series_id = COALESCE(series_id, ?),
+			series = CASE WHEN TRIM(series) = '' THEN ? ELSE series END,
+			series_year = CASE WHEN series_year = 0 THEN ? ELSE series_year END,
+			issue = CASE WHEN TRIM(issue) = '' THEN ? ELSE issue END,
+			publisher = CASE WHEN TRIM(publisher) = '' THEN ? ELSE publisher END,
+			cover_date = CASE WHEN TRIM(cover_date) = '' THEN ? ELSE cover_date END,
+			cover_image = CASE WHEN TRIM(cover_image) = '' THEN ? ELSE cover_image END,
+			description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END,
+			metron_issue_id = COALESCE(metron_issue_id, ?),
+			comic_vine_id = COALESCE(comic_vine_id, ?),
+			metron_synced_at = CASE
+				WHEN metron_synced_at = '' THEN ?
+				WHEN ? > metron_synced_at THEN ?
+				ELSE metron_synced_at
+			END
+		WHERE id = ?
+	`, source.SeriesID, strings.TrimSpace(source.Series), source.SeriesYear, strings.TrimSpace(source.Issue),
+		strings.TrimSpace(source.Publisher), source.CoverDate, source.CoverImage, source.Description,
+		source.MetronIssueID, source.ComicVineID, source.MetronSyncedAt, source.MetronSyncedAt,
+		source.MetronSyncedAt, target.ID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to merge comic metadata")
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, huma.Error500InternalServerError("failed to commit comic merge")
+	}
+	return getComic(ctx, db, target.ID)
+}
+
+func getComicMergeRow(ctx context.Context, tx *sqlx.Tx, id int) (comicMergeRow, error) {
+	var comic comicMergeRow
+	err := tx.GetContext(ctx, &comic, `
+		SELECT id, series_id, series, series_year, issue, publisher, cover_date, cover_image,
+			description, metron_issue_id, comic_vine_id, metron_synced_at
+		FROM comics
+		WHERE id = ?
+	`, id)
+	if err == sql.ErrNoRows {
+		return comicMergeRow{}, huma.Error404NotFound("comic not found")
+	}
+	if err != nil {
+		return comicMergeRow{}, huma.Error500InternalServerError("failed to fetch comic for merge")
+	}
+	return comic, nil
+}

--- a/backend/internal/api/comics_merge_test.go
+++ b/backend/internal/api/comics_merge_test.go
@@ -1,0 +1,110 @@
+package api
+
+import "testing"
+
+func TestMergeComicPreservesRelationshipsAndFillsMissingMetadata(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	if _, err := db.Exec(`
+		UPDATE users SET is_admin = 1 WHERE id = 1;
+		INSERT INTO users (id, name) VALUES (2, 'Reader');
+		INSERT INTO comics (
+			id, series, series_year, issue, publisher, cover_date, cover_image, description,
+			metron_issue_id, comic_vine_id, metron_synced_at
+		) VALUES
+			(1, 'Target Series', 2020, '1', '', '', '', '', NULL, NULL, ''),
+			(2, 'Source Series', 2021, '2', 'Publisher', '2021-02-01', '/cover.jpg',
+			 'Source description', 2002, 4002, '2026-01-02T00:00:00Z');
+		INSERT INTO reading_orders (id, name) VALUES (1, 'Order');
+		INSERT INTO reading_order_comics (reading_order_id, comic_id, position, note)
+		VALUES (1, 1, 1, 'target position'), (1, 2, 2, 'source position');
+		INSERT INTO arcs (id, name) VALUES (1, 'Arc');
+		INSERT INTO arc_comics (arc_id, comic_id, position, note)
+		VALUES (1, 1, 1, 'target position'), (1, 2, 2, 'source position');
+		INSERT INTO characters (id, name) VALUES (1, 'Shared'), (2, 'Source only');
+		INSERT INTO comic_characters (comic_id, character_id)
+		VALUES (1, 1), (2, 1), (2, 2);
+		INSERT INTO user_comics (comic_id, user_id, read, skipped, read_at)
+		VALUES
+			(1, 1, 0, 1, ''),
+			(2, 1, 1, 0, '2026-01-02T00:00:00Z'),
+			(2, 2, 1, 0, '2026-01-01T00:00:00Z');
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := mergeComic(deletionUserContext(1), db, 1, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if output.Body.ID != 1 {
+		t.Fatalf("merged comic id = %d, want 1", output.Body.ID)
+	}
+	if output.Body.Publisher != "Publisher" || output.Body.Description != "Source description" {
+		t.Fatalf("missing metadata was not filled: %+v", output.Body.Comic)
+	}
+	if output.Body.Series != "Target Series" || output.Body.Issue != "1" {
+		t.Fatalf("target metadata was overwritten: %+v", output.Body.Comic)
+	}
+	if output.Body.MetronIssueID == nil || *output.Body.MetronIssueID != 2002 {
+		t.Fatalf("metron issue id = %v, want 2002", output.Body.MetronIssueID)
+	}
+	if output.Body.ComicVineID == nil || *output.Body.ComicVineID != 4002 {
+		t.Fatalf("comic vine id = %v, want 4002", output.Body.ComicVineID)
+	}
+
+	assertComicMergeCount(t, db, `SELECT COUNT(*) FROM comics WHERE id = 2`, 0)
+	assertComicMergeCount(t, db, `SELECT COUNT(*) FROM reading_order_comics WHERE comic_id = 1`, 2)
+	assertComicMergeCount(t, db, `SELECT COUNT(*) FROM arc_comics WHERE comic_id = 1`, 2)
+	assertComicMergeCount(t, db, `SELECT COUNT(*) FROM comic_characters WHERE comic_id = 1`, 2)
+	assertComicMergeCount(t, db, `SELECT COUNT(*) FROM user_comics WHERE comic_id = 1`, 2)
+
+	var state struct {
+		Read    bool   `db:"read"`
+		Skipped bool   `db:"skipped"`
+		ReadAt  string `db:"read_at"`
+	}
+	if err := db.Get(&state, `SELECT read, skipped, read_at FROM user_comics WHERE comic_id = 1 AND user_id = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if !state.Read || !state.Skipped || state.ReadAt != "2026-01-02T00:00:00Z" {
+		t.Fatalf("merged user state = %+v", state)
+	}
+}
+
+func TestMergeComicRequiresAdminAndDistinctExistingComics(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	if _, err := db.Exec(`
+		INSERT INTO users (id, name) VALUES (2, 'Reader');
+		INSERT INTO comics (id, series, issue, publisher) VALUES
+			(1, 'Series', '1', 'Publisher'),
+			(2, 'Series', '1', 'Publisher');
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := mergeComic(deletionUserContext(2), db, 1, 2); err == nil {
+		t.Fatal("non-admin merge returned nil error")
+	}
+	if _, err := db.Exec(`UPDATE users SET is_admin = 1 WHERE id = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := mergeComic(deletionUserContext(1), db, 1, 1); err == nil {
+		t.Fatal("self merge returned nil error")
+	}
+	if _, err := mergeComic(deletionUserContext(1), db, 1, 999); err == nil {
+		t.Fatal("missing source merge returned nil error")
+	}
+}
+
+func assertComicMergeCount(t *testing.T, db interface {
+	Get(dest any, query string, args ...any) error
+}, query string, want int) {
+	t.Helper()
+	var got int
+	if err := db.Get(&got, query); err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("query %q count = %d, want %d", query, got, want)
+	}
+}

--- a/backend/internal/api/models_comics.go
+++ b/backend/internal/api/models_comics.go
@@ -87,6 +87,13 @@ type UpdateComicReadInput struct {
 	}
 }
 
+type MergeComicInput struct {
+	ID   int `path:"id" doc:"Local identifier of the comic that should remain." example:"42"`
+	Body struct {
+		SourceID int `json:"sourceId" minimum:"1" doc:"Local identifier of the duplicate comic to merge into the retained comic." example:"84"`
+	}
+}
+
 type UpdateComicFromMetronInput struct {
 	ID   int `path:"id" doc:"Local comic identifier." example:"42"`
 	Body struct {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -281,12 +281,20 @@ const {
   metronMetadataApplyingID,
   metronMetadataStatus,
   metronMetadataResults,
+  mergeOpen: comicMergeOpen,
+  mergeCandidates: comicMergeCandidates,
+  mergeSearching: comicMergeSearching,
+  mergeSaving: comicMergeSaving,
   loadComics,
   openComic,
   openOrderComic,
   newComic,
   editComic,
   deleteComic,
+  openComicMerge,
+  closeComicMerge,
+  searchComicMerge,
+  mergeSelectedComic,
   toggleComicRead,
   toggleComicSkipped,
   resetMetronMetadata,
@@ -958,6 +966,10 @@ onUnmounted(() => {
         :read-only="isReadOnlyGuest"
         :can-delete="isAdmin"
         :deleting="saving"
+        :merge-open="comicMergeOpen"
+        :merge-candidates="comicMergeCandidates"
+        :merge-searching="comicMergeSearching"
+        :merge-saving="comicMergeSaving"
         @back="backToPreviousPage"
         @edit="editArc"
         @delete="deleteArc"
@@ -1088,6 +1100,10 @@ onUnmounted(() => {
         @toggle-skipped="toggleComicSkipped"
         @edit="editComic"
         @delete="deleteComic"
+        @open-merge="openComicMerge"
+        @close-merge="closeComicMerge"
+        @search-merge="searchComicMerge"
+        @merge="mergeSelectedComic"
         @open-character="openCharacter"
         @open-series="openSeries"
       />

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -379,6 +379,10 @@ export function deleteComic(id) {
   return request(`/comics/${id}`, { method: 'DELETE' })
 }
 
+export function mergeComic(id, sourceId) {
+  return send(`/comics/${id}/merge`, 'POST', { sourceId })
+}
+
 export async function listReadingOrders(params = {}) {
   const { data, pagination } = await requestWithMeta(`/readingOrders${queryString(params)}`)
   return pagedListResult(data, pagination)

--- a/ui/src/features/comics/components/ComicDetailView.vue
+++ b/ui/src/features/comics/components/ComicDetailView.vue
@@ -1,5 +1,6 @@
 <script setup>
 import DetailNavigation from '@/shared/components/detail/DetailNavigation.vue'
+import ComicMergeDialog from '@/features/comics/components/ComicMergeDialog.vue'
 import { computed } from 'vue'
 import { assetURL } from '@/api/client.js'
 
@@ -38,6 +39,10 @@ const props = defineProps({
   },
   canDelete: { type: Boolean, default: false },
   deleting: { type: Boolean, default: false },
+  mergeOpen: { type: Boolean, default: false },
+  mergeCandidates: { type: Array, default: () => [] },
+  mergeSearching: { type: Boolean, default: false },
+  mergeSaving: { type: Boolean, default: false },
 })
 
 const emit = defineEmits([
@@ -50,6 +55,10 @@ const emit = defineEmits([
   'open-character',
   'open-series',
   'delete',
+  'open-merge',
+  'close-merge',
+  'search-merge',
+  'merge',
 ])
 
 const metronActionDisabled = computed(
@@ -77,6 +86,15 @@ function seriesLabel(comic) {
 <template>
   <div class="detail-view">
     <DetailNavigation @back="$emit('back')">
+      <button
+        v-if="selectedComic && canDelete"
+        class="secondary-button"
+        type="button"
+        :disabled="deleting || mergeSaving"
+        @click="$emit('open-merge')"
+      >
+        Merge duplicate
+      </button>
       <button
         v-if="selectedComic && canDelete"
         class="danger-button"
@@ -239,5 +257,16 @@ function seriesLabel(comic) {
       </div>
       <p v-else class="empty-state">Select a comic to view it.</p>
     </article>
+
+    <ComicMergeDialog
+      v-if="mergeOpen && selectedComic"
+      :target="selectedComic"
+      :candidates="mergeCandidates"
+      :searching="mergeSearching"
+      :saving="mergeSaving"
+      @close="$emit('close-merge')"
+      @search="$emit('search-merge', $event)"
+      @merge="$emit('merge', $event)"
+    />
   </div>
 </template>

--- a/ui/src/features/comics/components/ComicMergeDialog.vue
+++ b/ui/src/features/comics/components/ComicMergeDialog.vue
@@ -1,0 +1,73 @@
+<script setup>
+import { ref } from 'vue'
+
+defineProps({
+  target: { type: Object, required: true },
+  candidates: { type: Array, default: () => [] },
+  searching: { type: Boolean, default: false },
+  saving: { type: Boolean, default: false },
+})
+
+const emit = defineEmits(['close', 'search', 'merge'])
+const query = ref('')
+
+function search() {
+  emit('search', query.value)
+}
+</script>
+
+<template>
+  <div class="modal-backdrop" @click.self="$emit('close')">
+    <section
+      class="comic-merge-dialog"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="merge-title"
+    >
+      <header class="panel-header">
+        <div>
+          <p class="eyebrow">Admin</p>
+          <h3 id="merge-title">Merge a duplicate into {{ target.title }}</h3>
+        </div>
+        <button
+          class="icon-button"
+          type="button"
+          aria-label="Close comic merge"
+          @click="$emit('close')"
+        >
+          ×
+        </button>
+      </header>
+
+      <p class="muted">
+        The selected duplicate will be deleted after its reading progress, list positions, arcs,
+        characters, and missing metadata are moved to this comic.
+      </p>
+
+      <form class="comic-merge-search" @submit.prevent="search">
+        <input v-model="query" type="search" placeholder="Search duplicate comics" autofocus />
+        <button class="primary-button" type="submit" :disabled="searching || saving">
+          {{ searching ? 'Searching...' : 'Search' }}
+        </button>
+      </form>
+
+      <div v-if="candidates.length" class="comic-merge-results">
+        <button
+          v-for="comic in candidates"
+          :key="comic.id"
+          class="row"
+          type="button"
+          :disabled="saving"
+          @click="emit('merge', comic)"
+        >
+          <span>
+            <strong>{{ comic.title }}</strong>
+            <small>{{ comic.publisher || 'Unknown publisher' }}</small>
+          </span>
+          <span class="status-pill">Merge</span>
+        </button>
+      </div>
+      <p v-else-if="!searching" class="muted">Search for the duplicate comic to merge.</p>
+    </section>
+  </div>
+</template>

--- a/ui/src/features/comics/useComics.js
+++ b/ui/src/features/comics/useComics.js
@@ -4,6 +4,7 @@ import {
   deleteComic as removeComic,
   getComic,
   listComics,
+  mergeComic as mergeComicRequest,
   searchMetronComics,
   updateComic,
   updateComicFromMetron,
@@ -34,6 +35,10 @@ export function useComics({
   const metronMetadataApplyingID = ref(null)
   const metronMetadataStatus = ref('')
   const metronMetadataResults = ref([])
+  const mergeOpen = ref(false)
+  const mergeCandidates = ref([])
+  const mergeSearching = ref(false)
+  const mergeSaving = ref(false)
 
   async function loadComics(options = {}) {
     await loadPagedList('comics', comics, listComics, options)
@@ -107,6 +112,54 @@ export function useComics({
       error.value = err.message
     } finally {
       saving.value = false
+    }
+  }
+
+  function openComicMerge() {
+    if (!selectedComic.value) return
+    mergeCandidates.value = []
+    mergeOpen.value = true
+  }
+
+  function closeComicMerge() {
+    if (mergeSaving.value) return
+    mergeOpen.value = false
+    mergeCandidates.value = []
+  }
+
+  async function searchComicMerge(query) {
+    if (!selectedComic.value || mergeSearching.value) return
+    mergeSearching.value = true
+    error.value = ''
+    try {
+      const page = await listComics({ q: String(query || '').trim(), limit: 50 })
+      mergeCandidates.value = page.items.filter((comic) => comic.id !== selectedComic.value.id)
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      mergeSearching.value = false
+    }
+  }
+
+  async function mergeSelectedComic(source) {
+    const target = selectedComic.value
+    if (!target?.id || !source?.id || mergeSaving.value) return
+    if (!confirm(`Merge ${source.title} into ${target.title}? The duplicate will be deleted.`))
+      return
+
+    mergeSaving.value = true
+    error.value = ''
+    try {
+      const detail = await mergeComicRequest(target.id, source.id)
+      selectedComic.value = detail
+      comicForm.value = { ...detail }
+      await loadComics({ force: true })
+      mergeOpen.value = false
+      mergeCandidates.value = []
+    } catch (err) {
+      error.value = err.message
+    } finally {
+      mergeSaving.value = false
     }
   }
 
@@ -324,6 +377,10 @@ export function useComics({
     metronMetadataApplyingID,
     metronMetadataStatus,
     metronMetadataResults,
+    mergeOpen,
+    mergeCandidates,
+    mergeSearching,
+    mergeSaving,
     loadComics,
     openComic,
     openOrderComic,
@@ -331,6 +388,10 @@ export function useComics({
     editComic,
     saveComic,
     deleteComic,
+    openComicMerge,
+    closeComicMerge,
+    searchComicMerge,
+    mergeSelectedComic,
     toggleComicRead,
     toggleComicSkipped,
     resetMetronMetadata,

--- a/ui/src/styles/detail-forms.css
+++ b/ui/src/styles/detail-forms.css
@@ -9,6 +9,29 @@
   box-shadow: 0 12px 34px var(--shadow-panel);
 }
 
+.comic-merge-dialog {
+  width: min(680px, calc(100% - 28px));
+  max-height: min(720px, calc(100dvh - 28px));
+  overflow: auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  background: var(--panel-bg);
+  padding: 20px;
+  box-shadow: 0 24px 64px var(--shadow-panel);
+}
+
+.comic-merge-search {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  gap: 10px;
+  margin: 18px 0;
+}
+
+.comic-merge-results {
+  display: grid;
+  gap: 8px;
+}
+
 .panel-header {
   justify-content: space-between;
   margin-bottom: 18px;


### PR DESCRIPTION
## Summary

- add an admin-only atomic endpoint that merges a duplicate comic into a retained comic
- preserve reading-order and arc positions, combine per-user read/skip state, and deduplicate character links
- keep retained metadata and fill its blank fields and missing Metron/ComicVine IDs from the duplicate
- add an admin merge dialog on comic details with duplicate search and destructive confirmation

## Testing

- [x] `go test ./...` from `backend`
- [x] `go vet ./...` from `backend`
- [x] `go build ./...` from `backend`
- [x] `npm run format` from `ui`
- [x] `npm run lint` from `ui`
- [x] `npm run test` from `ui`
- [x] `npm run build` from `ui`

## Notes

The currently open comic is always retained. The selected duplicate is deleted only after all relationships and metadata updates succeed in the same transaction.