### PR TITLE
fix: speed up large reading order editing

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -279,7 +279,6 @@ const {
   loading,
   error,
   saving,
-  loadComics: (...args) => loadComics(...args),
   loadPagedList,
 })
 

--- a/ui/src/features/reading-orders/components/ReadingOrderEditor.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrderEditor.vue
@@ -3,6 +3,10 @@ import { computed, onBeforeUnmount, ref, watch } from 'vue'
 
 import { assetURL, listComics } from '@/api/client.js'
 import { comicLabel } from '@/features/comics/model.js'
+import {
+  readingOrderEditorPage,
+  readingOrderEditorPageSize,
+} from '@/features/reading-orders/model.js'
 
 const props = defineProps({
   form: { type: Object, required: true },
@@ -31,11 +35,13 @@ const sectionTitle = ref('')
 const sectionDescription = ref('')
 const activeAddType = ref('comic')
 const expandedEntryKeys = ref(new Set())
+const entryPage = ref(0)
 
 let comicSearchTimer = null
 let comicSearchRequestId = 0
 
 const orderEntries = computed(() => props.form.entries || props.form.comics || [])
+const entryPageState = computed(() => readingOrderEditorPage(orderEntries.value, entryPage.value))
 const coverPreview = computed(() => {
   if (props.form.coverImageData) return props.form.coverImageData
   if (props.form.image) return assetURL(props.form.image)
@@ -46,6 +52,14 @@ watch(
   () => props.form.id,
   () => {
     expandedEntryKeys.value = new Set()
+    entryPage.value = 0
+  },
+)
+
+watch(
+  () => orderEntries.value.length,
+  () => {
+    entryPage.value = entryPageState.value.page
   },
 )
 
@@ -244,7 +258,14 @@ function addSection() {
 }
 
 function addNewEntryToEnd(entry) {
-  insertEntryAt(entry, orderEntries.value.length)
+  const index = orderEntries.value.length
+  insertEntryAt(entry, index)
+  entryPage.value = Math.floor(index / readingOrderEditorPageSize)
+}
+
+function goToEntryPage(page) {
+  endDrag()
+  entryPage.value = Math.min(Math.max(0, page), entryPageState.value.pageCount - 1)
 }
 
 function dropAt(event, index) {
@@ -555,7 +576,54 @@ function endDrag() {
       <section class="entry-section reading-order-list-edit">
         <div class="section-title">
           <h4>List Order</h4>
+          <span>{{ orderEntries.length }} entries</span>
         </div>
+
+        <nav
+          v-if="entryPageState.pageCount > 1"
+          class="reading-order-entry-pages"
+          aria-label="Reading order entry pages"
+        >
+          <span>
+            Entries {{ entryPageState.start + 1 }}–{{ entryPageState.end }} of
+            {{ orderEntries.length }}
+          </span>
+          <div>
+            <button
+              type="button"
+              class="secondary-button"
+              :disabled="entryPageState.page === 0"
+              @click="goToEntryPage(0)"
+            >
+              First
+            </button>
+            <button
+              type="button"
+              class="secondary-button"
+              :disabled="entryPageState.page === 0"
+              @click="goToEntryPage(entryPageState.page - 1)"
+            >
+              Previous
+            </button>
+            <strong>Page {{ entryPageState.page + 1 }} of {{ entryPageState.pageCount }}</strong>
+            <button
+              type="button"
+              class="secondary-button"
+              :disabled="entryPageState.page === entryPageState.pageCount - 1"
+              @click="goToEntryPage(entryPageState.page + 1)"
+            >
+              Next
+            </button>
+            <button
+              type="button"
+              class="secondary-button"
+              :disabled="entryPageState.page === entryPageState.pageCount - 1"
+              @click="goToEntryPage(entryPageState.pageCount - 1)"
+            >
+              Last
+            </button>
+          </div>
+        </nav>
 
         <div
           v-if="orderEntries.length === 0"
@@ -569,7 +637,10 @@ function endDrag() {
         </div>
 
         <div v-else class="order-entry-list">
-          <template v-for="(entry, index) in orderEntries" :key="index">
+          <template
+            v-for="{ entry, index } in entryPageState.entries"
+            :key="entryKey(entry, index)"
+          >
             <div
               class="entry-drop-zone"
               :class="{ active: dragOverIndex === index }"
@@ -699,12 +770,38 @@ function endDrag() {
 
           <div
             class="entry-drop-zone end-zone"
-            :class="{ active: dragOverIndex === orderEntries.length }"
-            @dragover="overDropZone($event, orderEntries.length)"
+            :class="{ active: dragOverIndex === entryPageState.end }"
+            @dragover="overDropZone($event, entryPageState.end)"
             @dragleave="dragOverIndex = null"
-            @drop="dropAt($event, orderEntries.length)"
+            @drop="dropAt($event, entryPageState.end)"
           />
         </div>
+
+        <nav
+          v-if="entryPageState.pageCount > 1"
+          class="reading-order-entry-pages reading-order-entry-pages-bottom"
+          aria-label="Reading order entry pages"
+        >
+          <span>Page {{ entryPageState.page + 1 }} of {{ entryPageState.pageCount }}</span>
+          <div>
+            <button
+              type="button"
+              class="secondary-button"
+              :disabled="entryPageState.page === 0"
+              @click="goToEntryPage(entryPageState.page - 1)"
+            >
+              Previous
+            </button>
+            <button
+              type="button"
+              class="secondary-button"
+              :disabled="entryPageState.page === entryPageState.pageCount - 1"
+              @click="goToEntryPage(entryPageState.page + 1)"
+            >
+              Next
+            </button>
+          </div>
+        </nav>
       </section>
     </div>
   </form>

--- a/ui/src/features/reading-orders/model.js
+++ b/ui/src/features/reading-orders/model.js
@@ -13,6 +13,32 @@ export function emptyReadingOrder() {
   }
 }
 
+export const readingOrderEditorPageSize = 100
+
+export function readingOrderEditorPage(
+  entries,
+  requestedPage,
+  pageSize = readingOrderEditorPageSize,
+) {
+  const source = Array.isArray(entries) ? entries : []
+  const size = Math.max(1, Number(pageSize) || readingOrderEditorPageSize)
+  const pageCount = Math.max(1, Math.ceil(source.length / size))
+  const page = Math.min(Math.max(0, Number(requestedPage) || 0), pageCount - 1)
+  const start = page * size
+  const end = Math.min(start + size, source.length)
+
+  return {
+    page,
+    pageCount,
+    start,
+    end,
+    entries: source.slice(start, end).map((entry, offset) => ({
+      entry,
+      index: start + offset,
+    })),
+  }
+}
+
 export function readingOrderFormFromDetail(detail) {
   const entries = (detail.entries || []).map((entry) => {
     if (entry.type === 'section' && entry.section) {

--- a/ui/src/features/reading-orders/model.test.js
+++ b/ui/src/features/reading-orders/model.test.js
@@ -4,6 +4,7 @@ import test from 'node:test'
 import {
   readingOrderComicsPayload,
   readingOrderDisplayComics,
+  readingOrderEditorPage,
   readingOrderFormFromDetail,
 } from './model.js'
 
@@ -74,4 +75,22 @@ test('groups nested reading-order issues separately and then resumes the parent 
   assert.equal(display[2].section.title, 'Setup')
   assert.equal(display[0].read, true)
   assert.equal(display[1].skipped, true)
+})
+
+test('pages large reading orders without dropping or renumbering entries', () => {
+  const entries = Array.from({ length: 251 }, (_, index) => ({ comicId: index + 1 }))
+
+  const first = readingOrderEditorPage(entries, 0)
+  assert.equal(first.pageCount, 3)
+  assert.equal(first.entries.length, 100)
+  assert.equal(first.entries[0].index, 0)
+  assert.equal(first.entries[99].index, 99)
+
+  const last = readingOrderEditorPage(entries, 99)
+  assert.equal(last.page, 2)
+  assert.equal(last.start, 200)
+  assert.equal(last.end, 251)
+  assert.equal(last.entries.length, 51)
+  assert.equal(last.entries[0].entry.comicId, 201)
+  assert.equal(last.entries[50].index, 250)
 })

--- a/ui/src/features/reading-orders/useReadingOrders.js
+++ b/ui/src/features/reading-orders/useReadingOrders.js
@@ -20,15 +20,7 @@ import {
   readingOrderPayload,
 } from '@/features/reading-orders/model.js'
 
-export function useReadingOrders({
-  activeView,
-  viewMode,
-  loading,
-  error,
-  saving,
-  loadComics,
-  loadPagedList,
-}) {
+export function useReadingOrders({ activeView, viewMode, loading, error, saving, loadPagedList }) {
   const readingOrders = ref([])
   const selectedOrder = ref(null)
   const quickSavingOrderID = ref(null)
@@ -206,7 +198,7 @@ export function useReadingOrders({
   }
 
   async function loadReadingOrderEditorOptions() {
-    await Promise.all([loadComics(), loadReadingOrders()])
+    await loadReadingOrders()
   }
 
   async function saveReadingOrder() {

--- a/ui/src/styles/reading-order-editor.css
+++ b/ui/src/styles/reading-order-editor.css
@@ -5,6 +5,48 @@
   gap: 6px;
 }
 
+.reading-order-list-edit .section-title > span,
+.reading-order-entry-pages > span {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 750;
+}
+
+.reading-order-entry-pages {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 10px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--panel-soft-bg);
+  padding: 10px 12px;
+}
+
+.reading-order-entry-pages > div {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.reading-order-entry-pages .secondary-button {
+  min-height: 36px;
+  padding: 7px 10px;
+}
+
+.reading-order-entry-pages strong {
+  min-width: 104px;
+  color: var(--ink);
+  text-align: center;
+}
+
+.reading-order-entry-pages-bottom {
+  margin-top: 10px;
+  margin-bottom: 0;
+}
+
 .entry-drop-zone {
   min-height: 12px;
   border: 1px dashed transparent;

--- a/ui/src/styles/responsive-mobile.css
+++ b/ui/src/styles/responsive-mobile.css
@@ -504,6 +504,25 @@
     background: var(--surface);
   }
 
+  .reading-order-entry-pages {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .reading-order-entry-pages > div {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .reading-order-entry-pages strong {
+    grid-column: 1 / -1;
+    grid-row: 1;
+  }
+
+  .reading-order-entry-pages .secondary-button {
+    width: 100%;
+  }
+
   .icon-button {
     align-self: stretch;
     width: 100%;


### PR DESCRIPTION
## Summary

## Testing

- [ ] `go test ./...` from `backend`
- [ ] `npm --prefix ui run build`

## Notes

Do not include `.env` files, databases, cached covers, or personal reading-order data.
