### PR TITLE
feat: configure incomplete comic fields

### DIFF
--- a/backend/internal/api/metron_comic_scanner.go
+++ b/backend/internal/api/metron_comic_scanner.go
@@ -30,6 +30,22 @@ var weekdayNames = map[string]time.Weekday{
 	"saturday": time.Saturday,
 }
 
+var metronComicIncompleteFields = []string{
+	"comicVineId",
+	"publisher",
+	"coverImage",
+	"coverDate",
+	"description",
+}
+
+var metronComicIncompleteConditions = map[string]string{
+	"comicVineId": "comic_vine_id IS NULL",
+	"publisher":   "TRIM(publisher) = ''",
+	"coverImage":  "TRIM(cover_image) = ''",
+	"coverDate":   "TRIM(cover_date) = ''",
+	"description": "TRIM(description) = ''",
+}
+
 type MetronComicScanSettings struct {
 	Enabled             bool     `json:"enabled" doc:"Whether automatic and manual incomplete-data scans are enabled."`
 	ScanComics          bool     `json:"scanComics" doc:"Whether the comics table is included in scans."`
@@ -39,6 +55,7 @@ type MetronComicScanSettings struct {
 	DailyCallLimit      int      `json:"dailyCallLimit" minimum:"1" doc:"Maximum Metron issue calls shared by all scans during one server-local calendar day." example:"100"`
 	MinIntervalSeconds  int      `json:"minIntervalSeconds" minimum:"0" doc:"Minimum seconds between Metron issue calls made by this incomplete-comic scan." example:"20"`
 	RecheckCooldownDays int      `json:"recheckCooldownDays" minimum:"0" doc:"Days to wait before re-checking a comic that was already synced but is still missing a field Metron may not provide (e.g. no synopsis on record). 0 disables the cooldown and rechecks every run." example:"30"`
+	IncompleteFields    []string `json:"incompleteFields" doc:"Comic fields whose absence makes a comic eligible for enrichment."`
 }
 
 type MetronComicScanStatus struct {
@@ -96,7 +113,15 @@ func (s *metronComicScanner) Stop() {
 }
 
 func defaultMetronComicScanSettings() MetronComicScanSettings {
-	return MetronComicScanSettings{ScanComics: true, Schedule: "daily", StartTime: "02:00", DailyCallLimit: 100, MinIntervalSeconds: 20, RecheckCooldownDays: 30}
+	return MetronComicScanSettings{
+		ScanComics:          true,
+		Schedule:            "daily",
+		StartTime:           "02:00",
+		DailyCallLimit:      100,
+		MinIntervalSeconds:  20,
+		RecheckCooldownDays: 30,
+		IncompleteFields:    append([]string(nil), metronComicIncompleteFields...),
+	}
 }
 
 func loadMetronComicScanSettings(ctx context.Context, db *sqlx.DB) (MetronComicScanSettings, error) {
@@ -130,6 +155,22 @@ func validateMetronComicScanSettings(settings *MetronComicScanSettings) error {
 	}
 	if settings.RecheckCooldownDays < 0 {
 		return errors.New("recheckCooldownDays cannot be negative")
+	}
+	selectedFields := map[string]bool{}
+	for _, field := range settings.IncompleteFields {
+		if _, ok := metronComicIncompleteConditions[field]; !ok {
+			return fmt.Errorf("invalid incomplete field %q", field)
+		}
+		selectedFields[field] = true
+	}
+	if len(selectedFields) == 0 {
+		return errors.New("incompleteFields must contain at least one field")
+	}
+	settings.IncompleteFields = settings.IncompleteFields[:0]
+	for _, field := range metronComicIncompleteFields {
+		if selectedFields[field] {
+			settings.IncompleteFields = append(settings.IncompleteFields, field)
+		}
 	}
 	seen := map[string]bool{}
 	weekdays := make([]string, 0, len(settings.Weekdays))
@@ -245,19 +286,7 @@ func (s *metronComicScanner) stopScan(reason string) bool {
 }
 
 func (s *metronComicScanner) run(ctx context.Context, settings MetronComicScanSettings) {
-	var rows []struct {
-		ID       int `db:"id"`
-		MetronID int `db:"metron_issue_id"`
-	}
-	query := `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (comic_vine_id IS NULL OR TRIM(publisher) = '' OR TRIM(cover_image) = '' OR TRIM(cover_date) = '' OR TRIM(description) = '')`
-	args := []any{}
-	if settings.RecheckCooldownDays > 0 {
-		cutoff := time.Now().Add(-time.Duration(settings.RecheckCooldownDays) * 24 * time.Hour).UTC().Format(time.RFC3339)
-		query += ` AND (metron_synced_at = '' OR metron_synced_at <= ?)`
-		args = append(args, cutoff)
-	}
-	query += ` ORDER BY id`
-	err := s.db.SelectContext(ctx, &rows, query, args...)
+	rows, err := selectIncompleteComics(ctx, s.db, settings, time.Now())
 	if err == nil {
 		s.setScanned(len(rows))
 		var nextRequest time.Time
@@ -306,6 +335,38 @@ func (s *metronComicScanner) run(ctx context.Context, settings MetronComicScanSe
 	s.cancel = nil
 	s.mu.Unlock()
 	s.broadcastSnapshot()
+}
+
+type incompleteComicRow struct {
+	ID       int `db:"id"`
+	MetronID int `db:"metron_issue_id"`
+}
+
+func selectIncompleteComics(ctx context.Context, db *sqlx.DB, settings MetronComicScanSettings, now time.Time) ([]incompleteComicRow, error) {
+	conditions := make([]string, 0, len(settings.IncompleteFields))
+	for _, field := range settings.IncompleteFields {
+		if condition, ok := metronComicIncompleteConditions[field]; ok {
+			conditions = append(conditions, condition)
+		}
+	}
+	if len(conditions) == 0 {
+		return []incompleteComicRow{}, nil
+	}
+
+	query := `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (` + strings.Join(conditions, " OR ") + `)`
+	args := []any{}
+	if settings.RecheckCooldownDays > 0 {
+		cutoff := now.Add(-time.Duration(settings.RecheckCooldownDays) * 24 * time.Hour).UTC().Format(time.RFC3339)
+		query += ` AND (metron_synced_at = '' OR metron_synced_at <= ?)`
+		args = append(args, cutoff)
+	}
+	query += ` ORDER BY id`
+
+	rows := []incompleteComicRow{}
+	if err := db.SelectContext(ctx, &rows, query, args...); err != nil {
+		return nil, err
+	}
+	return rows, nil
 }
 
 func waitForComicScanInterval(ctx context.Context, nextRequest *time.Time, interval time.Duration) error {

--- a/backend/internal/api/metron_comic_scanner_test.go
+++ b/backend/internal/api/metron_comic_scanner_test.go
@@ -26,7 +26,7 @@ func newMetronComicScannerTestDB(t *testing.T) *sqlx.DB {
 
 func TestMetronComicScanSettingsRoundTrip(t *testing.T) {
 	db := newMetronComicScannerTestDB(t)
-	settings := MetronComicScanSettings{Enabled: true, ScanComics: true, Schedule: "weekly", Weekdays: []string{"friday", "monday"}, StartTime: "03:15", DailyCallLimit: 12, MinIntervalSeconds: 20}
+	settings := MetronComicScanSettings{Enabled: true, ScanComics: true, Schedule: "weekly", Weekdays: []string{"friday", "monday"}, StartTime: "03:15", DailyCallLimit: 12, MinIntervalSeconds: 20, IncompleteFields: []string{"publisher", "comicVineId"}}
 	if err := validateMetronComicScanSettings(&settings); err != nil {
 		t.Fatal(err)
 	}
@@ -37,8 +37,36 @@ func TestMetronComicScanSettingsRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.Enabled || got.DailyCallLimit != 12 || got.MinIntervalSeconds != 20 || len(got.Weekdays) != 2 {
+	if !got.Enabled || got.DailyCallLimit != 12 || got.MinIntervalSeconds != 20 || len(got.Weekdays) != 2 || len(got.IncompleteFields) != 2 {
 		t.Fatalf("unexpected settings: %+v", got)
+	}
+}
+
+func TestMetronComicScanLegacySettingsKeepDefaultIncompleteFields(t *testing.T) {
+	db := newMetronComicScannerTestDB(t)
+	if _, err := db.Exec(`INSERT INTO app_settings (key, value) VALUES (?, ?)`, metronComicScanSettingsKey, `{"enabled":true}`); err != nil {
+		t.Fatal(err)
+	}
+	settings, err := loadMetronComicScanSettings(context.Background(), db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(settings.IncompleteFields) != len(metronComicIncompleteFields) {
+		t.Fatalf("legacy incomplete fields = %v; want defaults %v", settings.IncompleteFields, metronComicIncompleteFields)
+	}
+}
+
+func TestMetronComicScanSettingsRequireKnownIncompleteFields(t *testing.T) {
+	settings := defaultMetronComicScanSettings()
+	settings.IncompleteFields = nil
+	if err := validateMetronComicScanSettings(&settings); err == nil {
+		t.Fatal("empty incomplete fields returned nil error")
+	}
+
+	settings = defaultMetronComicScanSettings()
+	settings.IncompleteFields = append(settings.IncompleteFields, "unknown")
+	if err := validateMetronComicScanSettings(&settings); err == nil {
+		t.Fatal("unknown incomplete field returned nil error")
 	}
 }
 
@@ -124,13 +152,9 @@ func TestMetronComicScanCooldownExcludesRecentlySyncedComics(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cutoff := now.Add(-30 * 24 * time.Hour).Format(time.RFC3339)
-	var rows []struct {
-		ID       int `db:"id"`
-		MetronID int `db:"metron_issue_id"`
-	}
-	query := `SELECT id, metron_issue_id FROM comics WHERE metron_issue_id IS NOT NULL AND (comic_vine_id IS NULL OR TRIM(publisher) = '' OR TRIM(cover_image) = '' OR TRIM(cover_date) = '' OR TRIM(description) = '') AND (metron_synced_at = '' OR metron_synced_at <= ?) ORDER BY id`
-	if err := db.Select(&rows, query, cutoff); err != nil {
+	settings := defaultMetronComicScanSettings()
+	rows, err := selectIncompleteComics(context.Background(), db, settings, now)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -149,6 +173,48 @@ func TestMetronComicScanCooldownExcludesRecentlySyncedComics(t *testing.T) {
 	}
 	if !got[4] {
 		t.Fatal("comic missing only a Comic Vine ID should be selected")
+	}
+}
+
+func TestMetronComicScanUsesSelectedIncompleteFields(t *testing.T) {
+	db := newMetronComicScannerTestDB(t)
+	if _, err := db.Exec(`
+		CREATE TABLE comics (
+			id INTEGER PRIMARY KEY,
+			publisher TEXT NOT NULL DEFAULT '',
+			cover_date TEXT NOT NULL DEFAULT '',
+			cover_image TEXT NOT NULL DEFAULT '',
+			description TEXT NOT NULL DEFAULT '',
+			metron_issue_id INTEGER,
+			comic_vine_id INTEGER,
+			metron_synced_at TEXT NOT NULL DEFAULT ''
+		);
+		INSERT INTO comics VALUES
+			(1, '', '2020-01-01', '/one.jpg', 'Complete', 101, 1001, ''),
+			(2, 'Publisher', '2020-01-01', '/two.jpg', 'Complete', 102, NULL, ''),
+			(3, 'Publisher', '2020-01-01', '/three.jpg', '', 103, 1003, '');
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := defaultMetronComicScanSettings()
+	settings.RecheckCooldownDays = 0
+	settings.IncompleteFields = []string{"publisher"}
+	rows, err := selectIncompleteComics(context.Background(), db, settings, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].MetronID != 101 {
+		t.Fatalf("publisher rows = %+v; want only Metron issue 101", rows)
+	}
+
+	settings.IncompleteFields = []string{"comicVineId", "description"}
+	rows, err = selectIncompleteComics(context.Background(), db, settings, time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 || rows[0].MetronID != 102 || rows[1].MetronID != 103 {
+		t.Fatalf("selected rows = %+v; want Metron issues 102 and 103", rows)
 	}
 }
 

--- a/ui/src/features/settings/components/AppSettingsView.vue
+++ b/ui/src/features/settings/components/AppSettingsView.vue
@@ -29,10 +29,22 @@ const emit = defineEmits([
 const draft = reactive({})
 const discoveryDraft = reactive({})
 const weekdays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
+const incompleteFieldOptions = [
+  { value: 'comicVineId', label: 'Comic Vine ID' },
+  { value: 'publisher', label: 'Publisher' },
+  { value: 'coverImage', label: 'Cover image' },
+  { value: 'coverDate', label: 'Cover date' },
+  { value: 'description', label: 'Description' },
+]
 
 watch(
   () => props.metronComicScan?.settings,
-  (settings) => Object.assign(draft, settings || {}),
+  (settings) => {
+    Object.assign(draft, settings || {})
+    if (!Array.isArray(draft.incompleteFields)) {
+      draft.incompleteFields = incompleteFieldOptions.map((option) => option.value)
+    }
+  },
   { immediate: true },
 )
 
@@ -49,6 +61,13 @@ function toggleWeekday(day, checked) {
   draft.weekdays = [...selected]
 }
 
+function toggleIncompleteField(field, checked) {
+  const selected = new Set(draft.incompleteFields || [])
+  if (checked) selected.add(field)
+  else selected.delete(field)
+  draft.incompleteFields = [...selected]
+}
+
 function save() {
   emit('save', {
     enabled: Boolean(draft.enabled),
@@ -59,6 +78,7 @@ function save() {
     dailyCallLimit: Number(draft.dailyCallLimit) || 1,
     minIntervalSeconds: Math.max(0, Number(draft.minIntervalSeconds) || 0),
     recheckCooldownDays: Math.max(0, Number(draft.recheckCooldownDays) || 0),
+    incompleteFields: draft.incompleteFields || [],
   })
 }
 
@@ -323,8 +343,8 @@ function registrationModeLabel(mode) {
           <p class="eyebrow">Metron maintenance</p>
           <h3>Incomplete comic data</h3>
           <p class="muted">
-            Fill missing publisher, cover, cover date, and description fields. Issue responses also
-            create missing arc and character links without extra detail calls.
+            Choose which missing fields make a comic incomplete. Issue responses also create missing
+            arc and character links without extra detail calls.
           </p>
         </div>
         <label class="compact-toggle metron-scan-toggle">
@@ -332,6 +352,21 @@ function registrationModeLabel(mode) {
           <span>{{ draft.enabled ? 'Enabled' : 'Disabled' }}</span>
         </label>
       </header>
+
+      <fieldset class="permission-scopes metron-incomplete-fields">
+        <legend>Consider a comic incomplete when it has no</legend>
+        <label v-for="option in incompleteFieldOptions" :key="option.value">
+          <input
+            type="checkbox"
+            :checked="(draft.incompleteFields || []).includes(option.value)"
+            @change="toggleIncompleteField(option.value, $event.target.checked)"
+          />
+          <span>{{ option.label }}</span>
+        </label>
+      </fieldset>
+      <p v-if="!(draft.incompleteFields || []).length" class="access-note">
+        Select at least one field before saving or running this scan.
+      </p>
 
       <div class="metron-scan-fields">
         <label class="metron-scan-field">
@@ -399,14 +434,19 @@ function registrationModeLabel(mode) {
       </div>
 
       <div class="metron-scan-actions">
-        <button type="button" class="primary-button" :disabled="saving" @click="save">
+        <button
+          type="button"
+          class="primary-button"
+          :disabled="saving || !(draft.incompleteFields || []).length"
+          @click="save"
+        >
           {{ saving ? 'Saving...' : 'Save settings' }}
         </button>
         <button
           v-if="!metronComicScan.running"
           type="button"
           class="secondary-action"
-          :disabled="!draft.enabled"
+          :disabled="!draft.enabled || !(draft.incompleteFields || []).length"
           @click="$emit('trigger')"
         >
           Scan now


### PR DESCRIPTION
## Summary

- let admins select which missing fields make a comic eligible for Metron maintenance
- support Comic Vine ID, publisher, cover image, cover date, and description criteria
- build the scanner query exclusively from a validated field whitelist
- retain all current criteria as defaults for existing saved settings

## Testing

- [x] `go test ./...` from `backend`
- [x] `go vet ./...` from `backend`
- [x] `go build ./...` from `backend`
- [x] `npm run format` from `ui`
- [x] `npm run lint` from `ui`
- [x] `npm run test` from `ui`
- [x] `npm run build` from `ui`

## Notes

At least one criterion is required. Settings saved before this feature automatically use all five existing criteria.