### PR TITLE
Import multipart CBL reading lists

### DIFF
--- a/backend/internal/api/models_reading_orders.go
+++ b/backend/internal/api/models_reading_orders.go
@@ -98,12 +98,19 @@ type UpdateReadingOrderRatingInput struct {
 
 type ReadingOrderCBLImportInput struct {
 	Body struct {
-		Filename string `json:"filename,omitempty" doc:"Original CBL filename, used as a fallback reading-order name." example:"Infinity Gauntlet.cbl"`
-		Content  string `json:"content"            minLength:"1" doc:"CBL XML document content."`
+		Filename string                      `json:"filename,omitempty" doc:"Original CBL filename, used as a fallback reading-order name for a single-file import." example:"Infinity Gauntlet.cbl"`
+		Content  string                      `json:"content,omitempty"  doc:"CBL XML document content for a single-file import."`
+		Parts    []ReadingOrderCBLImportPart `json:"parts,omitempty"    doc:"Two or more CBL part files that share a name ending in Part NN. Each part becomes a child of one grouped reading order."`
 	}
 }
 
+type ReadingOrderCBLImportPart struct {
+	Filename string `json:"filename,omitempty" doc:"Original CBL part filename." example:"[Marvel] CMRO Core Reading Order-Part 01.cbl"`
+	Content  string `json:"content" minLength:"1" doc:"CBL XML document content for this part."`
+}
+
 type ReadingOrderCBLUnmatchedBook struct {
+	Part     string `json:"part,omitempty" doc:"CBL part name when this book came from a multipart import." example:"[Marvel] CMRO Core Reading Order-Part 02"`
 	Position int    `json:"position" doc:"One-based book position in the CBL file." example:"3"`
 	Series   string `json:"series"   doc:"CBL book series attribute." example:"Batman"`
 	Number   string `json:"number"   doc:"CBL book number attribute." example:"6"`

--- a/backend/internal/api/readingorders_cbl.go
+++ b/backend/internal/api/readingorders_cbl.go
@@ -6,6 +6,8 @@ import (
 	"encoding/xml"
 	"fmt"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"unicode"
@@ -15,6 +17,8 @@ import (
 )
 
 const cblNoLocalComicMatch = "no local comic matched"
+
+var cblPartSuffixPattern = regexp.MustCompile(`(?i)(?:\s*[-_]\s*|\s+)part\s*[-_]?\s*(\d+)\s*$`)
 
 type cblReadingList struct {
 	XMLName   xml.Name  `xml:"ReadingList"`
@@ -40,31 +44,150 @@ type cblDatabase struct {
 	Issue  string `xml:"Issue,attr,omitempty"`
 }
 
+type cblImportDocument struct {
+	name string
+	list cblReadingList
+	part int
+}
+
+type cblImportResult struct {
+	readingOrder   ReadingOrderDetail
+	matchedCount   int
+	unmatchedCount int
+	unmatched      []ReadingOrderCBLUnmatchedBook
+}
+
 func importReadingOrderCBL(ctx context.Context, db *sqlx.DB, input *ReadingOrderCBLImportInput) (*ReadingOrderCBLImportOutput, error) {
-	var cbl cblReadingList
-	if err := xml.Unmarshal([]byte(input.Body.Content), &cbl); err != nil {
-		return nil, huma.Error400BadRequest("invalid CBL XML")
+	documents, err := parseCBLImportDocuments(input)
+	if err != nil {
+		return nil, err
+	}
+	if len(documents) == 1 {
+		result, err := importCBLDocument(ctx, db, documents[0])
+		if err != nil {
+			return nil, err
+		}
+		return cblImportOutput(result), nil
+	}
+	return importMultipartReadingOrderCBL(ctx, db, documents)
+}
+
+func parseCBLImportDocuments(input *ReadingOrderCBLImportInput) ([]cblImportDocument, error) {
+	if input == nil {
+		return nil, huma.Error400BadRequest("CBL content is required")
 	}
 
-	name := strings.TrimSpace(cbl.Name)
-	if name == "" {
-		name = readingOrderNameFromCBLFilename(input.Body.Filename)
+	parts := input.Body.Parts
+	if strings.TrimSpace(input.Body.Content) != "" {
+		if len(parts) > 0 {
+			return nil, huma.Error400BadRequest("provide either one CBL document or multipart CBL files, not both")
+		}
+		parts = []ReadingOrderCBLImportPart{{
+			Filename: input.Body.Filename,
+			Content:  input.Body.Content,
+		}}
 	}
-	if name == "" {
-		name = "Imported CBL reading order"
+	if len(parts) == 0 {
+		return nil, huma.Error400BadRequest("CBL content is required")
 	}
+	if len(parts) > 100 {
+		return nil, huma.Error400BadRequest("a multipart CBL import supports at most 100 files")
+	}
+
+	documents := make([]cblImportDocument, 0, len(parts))
+	for _, part := range parts {
+		if strings.TrimSpace(part.Content) == "" {
+			return nil, huma.Error400BadRequest("each CBL part must include content")
+		}
+		var cbl cblReadingList
+		if err := xml.Unmarshal([]byte(part.Content), &cbl); err != nil {
+			return nil, huma.Error400BadRequest("invalid CBL XML in " + cblImportPartLabel(part.Filename))
+		}
+		name := strings.TrimSpace(cbl.Name)
+		if name == "" {
+			name = readingOrderNameFromCBLFilename(part.Filename)
+		}
+		if name == "" {
+			name = "Imported CBL reading order"
+		}
+		documents = append(documents, cblImportDocument{
+			name: name,
+			list: cbl,
+		})
+	}
+	return documents, nil
+}
+
+func importMultipartReadingOrderCBL(ctx context.Context, db *sqlx.DB, documents []cblImportDocument) (*ReadingOrderCBLImportOutput, error) {
+	parentName, err := prepareMultipartCBLDocuments(documents)
+	if err != nil {
+		return nil, err
+	}
+
+	createdOrderIDs := make([]int, 0, len(documents)+1)
+	complete := false
+	defer func() {
+		if !complete {
+			cleanupCBLReadingOrders(ctx, db, createdOrderIDs)
+		}
+	}()
+
+	entries := make([]ReadingOrderEntryPayload, 0, len(documents))
+	unmatched := make([]ReadingOrderCBLUnmatchedBook, 0)
+	matchedCount := 0
+	for _, document := range documents {
+		partResult, err := importCBLDocument(ctx, db, document)
+		if err != nil {
+			return nil, err
+		}
+		createdOrderIDs = append(createdOrderIDs, partResult.readingOrder.ID)
+		entries = append(entries, ReadingOrderEntryPayload{
+			Type:           "readingOrder",
+			ReadingOrderID: partResult.readingOrder.ID,
+		})
+		matchedCount += partResult.matchedCount
+		for _, book := range partResult.unmatched {
+			book.Part = document.name
+			unmatched = append(unmatched, book)
+		}
+	}
+
+	parent, err := createReadingOrder(ctx, db, nil, ReadingOrderPayload{Name: parentName})
+	if err != nil {
+		return nil, err
+	}
+	createdOrderIDs = append(createdOrderIDs, parent.Body.ID)
+	setInput := &SetReadingOrderComicsInput{ID: parent.Body.ID}
+	setInput.Body.Entries = entries
+	detail, err := setReadingOrderComics(ctx, db, setInput)
+	if err != nil {
+		return nil, err
+	}
+
+	complete = true
+	return &ReadingOrderCBLImportOutput{Body: ReadingOrderCBLImportResult{
+		ReadingOrder:   detail.Body,
+		MatchedCount:   matchedCount,
+		UnmatchedCount: len(unmatched),
+		Unmatched:      unmatched,
+	}}, nil
+}
+
+func importCBLDocument(ctx context.Context, db *sqlx.DB, document cblImportDocument) (cblImportResult, error) {
+	cbl := document.list
+	name := document.name
 
 	entries := make([]ReadingOrderEntryPayload, 0, len(cbl.Books))
 	unmatched := make([]ReadingOrderCBLUnmatchedBook, 0)
 	for i, book := range cbl.Books {
 		comic, reason, err := matchCBLBook(ctx, db, book)
 		if err != nil {
-			return nil, err
+			return cblImportResult{}, err
 		}
 		if comic == nil && reason == cblNoLocalComicMatch {
 			comic, err = createComicFromCBLBook(ctx, db, book)
 			if err != nil {
-				return nil, err
+				return cblImportResult{}, err
 			}
 		}
 		if comic == nil {
@@ -79,22 +202,91 @@ func importReadingOrderCBL(ctx context.Context, db *sqlx.DB, input *ReadingOrder
 
 	created, err := createReadingOrder(ctx, db, nil, ReadingOrderPayload{Name: name})
 	if err != nil {
-		return nil, err
+		return cblImportResult{}, err
 	}
 
 	setInput := &SetReadingOrderComicsInput{ID: created.Body.ID}
 	setInput.Body.Entries = entries
 	detail, err := setReadingOrderComics(ctx, db, setInput)
 	if err != nil {
-		return nil, err
+		return cblImportResult{}, err
 	}
 
+	return cblImportResult{
+		readingOrder:   detail.Body,
+		matchedCount:   len(entries),
+		unmatchedCount: len(unmatched),
+		unmatched:      unmatched,
+	}, nil
+}
+
+func cblImportOutput(result cblImportResult) *ReadingOrderCBLImportOutput {
 	return &ReadingOrderCBLImportOutput{Body: ReadingOrderCBLImportResult{
-		ReadingOrder:   detail.Body,
-		MatchedCount:   len(entries),
-		UnmatchedCount: len(unmatched),
-		Unmatched:      unmatched,
-	}}, nil
+		ReadingOrder:   result.readingOrder,
+		MatchedCount:   result.matchedCount,
+		UnmatchedCount: result.unmatchedCount,
+		Unmatched:      result.unmatched,
+	}}
+}
+
+func prepareMultipartCBLDocuments(documents []cblImportDocument) (string, error) {
+	if len(documents) < 2 {
+		return "", huma.Error400BadRequest("multipart CBL import requires at least two files")
+	}
+
+	parentName := ""
+	seenParts := map[int]bool{}
+	for i := range documents {
+		base, part, ok := cblMultipartPartName(documents[i].name)
+		if !ok {
+			return "", huma.Error400BadRequest("multipart CBL names must end in Part NN")
+		}
+		if parentName == "" {
+			parentName = base
+		} else if !strings.EqualFold(parentName, base) {
+			return "", huma.Error400BadRequest("multipart CBL files must share the same reading-order name")
+		}
+		if seenParts[part] {
+			return "", huma.Error400BadRequest(fmt.Sprintf("multipart CBL contains duplicate Part %d", part))
+		}
+		seenParts[part] = true
+		documents[i].part = part
+	}
+
+	sort.SliceStable(documents, func(i, j int) bool {
+		if documents[i].part != documents[j].part {
+			return documents[i].part < documents[j].part
+		}
+		return strings.ToLower(documents[i].name) < strings.ToLower(documents[j].name)
+	})
+	return parentName, nil
+}
+
+func cblMultipartPartName(name string) (string, int, bool) {
+	name = strings.TrimSpace(name)
+	matches := cblPartSuffixPattern.FindStringSubmatchIndex(name)
+	if len(matches) < 4 {
+		return "", 0, false
+	}
+	part, ok := parseCBLPositiveInt(name[matches[2]:matches[3]])
+	base := strings.TrimSpace(name[:matches[0]])
+	return base, part, ok && base != ""
+}
+
+func cblImportPartLabel(filename string) string {
+	if name := filepath.Base(strings.TrimSpace(filename)); name != "" && name != "." {
+		return name
+	}
+	return "CBL part"
+}
+
+func cleanupCBLReadingOrders(ctx context.Context, db *sqlx.DB, ids []int) {
+	for i := len(ids) - 1; i >= 0; i-- {
+		_, _ = db.ExecContext(ctx, `DELETE FROM reading_order_comics WHERE reading_order_id = ?`, ids[i])
+		_, _ = db.ExecContext(ctx, `DELETE FROM reading_order_children WHERE parent_reading_order_id = ? OR child_reading_order_id = ?`, ids[i], ids[i])
+		_, _ = db.ExecContext(ctx, `DELETE FROM reading_order_sections WHERE reading_order_id = ?`, ids[i])
+		_, _ = db.ExecContext(ctx, `DELETE FROM reading_orders WHERE id = ?`, ids[i])
+	}
 }
 
 func exportReadingOrderCBL(ctx context.Context, db *sqlx.DB, id int) (*ReadingOrderCBLExportOutput, error) {

--- a/backend/internal/api/readingorders_routes.go
+++ b/backend/internal/api/readingorders_routes.go
@@ -24,8 +24,8 @@ func RegisterReadingOrderRoutes(api huma.API, db *sqlx.DB, covers *CoverCache) {
 	huma.Register(api, huma.Operation{
 		OperationID:   "importReadingOrderCBL",
 		Tags:          []string{tagReadingOrders},
-		Summary:       "Import a CBL reading order",
-		Description:   "Creates a reading order from CBL XML. Books are matched by Comic Vine issue ID first, then by series, issue number, and volume or year; valid books without a local match are created.",
+		Summary:       "Import one or more CBL reading-order parts",
+		Description:   "Creates a reading order from one CBL file, or groups multipart files named Part NN beneath a parent reading order. Books are matched by Comic Vine issue ID first, then by series, issue number, and volume or year; valid books without a local match are created.",
 		Method:        http.MethodPost,
 		Path:          "/readingOrders/cbl/import",
 		DefaultStatus: 201,

--- a/backend/internal/api/readingorders_test.go
+++ b/backend/internal/api/readingorders_test.go
@@ -527,6 +527,104 @@ func TestReadingOrderCBLImportPrefersComicVineThenFallsBackAndCreatesMissingComi
 	}
 }
 
+func TestReadingOrderCBLImportGroupsMultipartFilesInPartOrder(t *testing.T) {
+	ctx := testUserContext()
+	db := setupReadingOrderCBLTestDB(t)
+
+	input := &ReadingOrderCBLImportInput{}
+	input.Body.Parts = []ReadingOrderCBLImportPart{
+		{
+			Filename: "[Marvel] CMRO Core Reading Order-Part 02.cbl",
+			Content: `<ReadingList>
+	<Name>[Marvel] CMRO Core Reading Order-Part 02</Name>
+	<Books>
+		<Book Series="Fantastic Four" Number="2" Volume="1961" Year="1962"><Database Name="cv" Issue="5712" /></Book>
+		<Book Number="3" Volume="1961" Year="1962" />
+	</Books>
+</ReadingList>`,
+		},
+		{
+			Filename: "[Marvel] CMRO Core Reading Order-Part 01.cbl",
+			Content: `<ReadingList>
+	<Name>[Marvel] CMRO Core Reading Order-Part 01</Name>
+	<Books>
+		<Book Series="Fantastic Four" Number="1" Volume="1961" Year="1961"><Database Name="cv" Issue="5558" /></Book>
+	</Books>
+</ReadingList>`,
+		},
+	}
+
+	result, err := importReadingOrderCBL(ctx, db, input)
+	if err != nil {
+		t.Fatalf("importReadingOrderCBL: %v", err)
+	}
+
+	if result.Body.ReadingOrder.Name != "[Marvel] CMRO Core Reading Order" {
+		t.Fatalf("parent name = %q; want suffix-free multipart name", result.Body.ReadingOrder.Name)
+	}
+	if result.Body.MatchedCount != 2 || result.Body.UnmatchedCount != 1 {
+		t.Fatalf("matched/unmatched = %d/%d; want 2/1", result.Body.MatchedCount, result.Body.UnmatchedCount)
+	}
+	if len(result.Body.Unmatched) != 1 || result.Body.Unmatched[0].Part != "[Marvel] CMRO Core Reading Order-Part 02" {
+		t.Fatalf("unmatched = %#v; want source part on malformed book", result.Body.Unmatched)
+	}
+
+	order := result.Body.ReadingOrder
+	if len(order.ChildReadingOrders) != 2 || len(order.Entries) != 2 || len(order.Comics) != 2 {
+		t.Fatalf("parent children/entries/comics = %d/%d/%d; want 2/2/2", len(order.ChildReadingOrders), len(order.Entries), len(order.Comics))
+	}
+	wantPartNames := []string{
+		"[Marvel] CMRO Core Reading Order-Part 01",
+		"[Marvel] CMRO Core Reading Order-Part 02",
+	}
+	for i, want := range wantPartNames {
+		if order.ChildReadingOrders[i].Name != want {
+			t.Fatalf("child %d name = %q; want %q", i, order.ChildReadingOrders[i].Name, want)
+		}
+		if order.Entries[i].ReadingOrder == nil || order.Entries[i].ReadingOrder.Name != want {
+			t.Fatalf("entry %d = %#v; want child %q", i, order.Entries[i], want)
+		}
+		if len(order.Entries[i].Comics) != 1 {
+			t.Fatalf("entry %d comics = %d; want 1", i, len(order.Entries[i].Comics))
+		}
+	}
+	if order.Comics[0].Issue != "1" || order.Comics[1].Issue != "2" {
+		t.Fatalf("flattened issues = %q, %q; want part order 1, 2", order.Comics[0].Issue, order.Comics[1].Issue)
+	}
+	if !strings.Contains(order.Comics[0].Comment, "Part 01") || !strings.Contains(order.Comics[1].Comment, "Part 02") {
+		t.Fatalf("flattened source comments = %q, %q; want originating part", order.Comics[0].Comment, order.Comics[1].Comment)
+	}
+
+	var readingOrderCount int
+	if err := db.Get(&readingOrderCount, `SELECT COUNT(*) FROM reading_orders`); err != nil {
+		t.Fatalf("count reading orders: %v", err)
+	}
+	if readingOrderCount != 3 {
+		t.Fatalf("reading order count = %d; want parent plus two parts", readingOrderCount)
+	}
+}
+
+func TestMultipartCBLImportRejectsUnrelatedReadingLists(t *testing.T) {
+	ctx := testUserContext()
+	db := setupReadingOrderCBLTestDB(t)
+	input := &ReadingOrderCBLImportInput{}
+	input.Body.Parts = []ReadingOrderCBLImportPart{
+		{Filename: "First-Part 01.cbl", Content: `<ReadingList><Name>First-Part 01</Name></ReadingList>`},
+		{Filename: "Second-Part 02.cbl", Content: `<ReadingList><Name>Second-Part 02</Name></ReadingList>`},
+	}
+
+	if _, err := importReadingOrderCBL(ctx, db, input); err == nil {
+		t.Fatal("importReadingOrderCBL succeeded; want unrelated multipart names rejected")
+	}
+	var readingOrderCount int
+	if err := db.Get(&readingOrderCount, `SELECT COUNT(*) FROM reading_orders`); err != nil {
+		t.Fatalf("count reading orders: %v", err)
+	}
+	if readingOrderCount != 0 {
+		t.Fatalf("reading order count = %d; want validation before creating data", readingOrderCount)
+	}
+}
+
 func imageDataURL(mime string, data []byte) string {
 	return "data:" + mime + ";base64," + base64.StdEncoding.EncodeToString(data)
 }

--- a/ui/src/features/reading-orders/components/ReadingOrdersBrowseView.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrdersBrowseView.vue
@@ -91,8 +91,8 @@ function createReadingOrder() {
 }
 
 function handleCBLFile(event) {
-  const file = event.target.files?.[0]
-  if (file) emit('import-cbl', file)
+  const files = Array.from(event.target.files || [])
+  if (files.length) emit('import-cbl', files)
   event.target.value = ''
 }
 </script>
@@ -131,6 +131,7 @@ function handleCBLFile(event) {
                   ref="cblFileInput"
                   hidden
                   type="file"
+                  multiple
                   accept=".cbl,application/xml,text/xml"
                   @change="handleCBLFile"
                 />

--- a/ui/src/features/reading-orders/useReadingOrders.js
+++ b/ui/src/features/reading-orders/useReadingOrders.js
@@ -280,18 +280,22 @@ export function useReadingOrders({
     }
   }
 
-  async function importReadingOrderCBLFile(file) {
-    if (!file) return null
+  async function importReadingOrderCBLFile(selectedFiles) {
+    const files = Array.isArray(selectedFiles) ? selectedFiles : [selectedFiles].filter(Boolean)
+    if (!files.length) return null
 
     cblImporting.value = true
     saving.value = true
     error.value = ''
 
     try {
-      const result = await importReadingOrderCBL({
-        filename: file.name || '',
-        content: await file.text(),
-      })
+      const parts = await Promise.all(
+        files.map(async (file) => ({
+          filename: file.name || '',
+          content: await file.text(),
+        })),
+      )
+      const result = await importReadingOrderCBL(parts.length === 1 ? parts[0] : { parts })
       selectedOrder.value = result.readingOrder
       orderForm.value = readingOrderFormFromDetail(result.readingOrder)
       await loadReadingOrders({ force: true })


### PR DESCRIPTION
## Summary

- let users select one or multiple CBL files from the existing Import CBL action
- validate shared Part NN naming, sort parts numerically, and group them beneath a suffix-free parent reading order
- retain each part as a nested reading order so the detail view identifies and collapses issues by their source part
- preserve single-file import behavior and report the source part for unmatched multipart books
- cover CMRO-style reverse-order selection, grouping, issue provenance, and unrelated-file validation

## Testing

- [x] go test ./... from backend
- [x] go vet ./... from backend
- [x] go build ./... from backend
- [x] npm --prefix ui test
- [x] npm --prefix ui run lint
- [x] npm --prefix ui run format
- [x] npm --prefix ui run build

## Notes

Designed against the multipart naming used by the CMRO CBL collection at https://github.com/DieselTech/CBL-ReadingLists/tree/aac74fb2d4a7b0e1bba12c8b6f2a539d6a0a5d0c/Marvel/Master%20Reading%20Order/CMRO.

Do not include .env files, databases, cached covers, or personal reading-order data.