### PR TITLE
Fix sticky toolbar spacing and mobile user layout

### DIFF
--- a/ui/src/styles/administration.css
+++ b/ui/src/styles/administration.css
@@ -270,6 +270,7 @@
 .user-permission-list {
   display: grid;
   gap: 8px;
+  min-width: 0;
 }
 
 .user-permission-row {
@@ -278,6 +279,8 @@
   background: var(--surface-soft);
   padding: 0;
   display: grid;
+  min-width: 0;
+  max-width: 100%;
   overflow: hidden;
 }
 
@@ -320,6 +323,11 @@
 
 .user-summary {
   min-width: 0;
+}
+
+.user-summary h3,
+.user-summary p {
+  overflow-wrap: anywhere;
 }
 
 .user-permission-header h3 {
@@ -370,12 +378,14 @@
   grid-template-columns: minmax(220px, 0.7fr) minmax(420px, 1.3fr);
   gap: 0;
   align-items: stretch;
+  min-width: 0;
 }
 
 .user-card-section {
   display: grid;
   align-content: start;
   gap: 12px;
+  min-width: 0;
   padding: 16px 18px;
 }
 
@@ -442,11 +452,13 @@
   grid-template-columns: minmax(180px, 240px) 1fr;
   gap: 12px;
   align-items: start;
+  min-width: 0;
 }
 
 .metron-control-column {
   display: grid;
   gap: 10px;
+  min-width: 0;
 }
 
 .permission-scopes {
@@ -481,6 +493,8 @@
 }
 
 .hourly-limit-field input {
+  width: 100%;
+  min-width: 0;
   min-height: 38px;
   border: 1px solid var(--line-strong);
   border-radius: 8px;

--- a/ui/src/styles/app-shell.css
+++ b/ui/src/styles/app-shell.css
@@ -494,10 +494,11 @@ h4 {
 }
 
 .content {
+  --content-padding: 28px;
   --sticky-toolbar-top: 0px;
   --sticky-toolbar-inline-offset: 28px;
-  --comic-list-sticky-top: 96px;
-  padding: 28px;
+  --comic-list-sticky-top: 82px;
+  padding: var(--content-padding);
   min-width: 0;
   width: 100%;
 }
@@ -543,7 +544,11 @@ h4 {
 }
 
 .toolbar.sticky-toolbar {
-  margin-top: calc(var(--sticky-toolbar-inline-offset) * -1);
+  margin-top: calc(var(--content-padding) * -1);
+}
+
+.detail-nav.sticky-toolbar {
+  margin-top: calc(var(--content-padding) * -1);
 }
 
 .sticky-toolbar,

--- a/ui/src/styles/responsive-mobile.css
+++ b/ui/src/styles/responsive-mobile.css
@@ -118,8 +118,9 @@
   }
 
   .content {
+    --content-padding: 14px;
     --sticky-toolbar-inline-offset: 14px;
-    padding: 14px;
+    padding: var(--content-padding);
   }
 
   .sticky-toolbar,
@@ -136,6 +137,10 @@
 
   .toolbar.sticky-toolbar {
     margin-top: 0;
+  }
+
+  .detail-nav.sticky-toolbar {
+    margin-top: calc(var(--content-padding) * -1);
   }
 
   .toolbar {

--- a/ui/src/styles/responsive-tablet.css
+++ b/ui/src/styles/responsive-tablet.css
@@ -119,12 +119,12 @@
   }
 
   .content {
+    --content-padding: 22px;
     max-width: none;
-    padding: 22px;
+    padding: var(--content-padding);
   }
 
   .toolbar.sticky-toolbar {
-    margin-top: -22px;
     margin-bottom: 0;
   }
 


### PR DESCRIPTION
## Summary
- remove the gap between the sticky page header and browse filters after scrolling
- align detail toolbars with the top content edge across desktop, tablet, and mobile layouts
- allow manage-user cards, nested grids, long account text, and form controls to shrink without horizontal mobile scrolling

## Verification
- npm run format
- npm run lint
- npm run test
- npm run build
- git diff --check