### PR TITLE
style: hide ComicVine ID on comic details

### DIFF
--- a/ui/src/features/comics/components/ComicDetailView.vue
+++ b/ui/src/features/comics/components/ComicDetailView.vue
@@ -178,10 +178,6 @@ function seriesLabel(comic) {
             <strong>{{ selectedComic.coverDate || 'Unknown' }}</strong>
             <small>Cover Date</small>
           </span>
-          <span v-if="selectedComic.comicVineId">
-            <strong>{{ selectedComic.comicVineId }}</strong>
-            <small>Comic Vine ID</small>
-          </span>
         </div>
 
         <div


### PR DESCRIPTION
## Summary

- remove the Comic Vine ID from the comic detail metadata grid
- retain ComicVine persistence and all backend uses for Metron enrichment, CBL matching, maintenance, and duplicate merging

## Testing

- [x] `npm run format` from `ui`
- [x] `npm run lint` from `ui`
- [x] `npm run test` from `ui`
- [x] `npm run build` from `ui`

## Notes

This is presentation-only; the API field and database column are unchanged.