### PR TITLE
Organize app settings and add CBL repository imports

### DIFF
--- a/backend/internal/api/models_reading_orders.go
+++ b/backend/internal/api/models_reading_orders.go
@@ -100,7 +100,7 @@ type ReadingOrderCBLImportInput struct {
 	Body struct {
 		Filename string                      `json:"filename,omitempty" doc:"Original CBL filename, used as a fallback reading-order name for a single-file import." example:"Infinity Gauntlet.cbl"`
 		Content  string                      `json:"content,omitempty"  doc:"CBL XML document content for a single-file import."`
-		Parts    []ReadingOrderCBLImportPart `json:"parts,omitempty"    doc:"Two or more CBL part files that share a name ending in Part NN. Each part becomes a child of one grouped reading order."`
+		Parts    []ReadingOrderCBLImportPart `json:"parts,omitempty"    doc:"Two or more CBL part files that share a numbered Part or pt marker. All parts are combined into one reading order with a section per part."`
 	}
 }
 

--- a/backend/internal/api/readingorders_cbl.go
+++ b/backend/internal/api/readingorders_cbl.go
@@ -18,7 +18,7 @@ import (
 
 const cblNoLocalComicMatch = "no local comic matched"
 
-var cblPartSuffixPattern = regexp.MustCompile(`(?i)(?:\s*[-_]\s*|\s+)part\s*[-_]?\s*(\d+)\s*$`)
+var cblPartPattern = regexp.MustCompile(`(?i)(?:^|[\s._-])(?:part|pt)\s*[._-]?\s*0*(\d+)(?:[\s._-]|$)`)
 
 type cblReadingList struct {
 	XMLName   xml.Name  `xml:"ReadingList"`
@@ -56,6 +56,8 @@ type cblImportResult struct {
 	unmatchedCount int
 	unmatched      []ReadingOrderCBLUnmatchedBook
 }
+
+type cblMissingComicResolver func(context.Context, cblBook) (*Comic, error)
 
 func importReadingOrderCBL(ctx context.Context, db *sqlx.DB, input *ReadingOrderCBLImportInput) (*ReadingOrderCBLImportOutput, error) {
 	documents, err := parseCBLImportDocuments(input)
@@ -119,88 +121,78 @@ func parseCBLImportDocuments(input *ReadingOrderCBLImportInput) ([]cblImportDocu
 }
 
 func importMultipartReadingOrderCBL(ctx context.Context, db *sqlx.DB, documents []cblImportDocument) (*ReadingOrderCBLImportOutput, error) {
-	parentName, err := prepareMultipartCBLDocuments(documents)
+	name, err := prepareMultipartCBLDocuments(documents)
 	if err != nil {
 		return nil, err
 	}
+	result, err := importCombinedCBLDocuments(ctx, db, 0, name, documents)
+	if err != nil {
+		return nil, err
+	}
+	return cblImportOutput(result), nil
+}
 
-	createdOrderIDs := make([]int, 0, len(documents)+1)
-	complete := false
-	defer func() {
-		if !complete {
-			cleanupCBLReadingOrders(ctx, db, createdOrderIDs)
-		}
-	}()
+func importCombinedCBLDocuments(ctx context.Context, db *sqlx.DB, readingOrderID int, name string, documents []cblImportDocument) (cblImportResult, error) {
+	return importCombinedCBLDocumentsWithResolver(ctx, db, readingOrderID, name, documents, nil)
+}
 
-	entries := make([]ReadingOrderEntryPayload, 0, len(documents))
+func importCombinedCBLDocumentsWithResolver(ctx context.Context, db *sqlx.DB, readingOrderID int, name string, documents []cblImportDocument, resolveMissing cblMissingComicResolver) (cblImportResult, error) {
+	entries := make([]ReadingOrderEntryPayload, 0)
 	unmatched := make([]ReadingOrderCBLUnmatchedBook, 0)
 	matchedCount := 0
 	for _, document := range documents {
-		partResult, err := importCBLDocument(ctx, db, document)
+		entries = append(entries, ReadingOrderEntryPayload{Type: "section", Title: document.name})
+		partEntries, partUnmatched, err := cblDocumentEntriesWithResolver(ctx, db, document.list, resolveMissing)
 		if err != nil {
-			return nil, err
+			return cblImportResult{}, err
 		}
-		createdOrderIDs = append(createdOrderIDs, partResult.readingOrder.ID)
-		entries = append(entries, ReadingOrderEntryPayload{
-			Type:           "readingOrder",
-			ReadingOrderID: partResult.readingOrder.ID,
-		})
-		matchedCount += partResult.matchedCount
-		for _, book := range partResult.unmatched {
+		entries = append(entries, partEntries...)
+		matchedCount += len(partEntries)
+		for _, book := range partUnmatched {
 			book.Part = document.name
 			unmatched = append(unmatched, book)
 		}
 	}
 
-	parent, err := createReadingOrder(ctx, db, nil, ReadingOrderPayload{Name: parentName})
-	if err != nil {
-		return nil, err
-	}
-	createdOrderIDs = append(createdOrderIDs, parent.Body.ID)
-	setInput := &SetReadingOrderComicsInput{ID: parent.Body.ID}
-	setInput.Body.Entries = entries
-	detail, err := setReadingOrderComics(ctx, db, setInput)
-	if err != nil {
-		return nil, err
-	}
-
-	complete = true
-	return &ReadingOrderCBLImportOutput{Body: ReadingOrderCBLImportResult{
-		ReadingOrder:   detail.Body,
-		MatchedCount:   matchedCount,
-		UnmatchedCount: len(unmatched),
-		Unmatched:      unmatched,
-	}}, nil
-}
-
-func importCBLDocument(ctx context.Context, db *sqlx.DB, document cblImportDocument) (cblImportResult, error) {
-	cbl := document.list
-	name := document.name
-
-	entries := make([]ReadingOrderEntryPayload, 0, len(cbl.Books))
-	unmatched := make([]ReadingOrderCBLUnmatchedBook, 0)
-	for i, book := range cbl.Books {
-		comic, reason, err := matchCBLBook(ctx, db, book)
+	createdReadingOrder := readingOrderID == 0
+	if createdReadingOrder {
+		created, err := createReadingOrder(ctx, db, nil, ReadingOrderPayload{Name: name})
 		if err != nil {
 			return cblImportResult{}, err
 		}
-		if comic == nil && reason == cblNoLocalComicMatch {
-			comic, err = createComicFromCBLBook(ctx, db, book)
-			if err != nil {
-				return cblImportResult{}, err
-			}
-		}
-		if comic == nil {
-			unmatched = append(unmatched, cblUnmatchedBook(i+1, book, reason))
-			continue
-		}
-		entries = append(entries, ReadingOrderEntryPayload{
-			Type:    "comic",
-			ComicID: comic.ID,
-		})
+		readingOrderID = created.Body.ID
+	} else if _, err := db.ExecContext(ctx, `UPDATE reading_orders SET name = ? WHERE id = ?`, name, readingOrderID); err != nil {
+		return cblImportResult{}, huma.Error500InternalServerError("failed to update multipart CBL reading order")
 	}
 
-	created, err := createReadingOrder(ctx, db, nil, ReadingOrderPayload{Name: name})
+	setInput := &SetReadingOrderComicsInput{ID: readingOrderID}
+	setInput.Body.Entries = entries
+	detail, err := setReadingOrderComicsInternal(ctx, db, setInput)
+	if err != nil {
+		if createdReadingOrder {
+			cleanupCBLReadingOrders(ctx, db, []int{readingOrderID})
+		}
+		return cblImportResult{}, err
+	}
+	return cblImportResult{
+		readingOrder:   detail.Body,
+		matchedCount:   matchedCount,
+		unmatchedCount: len(unmatched),
+		unmatched:      unmatched,
+	}, nil
+}
+
+func importCBLDocument(ctx context.Context, db *sqlx.DB, document cblImportDocument) (cblImportResult, error) {
+	return importCBLDocumentWithResolver(ctx, db, document, nil)
+}
+
+func importCBLDocumentWithResolver(ctx context.Context, db *sqlx.DB, document cblImportDocument, resolveMissing cblMissingComicResolver) (cblImportResult, error) {
+	entries, unmatched, err := cblDocumentEntriesWithResolver(ctx, db, document.list, resolveMissing)
+	if err != nil {
+		return cblImportResult{}, err
+	}
+
+	created, err := createReadingOrder(ctx, db, nil, ReadingOrderPayload{Name: document.name})
 	if err != nil {
 		return cblImportResult{}, err
 	}
@@ -218,6 +210,70 @@ func importCBLDocument(ctx context.Context, db *sqlx.DB, document cblImportDocum
 		unmatchedCount: len(unmatched),
 		unmatched:      unmatched,
 	}, nil
+}
+
+func updateCBLDocument(ctx context.Context, db *sqlx.DB, readingOrderID int, document cblImportDocument) (cblImportResult, error) {
+	return updateCBLDocumentWithResolver(ctx, db, readingOrderID, document, nil)
+}
+
+func updateCBLDocumentWithResolver(ctx context.Context, db *sqlx.DB, readingOrderID int, document cblImportDocument, resolveMissing cblMissingComicResolver) (cblImportResult, error) {
+	entries, unmatched, err := cblDocumentEntriesWithResolver(ctx, db, document.list, resolveMissing)
+	if err != nil {
+		return cblImportResult{}, err
+	}
+	if _, err := db.ExecContext(ctx, `UPDATE reading_orders SET name = ? WHERE id = ?`, document.name, readingOrderID); err != nil {
+		return cblImportResult{}, huma.Error500InternalServerError("failed to update CBL reading order")
+	}
+	setInput := &SetReadingOrderComicsInput{ID: readingOrderID}
+	setInput.Body.Entries = entries
+	detail, err := setReadingOrderComicsInternal(ctx, db, setInput)
+	if err != nil {
+		return cblImportResult{}, err
+	}
+	return cblImportResult{
+		readingOrder:   detail.Body,
+		matchedCount:   len(entries),
+		unmatchedCount: len(unmatched),
+		unmatched:      unmatched,
+	}, nil
+}
+
+func cblDocumentEntries(ctx context.Context, db *sqlx.DB, cbl cblReadingList) ([]ReadingOrderEntryPayload, []ReadingOrderCBLUnmatchedBook, error) {
+	return cblDocumentEntriesWithResolver(ctx, db, cbl, nil)
+}
+
+func cblDocumentEntriesWithResolver(ctx context.Context, db *sqlx.DB, cbl cblReadingList, resolveMissing cblMissingComicResolver) ([]ReadingOrderEntryPayload, []ReadingOrderCBLUnmatchedBook, error) {
+	entries := make([]ReadingOrderEntryPayload, 0, len(cbl.Books))
+	unmatched := make([]ReadingOrderCBLUnmatchedBook, 0)
+	for i, book := range cbl.Books {
+		comic, reason, err := matchCBLBook(ctx, db, book)
+		if err != nil {
+			return nil, nil, err
+		}
+		if comic == nil && reason == cblNoLocalComicMatch {
+			if resolveMissing != nil {
+				comic, err = resolveMissing(ctx, book)
+				if err != nil {
+					return nil, nil, err
+				}
+			}
+		}
+		if comic == nil && reason == cblNoLocalComicMatch {
+			comic, err = createComicFromCBLBook(ctx, db, book)
+			if err != nil {
+				return nil, nil, err
+			}
+		}
+		if comic == nil {
+			unmatched = append(unmatched, cblUnmatchedBook(i+1, book, reason))
+			continue
+		}
+		entries = append(entries, ReadingOrderEntryPayload{
+			Type:    "comic",
+			ComicID: comic.ID,
+		})
+	}
+	return entries, unmatched, nil
 }
 
 func cblImportOutput(result cblImportResult) *ReadingOrderCBLImportOutput {
@@ -264,12 +320,12 @@ func prepareMultipartCBLDocuments(documents []cblImportDocument) (string, error)
 
 func cblMultipartPartName(name string) (string, int, bool) {
 	name = strings.TrimSpace(name)
-	matches := cblPartSuffixPattern.FindStringSubmatchIndex(name)
+	matches := cblPartPattern.FindStringSubmatchIndex(name)
 	if len(matches) < 4 {
 		return "", 0, false
 	}
 	part, ok := parseCBLPositiveInt(name[matches[2]:matches[3]])
-	base := strings.TrimSpace(name[:matches[0]])
+	base := strings.Trim(strings.TrimSpace(name[:matches[0]]), "-_. ")
 	return base, part, ok && base != ""
 }
 

--- a/backend/internal/api/readingorders_repository_sync.go
+++ b/backend/internal/api/readingorders_repository_sync.go
@@ -1,0 +1,1142 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/Lofter1/ComicHero/backend/internal/metron"
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/sse"
+	"github.com/jmoiron/sqlx"
+)
+
+const (
+	cblRepositorySettingsKey = "cbl_repository_sync_settings"
+	cblRepositoryLastRunKey  = "cbl_repository_sync_last_scheduled_date"
+	cblRepositoryMaxFileSize = 4 << 20
+)
+
+type CBLRepositorySyncSettings struct {
+	Enabled      bool     `json:"enabled" doc:"Whether repository imports can run."`
+	Repositories []string `json:"repositories" doc:"Public GitHub repository URLs containing CBL files."`
+	AutoSync     bool     `json:"autoSync" doc:"Whether repositories are checked on a schedule."`
+	Schedule     string   `json:"schedule" enum:"daily,weekly"`
+	Weekdays     []string `json:"weekdays,omitempty"`
+	StartTime    string   `json:"startTime" example:"04:00"`
+}
+
+type CBLRepositorySyncStatus struct {
+	Settings               CBLRepositorySyncSettings `json:"settings"`
+	Running                bool                      `json:"running"`
+	StartedAt              string                    `json:"startedAt,omitempty"`
+	FinishedAt             string                    `json:"finishedAt,omitempty"`
+	StopReason             string                    `json:"stopReason,omitempty"`
+	CurrentRepository      string                    `json:"currentRepository,omitempty"`
+	CurrentFile            string                    `json:"currentFile,omitempty"`
+	RepositoriesProcessed  int                       `json:"repositoriesProcessed"`
+	FilesFound             int                       `json:"filesFound"`
+	Imported               int                       `json:"imported"`
+	Updated                int                       `json:"updated"`
+	Unchanged              int                       `json:"unchanged"`
+	Failed                 int                       `json:"failed"`
+	LastError              string                    `json:"lastError,omitempty"`
+	ResolveMissingOnMetron bool                      `json:"resolveMissingOnMetron,omitempty"`
+	PendingResolution      *CBLMetronIssueResolution `json:"pendingResolution,omitempty"`
+}
+
+type CBLRepositorySyncEvent struct {
+	Sync CBLRepositorySyncStatus `json:"sync"`
+}
+
+type CBLRepositoryFile struct {
+	RepositoryURL  string `json:"repositoryUrl"`
+	Path           string `json:"path"`
+	Size           int64  `json:"size"`
+	MultipartGroup string `json:"multipartGroup,omitempty"`
+	Part           int    `json:"part,omitempty"`
+}
+
+type CBLRepositoryFileSelection struct {
+	RepositoryURL string `json:"repositoryUrl"`
+	Path          string `json:"path"`
+}
+
+type CBLMetronIssueCandidate struct {
+	ID          int    `json:"id"`
+	ComicVineID int    `json:"comicVineId,omitempty"`
+	Series      string `json:"series"`
+	SeriesYear  int    `json:"seriesYear,omitempty"`
+	Number      string `json:"number"`
+	Publisher   string `json:"publisher,omitempty"`
+	CoverDate   string `json:"coverDate,omitempty"`
+	CoverImage  string `json:"coverImage,omitempty"`
+}
+
+type CBLMetronIssueResolution struct {
+	ID          string                    `json:"id"`
+	Series      string                    `json:"series"`
+	Number      string                    `json:"number"`
+	Volume      string                    `json:"volume,omitempty"`
+	Year        string                    `json:"year,omitempty"`
+	ComicVineID int                       `json:"comicVineId,omitempty"`
+	Candidates  []CBLMetronIssueCandidate `json:"candidates"`
+}
+
+type cblMetronResolutionChoice struct {
+	ResolutionID  string
+	MetronIssueID int
+}
+
+type cblRepositorySyncer struct {
+	db           *sqlx.DB
+	metronClient *metron.Client
+	covers       *CoverCache
+	httpClient   *http.Client
+	apiBase      string
+	rawBase      string
+
+	mu                sync.Mutex
+	status            CBLRepositorySyncStatus
+	cancel            context.CancelFunc
+	wake              chan struct{}
+	shutdown          context.CancelFunc
+	nextSubscriberID  uint64
+	subscribers       map[uint64]chan CBLRepositorySyncStatus
+	resolutionChoices chan cblMetronResolutionChoice
+	nextResolutionID  uint64
+}
+
+type cblGitHubRepository struct {
+	URL   string
+	Owner string
+	Name  string
+}
+
+type cblGitHubFile struct {
+	Path string
+	SHA  string
+	Size int64
+	Part int
+}
+
+type cblRepositoryFileState struct {
+	RepositoryURL  string `db:"repository_url"`
+	FilePath       string `db:"file_path"`
+	ContentSHA     string `db:"content_sha"`
+	ReadingOrderID int    `db:"reading_order_id"`
+	GroupKey       string `db:"group_key"`
+}
+
+func NewCBLRepositorySyncer(db *sqlx.DB, metronClient *metron.Client, covers *CoverCache) *cblRepositorySyncer {
+	return &cblRepositorySyncer{
+		db:           db,
+		metronClient: metronClient,
+		covers:       covers,
+		httpClient:   &http.Client{Timeout: 60 * time.Second},
+		apiBase:      "https://api.github.com",
+		rawBase:      "https://raw.githubusercontent.com",
+		wake:         make(chan struct{}, 1),
+		subscribers:  map[uint64]chan CBLRepositorySyncStatus{},
+	}
+}
+
+func (s *cblRepositorySyncer) Start() {
+	ctx, cancel := context.WithCancel(context.Background())
+	s.shutdown = cancel
+	go s.scheduleLoop(ctx)
+}
+
+func (s *cblRepositorySyncer) Stop() {
+	if s.shutdown != nil {
+		s.shutdown()
+	}
+	s.stop("server stopped")
+}
+
+func defaultCBLRepositorySyncSettings() CBLRepositorySyncSettings {
+	return CBLRepositorySyncSettings{
+		Repositories: []string{"https://github.com/DieselTech/CBL-ReadingLists"},
+		Schedule:     "daily",
+		Weekdays:     []string{"monday"},
+		StartTime:    "04:00",
+	}
+}
+
+func loadCBLRepositorySyncSettings(ctx context.Context, db *sqlx.DB) (CBLRepositorySyncSettings, error) {
+	settings := defaultCBLRepositorySyncSettings()
+	var value string
+	if err := db.GetContext(ctx, &value, `SELECT value FROM app_settings WHERE key = ?`, cblRepositorySettingsKey); err != nil {
+		if err == sql.ErrNoRows {
+			return settings, nil
+		}
+		return settings, err
+	}
+	if err := json.Unmarshal([]byte(value), &settings); err != nil {
+		return settings, err
+	}
+	return settings, nil
+}
+
+func validateCBLRepositorySyncSettings(settings *CBLRepositorySyncSettings) error {
+	if settings == nil {
+		return errors.New("settings are required")
+	}
+	settings.Schedule = strings.ToLower(strings.TrimSpace(settings.Schedule))
+	if settings.Schedule != "daily" && settings.Schedule != "weekly" {
+		return errors.New("schedule must be daily or weekly")
+	}
+	if _, err := time.Parse("15:04", settings.StartTime); err != nil {
+		return errors.New("startTime must use HH:MM")
+	}
+	if len(settings.Repositories) == 0 {
+		return errors.New("at least one repository is required")
+	}
+	seenRepositories := map[string]bool{}
+	repositories := make([]string, 0, len(settings.Repositories))
+	for _, value := range settings.Repositories {
+		repository, err := parseCBLGitHubRepository(value)
+		if err != nil {
+			return err
+		}
+		key := strings.ToLower(repository.URL)
+		if !seenRepositories[key] {
+			seenRepositories[key] = true
+			repositories = append(repositories, repository.URL)
+		}
+	}
+	settings.Repositories = repositories
+	seenDays := map[string]bool{}
+	days := make([]string, 0, len(settings.Weekdays))
+	for _, value := range settings.Weekdays {
+		day := strings.ToLower(strings.TrimSpace(value))
+		if _, ok := weekdayNames[day]; !ok {
+			return fmt.Errorf("invalid weekday %q", day)
+		}
+		if !seenDays[day] {
+			seenDays[day] = true
+			days = append(days, day)
+		}
+	}
+	sort.Strings(days)
+	settings.Weekdays = days
+	if settings.AutoSync && settings.Schedule == "weekly" && len(days) == 0 {
+		return errors.New("weekly schedules need at least one weekday")
+	}
+	return nil
+}
+
+func parseCBLGitHubRepository(value string) (cblGitHubRepository, error) {
+	value = strings.TrimSpace(value)
+	parsed, err := url.Parse(value)
+	if err != nil || parsed.Scheme != "https" || !strings.EqualFold(parsed.Hostname(), "github.com") {
+		return cblGitHubRepository{}, fmt.Errorf("repository %q must be an https://github.com/owner/repository URL", value)
+	}
+	parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return cblGitHubRepository{}, fmt.Errorf("repository %q must identify one GitHub repository", value)
+	}
+	name := strings.TrimSuffix(parts[1], ".git")
+	if name == "" || strings.ContainsAny(parts[0]+name, "?#") {
+		return cblGitHubRepository{}, fmt.Errorf("repository %q is invalid", value)
+	}
+	return cblGitHubRepository{
+		URL:   "https://github.com/" + parts[0] + "/" + name,
+		Owner: parts[0],
+		Name:  name,
+	}, nil
+}
+
+func saveCBLRepositorySyncSettings(ctx context.Context, db *sqlx.DB, settings CBLRepositorySyncSettings) error {
+	value, err := json.Marshal(settings)
+	if err != nil {
+		return err
+	}
+	_, err = db.ExecContext(ctx, `INSERT INTO app_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`, cblRepositorySettingsKey, string(value))
+	return err
+}
+
+func (s *cblRepositorySyncer) scheduleLoop(ctx context.Context) {
+	ticker := time.NewTicker(15 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.checkSchedule(ctx, time.Now())
+		case <-s.wake:
+			s.checkSchedule(ctx, time.Now())
+		}
+	}
+}
+
+func (s *cblRepositorySyncer) checkSchedule(ctx context.Context, now time.Time) {
+	settings, err := loadCBLRepositorySyncSettings(ctx, s.db)
+	if err != nil || !settings.Enabled || !settings.AutoSync || now.Format("15:04") != settings.StartTime {
+		return
+	}
+	if settings.Schedule == "weekly" {
+		matches := false
+		for _, day := range settings.Weekdays {
+			matches = matches || weekdayNames[day] == now.Weekday()
+		}
+		if !matches {
+			return
+		}
+	}
+	date := now.Format("2006-01-02")
+	var last string
+	_ = s.db.GetContext(ctx, &last, `SELECT value FROM app_settings WHERE key = ?`, cblRepositoryLastRunKey)
+	if last == date || s.trigger("scheduled", nil, false) != nil {
+		return
+	}
+	_, _ = s.db.ExecContext(ctx, `INSERT INTO app_settings (key, value) VALUES (?, ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value`, cblRepositoryLastRunKey, date)
+}
+
+func (s *cblRepositorySyncer) trigger(reason string, selections []CBLRepositoryFileSelection, resolveMissingOnMetron bool) error {
+	settings, err := loadCBLRepositorySyncSettings(context.Background(), s.db)
+	if err != nil {
+		return err
+	}
+	if !settings.Enabled {
+		return errors.New("CBL repository importing is disabled")
+	}
+	selectedFiles, err := selectedCBLRepositoryFiles(settings, selections)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	if s.status.Running {
+		s.mu.Unlock()
+		return errors.New("CBL repository import is already running")
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	s.cancel = cancel
+	s.resolutionChoices = make(chan cblMetronResolutionChoice, 1)
+	s.status = CBLRepositorySyncStatus{
+		Settings:               settings,
+		Running:                true,
+		StartedAt:              currentTimestamp(),
+		StopReason:             reason,
+		ResolveMissingOnMetron: resolveMissingOnMetron,
+	}
+	s.mu.Unlock()
+	s.broadcast()
+	go s.run(ctx, settings, selectedFiles, resolveMissingOnMetron)
+	return nil
+}
+
+func selectedCBLRepositoryFiles(settings CBLRepositorySyncSettings, selections []CBLRepositoryFileSelection) (map[string]map[string]bool, error) {
+	if len(selections) == 0 {
+		return nil, nil
+	}
+	configured := map[string]string{}
+	for _, value := range settings.Repositories {
+		repository, err := parseCBLGitHubRepository(value)
+		if err != nil {
+			return nil, err
+		}
+		configured[strings.ToLower(repository.URL)] = repository.URL
+	}
+	selected := map[string]map[string]bool{}
+	for _, selection := range selections {
+		repository, err := parseCBLGitHubRepository(selection.RepositoryURL)
+		if err != nil {
+			return nil, err
+		}
+		configuredURL, ok := configured[strings.ToLower(repository.URL)]
+		if !ok {
+			return nil, fmt.Errorf("repository %q is not configured", repository.URL)
+		}
+		filePath := strings.TrimSpace(selection.Path)
+		if filePath == "" || !strings.EqualFold(path.Ext(filePath), ".cbl") {
+			return nil, fmt.Errorf("selected path %q is not a CBL file", filePath)
+		}
+		if selected[configuredURL] == nil {
+			selected[configuredURL] = map[string]bool{}
+		}
+		selected[configuredURL][filePath] = true
+	}
+	return selected, nil
+}
+
+func (s *cblRepositorySyncer) stop(reason string) bool {
+	s.mu.Lock()
+	if !s.status.Running || s.cancel == nil {
+		s.mu.Unlock()
+		return false
+	}
+	s.status.StopReason = reason
+	s.cancel()
+	s.mu.Unlock()
+	s.broadcast()
+	return true
+}
+
+func (s *cblRepositorySyncer) run(ctx context.Context, settings CBLRepositorySyncSettings, selectedFiles map[string]map[string]bool, resolveMissingOnMetron bool) {
+	userID, err := ensureDefaultUser(ctx, s.db)
+	if err == nil {
+		ctx = context.WithValue(ctx, contextUserIDKey{}, userID)
+		resolveMissing := cblMissingComicResolver(nil)
+		if resolveMissingOnMetron {
+			resolveMissing = s.resolveMissingComicFromMetron
+		}
+		for _, value := range settings.Repositories {
+			if ctx.Err() != nil {
+				break
+			}
+			repository, parseErr := parseCBLGitHubRepository(value)
+			if parseErr != nil {
+				s.recordFailure(parseErr)
+				continue
+			}
+			selection := selectedFiles[repository.URL]
+			if selectedFiles != nil && len(selection) == 0 {
+				continue
+			}
+			s.update(func(status *CBLRepositorySyncStatus) {
+				status.CurrentRepository = repository.URL
+				status.CurrentFile = ""
+			})
+			if syncErr := s.syncRepositoryWithResolver(ctx, repository, selection, resolveMissing); syncErr != nil {
+				s.recordFailure(syncErr)
+			}
+			s.update(func(status *CBLRepositorySyncStatus) { status.RepositoriesProcessed++ })
+		}
+	}
+	if err != nil {
+		s.recordFailure(err)
+	}
+	s.mu.Lock()
+	s.status.Running = false
+	s.status.FinishedAt = currentTimestamp()
+	s.status.CurrentRepository = ""
+	s.status.CurrentFile = ""
+	s.status.PendingResolution = nil
+	if ctx.Err() != nil {
+		if s.status.StopReason == "manual" || s.status.StopReason == "scheduled" {
+			s.status.StopReason = "stopped"
+		}
+	} else if s.status.Failed > 0 {
+		s.status.StopReason = "complete with errors"
+	} else {
+		s.status.StopReason = "complete"
+	}
+	s.cancel = nil
+	s.resolutionChoices = nil
+	s.mu.Unlock()
+	s.broadcast()
+}
+
+func (s *cblRepositorySyncer) syncRepository(ctx context.Context, repository cblGitHubRepository, selectedPaths map[string]bool) error {
+	return s.syncRepositoryWithResolver(ctx, repository, selectedPaths, nil)
+}
+
+func (s *cblRepositorySyncer) syncRepositoryWithResolver(ctx context.Context, repository cblGitHubRepository, selectedPaths map[string]bool, resolveMissing cblMissingComicResolver) error {
+	branch, files, err := s.listRepositoryFiles(ctx, repository)
+	if err != nil {
+		return err
+	}
+	states, err := s.repositoryFileStates(ctx, repository.URL)
+	if err != nil {
+		return err
+	}
+	selectedPaths = expandManagedMultipartSelections(files, selectedPaths, states)
+	files, err = selectedRepositoryFiles(files, selectedPaths, repository.URL)
+	if err != nil {
+		return err
+	}
+	s.update(func(status *CBLRepositorySyncStatus) { status.FilesFound += len(files) })
+
+	groups := map[string][]cblGitHubFile{}
+	parentNames := map[string]string{}
+	singles := make([]cblGitHubFile, 0)
+	for _, file := range files {
+		groupKey, parentName, partNumber, ok := cblRepositoryPart(file.Path)
+		if !ok {
+			singles = append(singles, file)
+			continue
+		}
+		file.Part = partNumber
+		groups[groupKey] = append(groups[groupKey], file)
+		parentNames[groupKey] = parentName
+	}
+	for key, group := range groups {
+		if len(group) < 2 {
+			singles = append(singles, group...)
+			delete(groups, key)
+		}
+	}
+	sort.Slice(singles, func(i, j int) bool { return strings.ToLower(singles[i].Path) < strings.ToLower(singles[j].Path) })
+	for _, file := range singles {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		s.syncSingleFile(ctx, repository, branch, file, states[file.Path], resolveMissing)
+	}
+	groupKeys := make([]string, 0, len(groups))
+	for key := range groups {
+		groupKeys = append(groupKeys, key)
+	}
+	sort.Strings(groupKeys)
+	for _, key := range groupKeys {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		group := groups[key]
+		sort.SliceStable(group, func(i, j int) bool {
+			if group[i].Part != group[j].Part {
+				return group[i].Part < group[j].Part
+			}
+			return strings.ToLower(group[i].Path) < strings.ToLower(group[j].Path)
+		})
+		s.syncMultipartGroup(ctx, repository, branch, key, parentNames[key], group, states, resolveMissing)
+	}
+	return nil
+}
+
+func expandManagedMultipartSelections(files []cblGitHubFile, selectedPaths map[string]bool, states map[string]cblRepositoryFileState) map[string]bool {
+	if selectedPaths == nil {
+		return nil
+	}
+	expanded := make(map[string]bool, len(selectedPaths))
+	for filePath := range selectedPaths {
+		expanded[filePath] = true
+		groupKey := states[filePath].GroupKey
+		if groupKey == "" {
+			continue
+		}
+		for _, file := range files {
+			if candidateKey, _, _, ok := cblRepositoryPart(file.Path); ok && candidateKey == groupKey {
+				expanded[file.Path] = true
+			}
+		}
+	}
+	return expanded
+}
+
+func selectedRepositoryFiles(files []cblGitHubFile, selectedPaths map[string]bool, repositoryURL string) ([]cblGitHubFile, error) {
+	if selectedPaths == nil {
+		return files, nil
+	}
+	available := make(map[string]cblGitHubFile, len(files))
+	for _, file := range files {
+		available[file.Path] = file
+	}
+	selected := make([]cblGitHubFile, 0, len(selectedPaths))
+	for filePath := range selectedPaths {
+		file, ok := available[filePath]
+		if !ok {
+			return nil, fmt.Errorf("selected CBL file %q was not found in %s", filePath, repositoryURL)
+		}
+		selected = append(selected, file)
+	}
+	return selected, nil
+}
+
+func (s *cblRepositorySyncer) syncSingleFile(ctx context.Context, repository cblGitHubRepository, branch string, file cblGitHubFile, state cblRepositoryFileState, resolveMissing cblMissingComicResolver) {
+	s.setCurrentFile(file.Path)
+	if state.ReadingOrderID > 0 && state.ContentSHA == file.SHA {
+		s.increment("unchanged")
+		return
+	}
+	document, err := s.fetchCBLDocument(ctx, repository, branch, file.Path)
+	if err != nil {
+		s.recordFailure(err)
+		return
+	}
+	readingOrderID := state.ReadingOrderID
+	if readingOrderID > 0 {
+		if _, err = updateCBLDocumentWithResolver(ctx, s.db, readingOrderID, document, resolveMissing); err == nil {
+			s.increment("updated")
+		}
+	} else {
+		var result cblImportResult
+		result, err = importCBLDocumentWithResolver(ctx, s.db, document, resolveMissing)
+		if err == nil {
+			readingOrderID = result.readingOrder.ID
+			s.increment("imported")
+		}
+	}
+	if err != nil {
+		s.recordFailure(fmt.Errorf("%s: %w", file.Path, err))
+		return
+	}
+	if err := s.saveRepositoryFileState(ctx, repository.URL, file, readingOrderID, state.GroupKey); err != nil {
+		s.recordFailure(err)
+	}
+}
+
+func (s *cblRepositorySyncer) syncMultipartGroup(ctx context.Context, repository cblGitHubRepository, branch, groupKey, parentName string, files []cblGitHubFile, states map[string]cblRepositoryFileState, resolveMissing cblMissingComicResolver) {
+	readingOrderID := 0
+	changed := false
+	legacyOrderIDs := map[int]bool{}
+	for _, file := range files {
+		state := states[file.Path]
+		if readingOrderID == 0 && state.ReadingOrderID > 0 {
+			readingOrderID = state.ReadingOrderID
+		}
+		if state.ReadingOrderID > 0 {
+			legacyOrderIDs[state.ReadingOrderID] = true
+		}
+		if state.ReadingOrderID == 0 || state.ContentSHA != file.SHA {
+			changed = true
+		}
+	}
+	if readingOrderID > 0 {
+		for _, file := range files {
+			if states[file.Path].ReadingOrderID != readingOrderID || states[file.Path].GroupKey != groupKey {
+				changed = true
+				break
+			}
+		}
+	}
+	if !changed && readingOrderID > 0 {
+		for range files {
+			s.increment("unchanged")
+		}
+		return
+	}
+
+	documents := make([]cblImportDocument, 0, len(files))
+	for _, file := range files {
+		if ctx.Err() != nil {
+			return
+		}
+		s.setCurrentFile(file.Path)
+		document, err := s.fetchCBLDocument(ctx, repository, branch, file.Path)
+		if err != nil {
+			s.recordFailure(fmt.Errorf("%s: %w", file.Path, err))
+			return
+		}
+		documents = append(documents, document)
+	}
+	result, err := importCombinedCBLDocumentsWithResolver(ctx, s.db, readingOrderID, parentName, documents, resolveMissing)
+	if err != nil {
+		s.recordFailure(err)
+		return
+	}
+	if readingOrderID == 0 {
+		s.increment("imported")
+	} else {
+		s.increment("updated")
+	}
+	readingOrderID = result.readingOrder.ID
+	for _, file := range files {
+		if err := s.saveRepositoryFileState(ctx, repository.URL, file, readingOrderID, groupKey); err != nil {
+			s.recordFailure(err)
+		}
+	}
+	for legacyID := range legacyOrderIDs {
+		if legacyID == readingOrderID {
+			continue
+		}
+		cleanupCBLReadingOrders(ctx, s.db, []int{legacyID})
+	}
+}
+
+func (s *cblRepositorySyncer) resolveMissingComicFromMetron(ctx context.Context, book cblBook) (*Comic, error) {
+	if s.metronClient == nil {
+		return nil, errors.New("Metron is not configured")
+	}
+
+	var candidates []metron.Issue
+	comicVineID, hasComicVineID := cblComicVineID(book)
+	var err error
+	if hasComicVineID {
+		candidates, err = s.metronClient.SearchIssuesByComicVineID(ctx, comicVineID)
+		if err != nil {
+			return nil, fmt.Errorf("search Metron by Comic Vine ID %d: %w", comicVineID, err)
+		}
+	}
+	if len(candidates) == 0 {
+		series := strings.TrimSpace(book.Series)
+		number := strings.TrimSpace(book.Number)
+		if series == "" || number == "" {
+			return nil, nil
+		}
+		candidates, err = s.metronClient.SearchIssues(ctx, "", series, number)
+		if err != nil {
+			return nil, fmt.Errorf("search Metron for %s #%s: %w", series, number, err)
+		}
+	}
+	candidates = uniqueMetronIssueCandidates(candidates)
+	if len(candidates) == 0 {
+		return nil, nil
+	}
+
+	selected := candidates[0]
+	if len(candidates) > 1 {
+		selected, err = s.waitForMetronIssueResolution(ctx, book, comicVineID, candidates)
+		if err != nil {
+			return nil, err
+		}
+		if selected.ID == 0 {
+			return nil, nil
+		}
+	}
+
+	detail, err := s.metronClient.GetIssue(ctx, selected.ID)
+	if err != nil {
+		return nil, fmt.Errorf("load Metron issue %d: %w", selected.ID, err)
+	}
+	output, err := importMetronComicWithOptions(ctx, s.db, s.metronClient, s.covers, *detail, MetronImportOptions{Mode: "quick"})
+	if err != nil {
+		return nil, err
+	}
+	comic := output.Body.Comic
+	return &comic, nil
+}
+
+func uniqueMetronIssueCandidates(issues []metron.Issue) []metron.Issue {
+	seen := map[int]bool{}
+	unique := make([]metron.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if issue.ID <= 0 || seen[issue.ID] {
+			continue
+		}
+		seen[issue.ID] = true
+		unique = append(unique, issue)
+	}
+	return unique
+}
+
+func (s *cblRepositorySyncer) waitForMetronIssueResolution(ctx context.Context, book cblBook, comicVineID int, candidates []metron.Issue) (metron.Issue, error) {
+	byID := make(map[int]metron.Issue, len(candidates))
+	items := make([]CBLMetronIssueCandidate, 0, len(candidates))
+	for _, issue := range candidates {
+		byID[issue.ID] = issue
+		number := issue.Issue
+		if number == "" {
+			number = issue.Number
+		}
+		items = append(items, CBLMetronIssueCandidate{
+			ID:          issue.ID,
+			ComicVineID: issue.ComicVineID,
+			Series:      issue.Series,
+			SeriesYear:  issue.SeriesYear,
+			Number:      number,
+			Publisher:   issue.Publisher,
+			CoverDate:   issue.CoverDate,
+			CoverImage:  issue.CoverImage,
+		})
+	}
+
+	s.mu.Lock()
+	s.nextResolutionID++
+	resolutionID := fmt.Sprintf("cbl-metron-%d", s.nextResolutionID)
+	choices := s.resolutionChoices
+	s.status.PendingResolution = &CBLMetronIssueResolution{
+		ID:          resolutionID,
+		Series:      strings.TrimSpace(book.Series),
+		Number:      strings.TrimSpace(book.Number),
+		Volume:      strings.TrimSpace(book.Volume),
+		Year:        strings.TrimSpace(book.Year),
+		ComicVineID: comicVineID,
+		Candidates:  items,
+	}
+	s.mu.Unlock()
+	s.broadcast()
+	if choices == nil {
+		return metron.Issue{}, errors.New("Metron issue selection is unavailable")
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return metron.Issue{}, ctx.Err()
+		case choice := <-choices:
+			if choice.ResolutionID != resolutionID {
+				continue
+			}
+			if choice.MetronIssueID == 0 {
+				return metron.Issue{}, nil
+			}
+			issue, ok := byID[choice.MetronIssueID]
+			if !ok {
+				return metron.Issue{}, errors.New("selected Metron issue is not a candidate")
+			}
+			return issue, nil
+		}
+	}
+}
+
+func (s *cblRepositorySyncer) resolveMetronIssue(resolutionID string, metronIssueID int) error {
+	s.mu.Lock()
+	if !s.status.Running || s.status.PendingResolution == nil || s.status.PendingResolution.ID != resolutionID {
+		s.mu.Unlock()
+		return errors.New("Metron issue selection is no longer pending")
+	}
+	if metronIssueID != 0 {
+		valid := false
+		for _, candidate := range s.status.PendingResolution.Candidates {
+			valid = valid || candidate.ID == metronIssueID
+		}
+		if !valid {
+			s.mu.Unlock()
+			return errors.New("selected Metron issue is not a candidate")
+		}
+	}
+	choices := s.resolutionChoices
+	s.status.PendingResolution = nil
+	s.mu.Unlock()
+	if choices == nil {
+		return errors.New("Metron issue selection is no longer pending")
+	}
+	choices <- cblMetronResolutionChoice{ResolutionID: resolutionID, MetronIssueID: metronIssueID}
+	s.broadcast()
+	return nil
+}
+
+func cblRepositoryPart(filePath string) (string, string, int, bool) {
+	stem := strings.TrimSuffix(path.Base(filePath), path.Ext(filePath))
+	parentName, partNumber, ok := cblMultipartPartName(stem)
+	if !ok {
+		return "", "", 0, false
+	}
+	directory := strings.ToLower(path.Dir(filePath))
+	keyName := strings.ToLower(strings.Join(strings.Fields(parentName), " "))
+	return directory + "/" + keyName, parentName, partNumber, true
+}
+
+func (s *cblRepositorySyncer) listRepositoryFiles(ctx context.Context, repository cblGitHubRepository) (string, []cblGitHubFile, error) {
+	var metadata struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := s.getJSON(ctx, s.apiBase+"/repos/"+url.PathEscape(repository.Owner)+"/"+url.PathEscape(repository.Name), &metadata); err != nil {
+		return "", nil, fmt.Errorf("read %s metadata: %w", repository.URL, err)
+	}
+	if metadata.DefaultBranch == "" {
+		return "", nil, errors.New("repository has no default branch")
+	}
+	var tree struct {
+		Truncated bool `json:"truncated"`
+		Tree      []struct {
+			Path string `json:"path"`
+			Type string `json:"type"`
+			SHA  string `json:"sha"`
+			Size int64  `json:"size"`
+		} `json:"tree"`
+	}
+	treeURL := s.apiBase + "/repos/" + url.PathEscape(repository.Owner) + "/" + url.PathEscape(repository.Name) + "/git/trees/" + url.PathEscape(metadata.DefaultBranch) + "?recursive=1"
+	if err := s.getJSON(ctx, treeURL, &tree); err != nil {
+		return "", nil, fmt.Errorf("read %s tree: %w", repository.URL, err)
+	}
+	if tree.Truncated {
+		return "", nil, errors.New("GitHub returned a truncated repository tree")
+	}
+	files := make([]cblGitHubFile, 0)
+	for _, item := range tree.Tree {
+		if item.Type == "blob" && strings.EqualFold(path.Ext(item.Path), ".cbl") && item.Size <= cblRepositoryMaxFileSize {
+			files = append(files, cblGitHubFile{Path: item.Path, SHA: item.SHA, Size: item.Size})
+		}
+	}
+	return metadata.DefaultBranch, files, nil
+}
+
+func (s *cblRepositorySyncer) availableRepositoryFiles(ctx context.Context, settings CBLRepositorySyncSettings) ([]CBLRepositoryFile, error) {
+	available := make([]CBLRepositoryFile, 0)
+	for _, value := range settings.Repositories {
+		repository, err := parseCBLGitHubRepository(value)
+		if err != nil {
+			return nil, err
+		}
+		_, files, err := s.listRepositoryFiles(ctx, repository)
+		if err != nil {
+			return nil, err
+		}
+		groupCounts := map[string]int{}
+		for _, file := range files {
+			if groupKey, _, _, ok := cblRepositoryPart(file.Path); ok {
+				groupCounts[groupKey]++
+			}
+		}
+		for _, file := range files {
+			item := CBLRepositoryFile{RepositoryURL: repository.URL, Path: file.Path, Size: file.Size}
+			if groupKey, parentName, partNumber, ok := cblRepositoryPart(file.Path); ok && groupCounts[groupKey] > 1 {
+				item.MultipartGroup = parentName
+				item.Part = partNumber
+			}
+			available = append(available, item)
+		}
+	}
+	sort.Slice(available, func(i, j int) bool {
+		if available[i].RepositoryURL != available[j].RepositoryURL {
+			return strings.ToLower(available[i].RepositoryURL) < strings.ToLower(available[j].RepositoryURL)
+		}
+		return strings.ToLower(available[i].Path) < strings.ToLower(available[j].Path)
+	})
+	return available, nil
+}
+
+func (s *cblRepositorySyncer) getJSON(ctx context.Context, target string, output any) error {
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, target, nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("User-Agent", "ComicHero-CBL-Importer")
+	response, err := s.httpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return fmt.Errorf("GitHub returned %s", response.Status)
+	}
+	return json.NewDecoder(io.LimitReader(response.Body, 16<<20)).Decode(output)
+}
+
+func (s *cblRepositorySyncer) fetchCBLDocument(ctx context.Context, repository cblGitHubRepository, branch, filePath string) (cblImportDocument, error) {
+	target, err := url.Parse(s.rawBase)
+	if err != nil {
+		return cblImportDocument{}, err
+	}
+	target.Path = path.Join(target.Path, repository.Owner, repository.Name, branch, filePath)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, target.String(), nil)
+	if err != nil {
+		return cblImportDocument{}, err
+	}
+	request.Header.Set("User-Agent", "ComicHero-CBL-Importer")
+	response, err := s.httpClient.Do(request)
+	if err != nil {
+		return cblImportDocument{}, fmt.Errorf("download %s: %w", filePath, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return cblImportDocument{}, fmt.Errorf("download %s: GitHub returned %s", filePath, response.Status)
+	}
+	content, err := io.ReadAll(io.LimitReader(response.Body, cblRepositoryMaxFileSize+1))
+	if err != nil {
+		return cblImportDocument{}, err
+	}
+	if len(content) > cblRepositoryMaxFileSize {
+		return cblImportDocument{}, fmt.Errorf("%s exceeds the CBL file size limit", filePath)
+	}
+	input := &ReadingOrderCBLImportInput{}
+	input.Body.Filename = filePath
+	input.Body.Content = string(content)
+	documents, err := parseCBLImportDocuments(input)
+	if err != nil {
+		return cblImportDocument{}, err
+	}
+	return documents[0], nil
+}
+
+func (s *cblRepositorySyncer) repositoryFileStates(ctx context.Context, repositoryURL string) (map[string]cblRepositoryFileState, error) {
+	rows := []cblRepositoryFileState{}
+	if err := s.db.SelectContext(ctx, &rows, `SELECT repository_url, file_path, content_sha, reading_order_id, group_key FROM cbl_repository_files WHERE repository_url = ?`, repositoryURL); err != nil {
+		return nil, err
+	}
+	states := make(map[string]cblRepositoryFileState, len(rows))
+	for _, row := range rows {
+		states[row.FilePath] = row
+	}
+	return states, nil
+}
+
+func (s *cblRepositorySyncer) saveRepositoryFileState(ctx context.Context, repositoryURL string, file cblGitHubFile, readingOrderID int, groupKey string) error {
+	_, err := s.db.ExecContext(ctx, `
+		INSERT INTO cbl_repository_files (repository_url, file_path, content_sha, reading_order_id, group_key, imported_at)
+		VALUES (?, ?, ?, ?, ?, ?)
+		ON CONFLICT(repository_url, file_path) DO UPDATE SET
+			content_sha = excluded.content_sha,
+			reading_order_id = excluded.reading_order_id,
+			group_key = excluded.group_key,
+			imported_at = excluded.imported_at
+	`, repositoryURL, file.Path, file.SHA, readingOrderID, groupKey, currentTimestamp())
+	return err
+}
+
+func (s *cblRepositorySyncer) setCurrentFile(file string) {
+	s.update(func(status *CBLRepositorySyncStatus) { status.CurrentFile = file })
+}
+
+func (s *cblRepositorySyncer) increment(kind string) {
+	s.update(func(status *CBLRepositorySyncStatus) {
+		switch kind {
+		case "imported":
+			status.Imported++
+		case "updated":
+			status.Updated++
+		default:
+			status.Unchanged++
+		}
+	})
+}
+
+func (s *cblRepositorySyncer) recordFailure(err error) {
+	if err == nil {
+		return
+	}
+	s.update(func(status *CBLRepositorySyncStatus) {
+		status.Failed++
+		status.LastError = err.Error()
+	})
+}
+
+func (s *cblRepositorySyncer) update(change func(*CBLRepositorySyncStatus)) {
+	s.mu.Lock()
+	change(&s.status)
+	s.mu.Unlock()
+	s.broadcast()
+}
+
+func (s *cblRepositorySyncer) snapshot(ctx context.Context) CBLRepositorySyncStatus {
+	settings, _ := loadCBLRepositorySyncSettings(ctx, s.db)
+	s.mu.Lock()
+	status := s.status
+	s.mu.Unlock()
+	status.Settings = settings
+	return status
+}
+
+func (s *cblRepositorySyncer) subscribe(ctx context.Context) (<-chan CBLRepositorySyncStatus, func()) {
+	s.mu.Lock()
+	s.nextSubscriberID++
+	id := s.nextSubscriberID
+	updates := make(chan CBLRepositorySyncStatus, 16)
+	s.subscribers[id] = updates
+	s.mu.Unlock()
+	updates <- s.snapshot(ctx)
+	return updates, func() {
+		s.mu.Lock()
+		if current, ok := s.subscribers[id]; ok {
+			delete(s.subscribers, id)
+			close(current)
+		}
+		s.mu.Unlock()
+	}
+}
+
+func (s *cblRepositorySyncer) broadcast() {
+	status := s.snapshot(context.Background())
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, updates := range s.subscribers {
+		select {
+		case updates <- status:
+		default:
+			select {
+			case <-updates:
+			default:
+			}
+			select {
+			case updates <- status:
+			default:
+			}
+		}
+	}
+}
+
+type CBLRepositorySyncStatusOutput struct{ Body CBLRepositorySyncStatus }
+type UpdateCBLRepositorySyncSettingsInput struct{ Body CBLRepositorySyncSettings }
+type CBLRepositoryFilesOutput struct{ Body []CBLRepositoryFile }
+type TriggerCBLRepositorySyncInput struct {
+	Body struct {
+		Files                  []CBLRepositoryFileSelection `json:"files,omitempty"`
+		ResolveMissingOnMetron bool                         `json:"resolveMissingOnMetron,omitempty"`
+	}
+}
+type ResolveCBLMetronIssueInput struct {
+	Body struct {
+		ResolutionID  string `json:"resolutionId" minLength:"1"`
+		MetronIssueID int    `json:"metronIssueId" minimum:"0"`
+	}
+}
+
+func RegisterCBLRepositorySyncRoutes(api huma.API, db *sqlx.DB, syncer *cblRepositorySyncer) {
+	huma.Register(api, huma.Operation{OperationID: "getCBLRepositorySync", Tags: []string{tagReadingOrders}, Summary: "Get CBL repository sync settings and status", Method: http.MethodGet, Path: "/readingOrders/repository-sync", Errors: []int{401, 403, 500}}, func(ctx context.Context, _ *struct{}) (*CBLRepositorySyncStatusOutput, error) {
+		if _, err := requireAdminUser(ctx, db); err != nil {
+			return nil, err
+		}
+		return &CBLRepositorySyncStatusOutput{Body: syncer.snapshot(ctx)}, nil
+	})
+	sse.Register(api, huma.Operation{OperationID: "streamCBLRepositorySync", Tags: []string{tagReadingOrders}, Summary: "Stream CBL repository sync status", Method: http.MethodGet, Path: "/readingOrders/repository-sync/events", Errors: []int{401, 403, 500}}, map[string]any{"sync": CBLRepositorySyncEvent{}}, func(ctx context.Context, _ *struct{}, send sse.Sender) {
+		if _, err := requireAdminUser(ctx, db); err != nil {
+			return
+		}
+		updates, unsubscribe := syncer.subscribe(ctx)
+		defer unsubscribe()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case status, ok := <-updates:
+				if !ok || send.Data(CBLRepositorySyncEvent{Sync: status}) != nil {
+					return
+				}
+			}
+		}
+	})
+	huma.Register(api, huma.Operation{OperationID: "updateCBLRepositorySync", Tags: []string{tagReadingOrders}, Summary: "Update CBL repository sync settings", Method: http.MethodPut, Path: "/readingOrders/repository-sync", Errors: []int{400, 401, 403, 500}}, func(ctx context.Context, input *UpdateCBLRepositorySyncSettingsInput) (*CBLRepositorySyncStatusOutput, error) {
+		if _, err := requireAdminUser(ctx, db); err != nil {
+			return nil, err
+		}
+		if err := validateCBLRepositorySyncSettings(&input.Body); err != nil {
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		if err := saveCBLRepositorySyncSettings(ctx, db, input.Body); err != nil {
+			return nil, huma.Error500InternalServerError("failed to save CBL repository settings")
+		}
+		select {
+		case syncer.wake <- struct{}{}:
+		default:
+		}
+		syncer.broadcast()
+		return &CBLRepositorySyncStatusOutput{Body: syncer.snapshot(ctx)}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "listCBLRepositoryFiles", Tags: []string{tagReadingOrders}, Summary: "List available repository CBL files", Method: http.MethodGet, Path: "/readingOrders/repository-sync/files", Errors: []int{401, 403, 500}}, func(ctx context.Context, _ *struct{}) (*CBLRepositoryFilesOutput, error) {
+		if _, err := requireAdminUser(ctx, db); err != nil {
+			return nil, err
+		}
+		settings, err := loadCBLRepositorySyncSettings(ctx, db)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to load CBL repository settings")
+		}
+		files, err := syncer.availableRepositoryFiles(ctx, settings)
+		if err != nil {
+			return nil, huma.Error500InternalServerError(err.Error())
+		}
+		return &CBLRepositoryFilesOutput{Body: files}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "triggerCBLRepositorySync", Tags: []string{tagReadingOrders}, Summary: "Import all or selected CBL repository files", Method: http.MethodPost, Path: "/readingOrders/repository-sync/trigger", DefaultStatus: http.StatusAccepted, Errors: []int{400, 401, 403, 409, 500}}, func(ctx context.Context, input *TriggerCBLRepositorySyncInput) (*CBLRepositorySyncStatusOutput, error) {
+		if _, err := requireAdminUser(ctx, db); err != nil {
+			return nil, err
+		}
+		if err := syncer.trigger("manual", input.Body.Files, input.Body.ResolveMissingOnMetron); err != nil {
+			if strings.Contains(err.Error(), "already running") {
+				return nil, huma.Error409Conflict(err.Error())
+			}
+			return nil, huma.Error400BadRequest(err.Error())
+		}
+		return &CBLRepositorySyncStatusOutput{Body: syncer.snapshot(ctx)}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "resolveCBLRepositoryMetronIssue", Tags: []string{tagReadingOrders}, Summary: "Choose a Metron issue for an ambiguous CBL book", Method: http.MethodPost, Path: "/readingOrders/repository-sync/resolve", Errors: []int{400, 401, 403, 409, 500}}, func(ctx context.Context, input *ResolveCBLMetronIssueInput) (*CBLRepositorySyncStatusOutput, error) {
+		if _, err := requireAdminUser(ctx, db); err != nil {
+			return nil, err
+		}
+		if err := syncer.resolveMetronIssue(strings.TrimSpace(input.Body.ResolutionID), input.Body.MetronIssueID); err != nil {
+			return nil, huma.Error409Conflict(err.Error())
+		}
+		return &CBLRepositorySyncStatusOutput{Body: syncer.snapshot(ctx)}, nil
+	})
+	huma.Register(api, huma.Operation{OperationID: "stopCBLRepositorySync", Tags: []string{tagReadingOrders}, Summary: "Stop CBL repository import", Method: http.MethodPost, Path: "/readingOrders/repository-sync/stop", Errors: []int{401, 403, 500}}, func(ctx context.Context, _ *struct{}) (*CBLRepositorySyncStatusOutput, error) {
+		if _, err := requireAdminUser(ctx, db); err != nil {
+			return nil, err
+		}
+		syncer.stop("stopped by admin")
+		return &CBLRepositorySyncStatusOutput{Body: syncer.snapshot(ctx)}, nil
+	})
+}

--- a/backend/internal/api/readingorders_repository_sync_test.go
+++ b/backend/internal/api/readingorders_repository_sync_test.go
@@ -1,0 +1,304 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/Lofter1/ComicHero/backend/internal/metron"
+)
+
+func TestValidateCBLRepositorySyncSettingsNormalizesRepositories(t *testing.T) {
+	settings := CBLRepositorySyncSettings{
+		Repositories: []string{
+			"https://github.com/DieselTech/CBL-ReadingLists/",
+			"https://github.com/DieselTech/CBL-ReadingLists.git",
+			"https://github.com/example/other",
+		},
+		Schedule:  "weekly",
+		Weekdays:  []string{"Friday", "friday"},
+		StartTime: "04:30",
+		AutoSync:  true,
+	}
+	if err := validateCBLRepositorySyncSettings(&settings); err != nil {
+		t.Fatalf("validate settings: %v", err)
+	}
+	if len(settings.Repositories) != 2 || settings.Repositories[0] != "https://github.com/DieselTech/CBL-ReadingLists" {
+		t.Fatalf("repositories = %#v; want canonical unique URLs", settings.Repositories)
+	}
+	if len(settings.Weekdays) != 1 || settings.Weekdays[0] != "friday" {
+		t.Fatalf("weekdays = %#v; want one normalized Friday", settings.Weekdays)
+	}
+}
+
+func TestCBLRepositoryPartRecognizesDescriptiveAndAbbreviatedParts(t *testing.T) {
+	tests := []struct {
+		path       string
+		parentName string
+		part       int
+	}{
+		{"DC/Batman/[DC] Batman Modern Age - Part 01 Year One.cbl", "[DC] Batman Modern Age", 1},
+		{"Marvel/Guardians/Guardians of the Galaxy (2008) pt.2.cbl", "Guardians of the Galaxy (2008)", 2},
+	}
+	for _, test := range tests {
+		_, parentName, part, ok := cblRepositoryPart(test.path)
+		if !ok || parentName != test.parentName || part != test.part {
+			t.Fatalf("cblRepositoryPart(%q) = %q, %d, %v; want %q, %d, true", test.path, parentName, part, ok, test.parentName, test.part)
+		}
+	}
+	if _, _, _, ok := cblRepositoryPart("DC/Batman/Batman 001 - Golden Age.cbl"); ok {
+		t.Fatal("ordinary numbered list was treated as multipart")
+	}
+}
+
+func TestSelectedRepositoryFilesKeepsSingleMultipartPart(t *testing.T) {
+	files := []cblGitHubFile{
+		{Path: "Test Saga - Part 01.cbl", SHA: "one"},
+		{Path: "Test Saga - Part 02.cbl", SHA: "two"},
+	}
+	selected, err := selectedRepositoryFiles(files, map[string]bool{"Test Saga - Part 01.cbl": true}, "https://github.com/example/lists")
+	if err != nil {
+		t.Fatalf("selectedRepositoryFiles: %v", err)
+	}
+	if len(selected) != 1 || selected[0].Path != "Test Saga - Part 01.cbl" {
+		t.Fatalf("selected files = %#v; want only explicitly selected part", selected)
+	}
+}
+
+func TestCBLRepositorySyncUpdatesChangedMultipartFileInOneOrder(t *testing.T) {
+	db := setupReadingOrderCBLTestDB(t)
+	if _, err := db.Exec(`
+		CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+		CREATE TABLE cbl_repository_files (
+			repository_url TEXT NOT NULL,
+			file_path TEXT NOT NULL,
+			content_sha TEXT NOT NULL,
+			reading_order_id INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
+			group_key TEXT NOT NULL DEFAULT '',
+			imported_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (repository_url, file_path)
+		);
+	`); err != nil {
+		t.Fatalf("create repository sync schema: %v", err)
+	}
+
+	var mu sync.Mutex
+	partOneSHA := "sha-one"
+	partOneIssue := "1"
+	partOnePath := "DC/Test/Test Saga - Part 01 Beginning.cbl"
+	partTwoPath := "DC/Test/Test Saga - Part 02 Finale.cbl"
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		mu.Lock()
+		sha := partOneSHA
+		issue := partOneIssue
+		mu.Unlock()
+		switch request.URL.Path {
+		case "/repos/owner/lists":
+			fmt.Fprint(response, `{"default_branch":"main"}`)
+		case "/repos/owner/lists/git/trees/main":
+			fmt.Fprintf(response, `{"truncated":false,"tree":[`+
+				`{"path":%q,"type":"blob","sha":%q,"size":300},`+
+				`{"path":%q,"type":"blob","sha":"sha-two","size":300}]}`, partOnePath, sha, partTwoPath)
+		case "/owner/lists/main/" + partOnePath:
+			fmt.Fprintf(response, `<ReadingList><Name>Test Saga - Part 01 Beginning</Name><Books><Book Series="Series" Number="%s" Volume="2020" /></Books></ReadingList>`, issue)
+		case "/owner/lists/main/" + partTwoPath:
+			fmt.Fprint(response, `<ReadingList><Name>Test Saga - Part 02 Finale</Name><Books><Book Series="Series" Number="2" Volume="2020" /></Books></ReadingList>`)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	syncer := NewCBLRepositorySyncer(db, nil, nil)
+	syncer.httpClient = server.Client()
+	syncer.apiBase = server.URL
+	syncer.rawBase = server.URL
+	repository, _ := parseCBLGitHubRepository("https://github.com/owner/lists")
+	ctx := context.WithValue(context.Background(), contextUserIDKey{}, 1)
+	catalog, err := syncer.availableRepositoryFiles(ctx, CBLRepositorySyncSettings{Repositories: []string{repository.URL}})
+	if err != nil {
+		t.Fatalf("list available files: %v", err)
+	}
+	if len(catalog) != 2 || catalog[0].MultipartGroup != "Test Saga" || catalog[1].MultipartGroup != "Test Saga" {
+		t.Fatalf("catalog = %#v; want both files marked as one multipart group", catalog)
+	}
+	if err := syncer.syncRepository(ctx, repository, map[string]bool{partOnePath: true, partTwoPath: true}); err != nil {
+		t.Fatalf("first sync: %v", err)
+	}
+	if status := syncer.snapshot(ctx); status.FilesFound != 2 {
+		t.Fatalf("selected multipart files found = %d; want both explicitly selected parts", status.FilesFound)
+	}
+
+	var originalOrderID int
+	if err := db.Get(&originalOrderID, `SELECT reading_order_id FROM cbl_repository_files WHERE repository_url = ? AND file_path = ?`, repository.URL, partOnePath); err != nil {
+		t.Fatalf("read first mapping: %v", err)
+	}
+	var orderCount int
+	if err := db.Get(&orderCount, `SELECT COUNT(*) FROM reading_orders`); err != nil || orderCount != 1 {
+		t.Fatalf("reading order count = %d, %v; want one combined multipart order", orderCount, err)
+	}
+	var mappedOrderIDs []int
+	if err := db.Select(&mappedOrderIDs, `SELECT reading_order_id FROM cbl_repository_files ORDER BY file_path`); err != nil {
+		t.Fatalf("read multipart mappings: %v", err)
+	}
+	if len(mappedOrderIDs) != 2 || mappedOrderIDs[0] != originalOrderID || mappedOrderIDs[1] != originalOrderID {
+		t.Fatalf("multipart mapping IDs = %#v; want both files mapped to order %d", mappedOrderIDs, originalOrderID)
+	}
+
+	mu.Lock()
+	partOneSHA = "sha-one-updated"
+	partOneIssue = "3"
+	mu.Unlock()
+	if err := syncer.syncRepository(ctx, repository, nil); err != nil {
+		t.Fatalf("second sync: %v", err)
+	}
+
+	var updatedOrderID int
+	if err := db.Get(&updatedOrderID, `SELECT reading_order_id FROM cbl_repository_files WHERE repository_url = ? AND file_path = ?`, repository.URL, partOnePath); err != nil {
+		t.Fatalf("read updated mapping: %v", err)
+	}
+	if updatedOrderID != originalOrderID {
+		t.Fatalf("changed file reading order id = %d; want existing id %d", updatedOrderID, originalOrderID)
+	}
+	var issue string
+	if err := db.Get(&issue, `SELECT c.issue FROM reading_order_comics roc JOIN comics c ON c.id = roc.comic_id WHERE roc.reading_order_id = ? ORDER BY roc.position LIMIT 1`, originalOrderID); err != nil {
+		t.Fatalf("read updated part entry: %v", err)
+	}
+	if strings.TrimSpace(issue) != "3" {
+		t.Fatalf("updated part issue = %q; want 3", issue)
+	}
+	if err := db.Get(&orderCount, `SELECT COUNT(*) FROM reading_orders`); err != nil || orderCount != 1 {
+		t.Fatalf("reading order count after update = %d, %v; want no duplicate orders", orderCount, err)
+	}
+	var sectionCount int
+	if err := db.Get(&sectionCount, `SELECT COUNT(*) FROM reading_order_sections WHERE reading_order_id = ?`, originalOrderID); err != nil || sectionCount != 2 {
+		t.Fatalf("multipart section count = %d, %v; want one section per part", sectionCount, err)
+	}
+}
+
+func TestCBLRepositoryMetronResolverPrefersComicVineID(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	var requests []string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.URL.String())
+		response.Header().Set("Content-Type", "application/json")
+		switch request.URL.Path {
+		case "/issue/":
+			fmt.Fprint(response, `{"results":[{"id":55,"cv_id":987654,"series":{"name":"Saga","year_began":2012},"number":"1","publisher":{"name":"Image"}}]}`)
+		case "/issue/55/":
+			fmt.Fprint(response, `{"id":55,"cv_id":987654,"series":{"name":"Saga","year_began":2012},"number":"1","publisher":{"name":"Image"},"cover_date":"2012-03-01"}`)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	syncer := NewCBLRepositorySyncer(db, metron.New(metron.Config{BaseURL: server.URL}), nil)
+	comic, err := syncer.resolveMissingComicFromMetron(testUserContext(), cblBook{
+		Series:    "Saga",
+		Number:    "1",
+		Databases: []cblDatabase{{Name: "comicvine", Issue: "987654"}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if comic == nil || comic.MetronIssueID == nil || *comic.MetronIssueID != 55 {
+		t.Fatalf("comic = %#v; want imported Metron issue 55", comic)
+	}
+	if len(requests) != 2 || requests[0] != "/issue/?cv_id=987654" || requests[1] != "/issue/55/" {
+		t.Fatalf("Metron requests = %#v; want Comic Vine search followed by detail", requests)
+	}
+}
+
+func TestCBLRepositoryMetronResolverFallsBackToNameAndWaitsForSelection(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	var requests []string
+	var requestsMu sync.Mutex
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requestsMu.Lock()
+		requests = append(requests, request.URL.String())
+		requestsMu.Unlock()
+		response.Header().Set("Content-Type", "application/json")
+		switch {
+		case request.URL.Path == "/issue/" && request.URL.Query().Get("cv_id") != "":
+			fmt.Fprint(response, `{"results":[]}`)
+		case request.URL.Path == "/issue/":
+			fmt.Fprint(response, `{"results":[`+
+				`{"id":71,"series":{"name":"The Example","year_began":2001},"number":"4","publisher":{"name":"First"}},`+
+				`{"id":72,"series":{"name":"The Example","year_began":2020},"number":"4","publisher":{"name":"Second"}}]}`)
+		case request.URL.Path == "/issue/72/":
+			fmt.Fprint(response, `{"id":72,"series":{"name":"The Example","year_began":2020},"number":"4","publisher":{"name":"Second"}}`)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	syncer := NewCBLRepositorySyncer(db, metron.New(metron.Config{BaseURL: server.URL}), nil)
+	syncer.status.Running = true
+	syncer.resolutionChoices = make(chan cblMetronResolutionChoice, 1)
+	type result struct {
+		comic *Comic
+		err   error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		comic, err := syncer.resolveMissingComicFromMetron(testUserContext(), cblBook{
+			Series:    "The Example",
+			Number:    "4",
+			Databases: []cblDatabase{{Name: "ComicVine", Issue: "4444"}},
+		})
+		resultCh <- result{comic: comic, err: err}
+	}()
+
+	var pending *CBLMetronIssueResolution
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		syncer.mu.Lock()
+		pending = syncer.status.PendingResolution
+		syncer.mu.Unlock()
+		if pending != nil {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if pending == nil || len(pending.Candidates) != 2 {
+		t.Fatalf("pending resolution = %#v; want two Metron candidates", pending)
+	}
+	if err := syncer.resolveMetronIssue(pending.ID, 72); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case resolved := <-resultCh:
+		if resolved.err != nil {
+			t.Fatal(resolved.err)
+		}
+		if resolved.comic == nil || resolved.comic.MetronIssueID == nil || *resolved.comic.MetronIssueID != 72 {
+			t.Fatalf("comic = %#v; want selected Metron issue 72", resolved.comic)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("resolver did not continue after selection")
+	}
+
+	requestsMu.Lock()
+	defer requestsMu.Unlock()
+	want := []string{
+		"/issue/?cv_id=4444",
+		"/issue/?number=4&series_name=The+Example",
+		"/issue/72/",
+	}
+	if len(requests) != len(want) {
+		t.Fatalf("Metron requests = %#v; want %#v", requests, want)
+	}
+	for i := range want {
+		if requests[i] != want[i] {
+			t.Fatalf("Metron request %d = %q; want %q", i, requests[i], want[i])
+		}
+	}
+}

--- a/backend/internal/api/readingorders_routes.go
+++ b/backend/internal/api/readingorders_routes.go
@@ -25,7 +25,7 @@ func RegisterReadingOrderRoutes(api huma.API, db *sqlx.DB, covers *CoverCache) {
 		OperationID:   "importReadingOrderCBL",
 		Tags:          []string{tagReadingOrders},
 		Summary:       "Import one or more CBL reading-order parts",
-		Description:   "Creates a reading order from one CBL file, or groups multipart files named Part NN beneath a parent reading order. Books are matched by Comic Vine issue ID first, then by series, issue number, and volume or year; valid books without a local match are created.",
+		Description:   "Creates one reading order from one CBL file or from multiple numbered parts. Multipart files are combined in numeric order with a section for each part. Books are matched by Comic Vine issue ID first, then by series, issue number, and volume or year; valid books without a local match are created.",
 		Method:        http.MethodPost,
 		Path:          "/readingOrders/cbl/import",
 		DefaultStatus: 201,

--- a/backend/internal/api/readingorders_test.go
+++ b/backend/internal/api/readingorders_test.go
@@ -570,37 +570,28 @@ func TestReadingOrderCBLImportGroupsMultipartFilesInPartOrder(t *testing.T) {
 	}
 
 	order := result.Body.ReadingOrder
-	if len(order.ChildReadingOrders) != 2 || len(order.Entries) != 2 || len(order.Comics) != 2 {
-		t.Fatalf("parent children/entries/comics = %d/%d/%d; want 2/2/2", len(order.ChildReadingOrders), len(order.Entries), len(order.Comics))
+	if len(order.ChildReadingOrders) != 0 || len(order.Entries) != 4 || len(order.Comics) != 2 {
+		t.Fatalf("multipart children/entries/comics = %d/%d/%d; want 0/4/2", len(order.ChildReadingOrders), len(order.Entries), len(order.Comics))
 	}
 	wantPartNames := []string{
 		"[Marvel] CMRO Core Reading Order-Part 01",
 		"[Marvel] CMRO Core Reading Order-Part 02",
 	}
 	for i, want := range wantPartNames {
-		if order.ChildReadingOrders[i].Name != want {
-			t.Fatalf("child %d name = %q; want %q", i, order.ChildReadingOrders[i].Name, want)
-		}
-		if order.Entries[i].ReadingOrder == nil || order.Entries[i].ReadingOrder.Name != want {
-			t.Fatalf("entry %d = %#v; want child %q", i, order.Entries[i], want)
-		}
-		if len(order.Entries[i].Comics) != 1 {
-			t.Fatalf("entry %d comics = %d; want 1", i, len(order.Entries[i].Comics))
+		entry := order.Entries[i*2]
+		if entry.Type != "section" || entry.Section == nil || entry.Section.Title != want {
+			t.Fatalf("part section %d = %#v; want %q", i, entry, want)
 		}
 	}
 	if order.Comics[0].Issue != "1" || order.Comics[1].Issue != "2" {
 		t.Fatalf("flattened issues = %q, %q; want part order 1, 2", order.Comics[0].Issue, order.Comics[1].Issue)
 	}
-	if !strings.Contains(order.Comics[0].Comment, "Part 01") || !strings.Contains(order.Comics[1].Comment, "Part 02") {
-		t.Fatalf("flattened source comments = %q, %q; want originating part", order.Comics[0].Comment, order.Comics[1].Comment)
-	}
-
 	var readingOrderCount int
 	if err := db.Get(&readingOrderCount, `SELECT COUNT(*) FROM reading_orders`); err != nil {
 		t.Fatalf("count reading orders: %v", err)
 	}
-	if readingOrderCount != 3 {
-		t.Fatalf("reading order count = %d; want parent plus two parts", readingOrderCount)
+	if readingOrderCount != 1 {
+		t.Fatalf("reading order count = %d; want one combined multipart order", readingOrderCount)
 	}
 }
 

--- a/backend/internal/app/routes.go
+++ b/backend/internal/app/routes.go
@@ -13,12 +13,15 @@ func registerRoutes(cfg config.Config, humaAPI huma.API, database *sqlx.DB, metr
 	importJobs := api.NewMetronImportJobStore()
 	comicScanner := api.NewMetronComicScanner(database, metronClient, covers)
 	comicDiscovery := api.NewMetronComicDiscovery(database, metronClient, covers)
+	cblRepositorySyncer := api.NewCBLRepositorySyncer(database, metronClient, covers)
 
 	comicScanner.Start()
 	comicDiscovery.Start()
+	cblRepositorySyncer.Start()
 
 	api.RegisterSystemRoutes(humaAPI, cfg.Version)
 	api.RegisterReadingOrderRoutes(humaAPI, database, covers)
+	api.RegisterCBLRepositorySyncRoutes(humaAPI, database, cblRepositorySyncer)
 	api.RegisterUserRoutes(humaAPI, database)
 	api.RegisterDashboardRoutes(humaAPI, database)
 	api.RegisterStatisticsRoutes(humaAPI, database)
@@ -30,6 +33,7 @@ func registerRoutes(cfg config.Config, humaAPI huma.API, database *sqlx.DB, metr
 	api.RegisterMetronComicDiscoveryRoutes(humaAPI, database, comicDiscovery)
 
 	return func() {
+		cblRepositorySyncer.Stop()
 		comicDiscovery.Stop()
 		comicScanner.Stop()
 	}

--- a/backend/internal/db/migrations/017_cbl_repository_files.sql
+++ b/backend/internal/db/migrations/017_cbl_repository_files.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+CREATE TABLE cbl_repository_files (
+    repository_url         TEXT    NOT NULL,
+    file_path              TEXT    NOT NULL,
+    content_sha            TEXT    NOT NULL,
+    reading_order_id       INTEGER NOT NULL REFERENCES reading_orders(id) ON DELETE CASCADE,
+    group_key              TEXT    NOT NULL DEFAULT '',
+    imported_at            TEXT    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (repository_url, file_path)
+);
+CREATE INDEX idx_cbl_repository_files_reading_order
+ON cbl_repository_files(reading_order_id);
+-- +goose Down
+DROP INDEX IF EXISTS idx_cbl_repository_files_reading_order;
+DROP TABLE IF EXISTS cbl_repository_files;

--- a/backend/internal/metron/client_test.go
+++ b/backend/internal/metron/client_test.go
@@ -124,6 +124,27 @@ func TestListReadingListsFetchesEveryUnfilteredPage(t *testing.T) {
 	}
 }
 
+func TestSearchIssuesByComicVineIDUsesDocumentedFilter(t *testing.T) {
+	var requestURL string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestURL = r.URL.String()
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"results":[{"id":12,"cv_id":987654,"series":{"name":"Batman"},"number":"6"}]}`))
+	}))
+	defer server.Close()
+
+	issues, err := New(Config{BaseURL: server.URL}).SearchIssuesByComicVineID(context.Background(), 987654)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if requestURL != "/issue/?cv_id=987654" {
+		t.Fatalf("request URL = %q; want Comic Vine filter", requestURL)
+	}
+	if len(issues) != 1 || issues[0].ID != 12 || issues[0].ComicVineID != 987654 {
+		t.Fatalf("issues = %#v; want matching Metron issue", issues)
+	}
+}
+
 func TestClientPreservesMetronIssueNumberSuffix(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/backend/internal/metron/issues.go
+++ b/backend/internal/metron/issues.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strconv"
 )
 
 func (c *Client) SearchIssues(ctx context.Context, query, series, issue string) ([]Issue, error) {
@@ -16,6 +17,21 @@ func (c *Client) SearchIssues(ctx context.Context, query, series, issue string) 
 	if issue != "" {
 		values.Set("number", issue)
 	}
+
+	results, err := c.getList(ctx, "/issue/", values)
+	if err != nil {
+		return nil, err
+	}
+	issues := make([]Issue, 0, len(results))
+	for _, raw := range results {
+		issues = append(issues, issueFromMap(raw))
+	}
+	return issues, nil
+}
+
+func (c *Client) SearchIssuesByComicVineID(ctx context.Context, comicVineID int) ([]Issue, error) {
+	values := url.Values{}
+	values.Set("cv_id", strconv.Itoa(comicVineID))
 
 	results, err := c.getList(ctx, "/issue/", values)
 	if err != nil {

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -126,8 +126,12 @@ const {
 const {
   comicScan: metronComicScan,
   comicDiscovery: metronComicDiscovery,
+  cblRepositorySync,
+  cblRepositoryFiles,
   savingComicScan: savingMetronComicScan,
   savingComicDiscovery: savingMetronComicDiscovery,
+  savingCBLRepositorySync,
+  loadingCBLRepositoryFiles,
   generatedInvite,
   generatingInvite,
   savingRegistrationMode,
@@ -139,6 +143,11 @@ const {
   saveComicDiscovery: saveMetronComicDiscovery,
   runComicDiscovery: runMetronComicDiscovery,
   cancelComicDiscovery: cancelMetronComicDiscovery,
+  saveCBLRepositorySync,
+  loadCBLRepositoryFiles,
+  runCBLRepositorySync,
+  cancelCBLRepositorySync,
+  resolveCBLMetronIssue,
   generateInvite: generateUserInvite,
   saveRegistration: saveRegistrationMode,
   savePublic: savePublicAccess,
@@ -567,18 +576,15 @@ async function loadActiveViewData(options = {}) {
     await loadCharacters(options)
     return
   }
-  if (activeView.value === 'metron') {
-    if (canMetronMonitor.value) {
-      await loadMetronQuota()
-    }
-    return
-  }
   if (activeView.value === 'users') {
     await loadUserAdminRows()
     return
   }
   if (activeView.value === 'settings') {
-    await loadMetronSettings()
+    await Promise.all([
+      loadMetronSettings(),
+      canMetronMonitor.value ? loadMetronQuota() : Promise.resolve(),
+    ])
     return
   }
   if (activeView.value === 'account') {
@@ -591,12 +597,10 @@ async function loadActiveViewData(options = {}) {
 }
 
 async function refreshActiveLibraryData() {
-  if (activeView.value === 'metron') return
   await loadActiveViewData({ force: true })
 }
 
 async function refreshActiveListData() {
-  if (activeView.value === 'metron') return
   error.value = ''
   try {
     await loadActiveViewData({ force: true })
@@ -788,7 +792,6 @@ onUnmounted(() => {
       :is-admin="isAdmin"
       :public-access="publicAccess"
       :read-only-guest="isReadOnlyGuest"
-      :show-metron="canAccessMetronArea && !isReadOnlyGuest"
       :auth-saving="authSaving"
       :version="systemInfo?.version || ''"
       @set-theme="setThemePreference"
@@ -815,16 +818,6 @@ onUnmounted(() => {
       />
 
       <LoadingState v-if="showBlockingLoading" />
-
-      <MetronImport
-        v-else-if="activeView === 'metron'"
-        :import-jobs="metronImportJobs"
-        :metron-quota="metronQuota"
-        @imported="handleMetronImported"
-        @error="showError"
-        @job-started="trackMetronImportJob"
-        @quota-updated="updateMetronQuota"
-      />
 
       <DashboardView
         v-else-if="activeView === 'dashboard'"
@@ -855,8 +848,12 @@ onUnmounted(() => {
         v-else-if="activeView === 'settings'"
         :metron-comic-scan="metronComicScan"
         :metron-comic-discovery="metronComicDiscovery"
+        :cbl-repository-sync="cblRepositorySync"
+        :cbl-repository-files="cblRepositoryFiles"
         :saving="savingMetronComicScan"
         :saving-discovery="savingMetronComicDiscovery"
+        :saving-cbl-repository-sync="savingCBLRepositorySync"
+        :loading-cbl-repository-files="loadingCBLRepositoryFiles"
         :registration-mode="registrationMode"
         :saving-registration-mode="savingRegistrationMode"
         :public-access="publicAccess"
@@ -869,10 +866,26 @@ onUnmounted(() => {
         @save-discovery="saveMetronComicDiscovery"
         @trigger-discovery="runMetronComicDiscovery"
         @stop-discovery="cancelMetronComicDiscovery"
+        @save-cbl-repository-sync="saveCBLRepositorySync"
+        @load-cbl-repository-files="loadCBLRepositoryFiles"
+        @trigger-cbl-repository-sync="runCBLRepositorySync"
+        @stop-cbl-repository-sync="cancelCBLRepositorySync"
+        @resolve-cbl-metron-issue="resolveCBLMetronIssue"
         @update-registration-mode="saveRegistrationMode"
         @update-public-access="savePublicAccess"
         @generate-invite="generateUserInvite"
-      />
+      >
+        <template #metron-import>
+          <MetronImport
+            :import-jobs="metronImportJobs"
+            :metron-quota="metronQuota"
+            @imported="handleMetronImported"
+            @error="showError"
+            @job-started="trackMetronImportJob"
+            @quota-updated="updateMetronQuota"
+          />
+        </template>
+      </AppSettingsView>
 
       <AccountView
         v-else-if="activeView === 'account'"

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -359,6 +359,34 @@ export function stopMetronComicDiscovery() {
   return send('/metron/discovery/comics/stop', 'POST', {})
 }
 
+export function getCBLRepositorySync() {
+  return request('/readingOrders/repository-sync')
+}
+
+export function cblRepositorySyncEventsURL() {
+  return `${API_BASE}/readingOrders/repository-sync/events`
+}
+
+export function updateCBLRepositorySync(payload) {
+  return send('/readingOrders/repository-sync', 'PUT', payload)
+}
+
+export function listCBLRepositoryFiles() {
+  return request('/readingOrders/repository-sync/files')
+}
+
+export function triggerCBLRepositorySync(payload = {}) {
+  return send('/readingOrders/repository-sync/trigger', 'POST', payload)
+}
+
+export function resolveCBLRepositoryMetronIssue(payload) {
+  return send('/readingOrders/repository-sync/resolve', 'POST', payload)
+}
+
+export function stopCBLRepositorySync() {
+  return send('/readingOrders/repository-sync/stop', 'POST', {})
+}
+
 export function updateUserMetronPermissions(id, payload) {
   return send(`/users/${id}/metron-permissions`, 'PUT', payload)
 }

--- a/ui/src/app/components/AppSidebar.vue
+++ b/ui/src/app/components/AppSidebar.vue
@@ -30,10 +30,6 @@ const props = defineProps({
     type: Boolean,
     default: false,
   },
-  showMetron: {
-    type: Boolean,
-    default: true,
-  },
   authSaving: {
     type: Boolean,
     default: false,
@@ -147,14 +143,6 @@ function toggleMobileMenu() {
         @click="closeMenus"
       >
         <span>Characters</span>
-      </router-link>
-      <router-link
-        v-if="showMetron"
-        :to="{ name: 'metron' }"
-        :class="{ active: activeView === 'metron' }"
-        @click="closeMenus"
-      >
-        <span>Metron</span>
       </router-link>
     </nav>
 

--- a/ui/src/features/metron/useMetronJobs.js
+++ b/ui/src/features/metron/useMetronJobs.js
@@ -49,7 +49,7 @@ export function useMetronJobs({ activeView, error, handleImported }) {
     metronImportMonitorOpen.value = true
     upsertMetronImportJob(job)
     connectMetronImportEvents()
-    if (activeView.value === 'metron') {
+    if (activeView.value === 'settings') {
       loadMetronQuota().catch(() => {})
     }
   }
@@ -116,14 +116,14 @@ export function useMetronJobs({ activeView, error, handleImported }) {
       }
       if (job.status === 'succeeded' && previous && previous.status !== 'succeeded') {
         await handleImported(job)
-        if (activeView.value === 'metron') {
+        if (activeView.value === 'settings') {
           loadMetronQuota().catch(() => {})
         }
         return
       }
       if (job.status === 'failed' && previous && previous.status !== 'failed') {
         error.value = job.message || 'Metron import failed.'
-        if (activeView.value === 'metron') {
+        if (activeView.value === 'settings') {
           loadMetronQuota().catch(() => {})
         }
         return

--- a/ui/src/features/settings/components/AppSettingsView.vue
+++ b/ui/src/features/settings/components/AppSettingsView.vue
@@ -1,12 +1,17 @@
 <script setup>
-import { reactive, watch } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
 import LoadingState from '@/shared/components/feedback/LoadingState.vue'
 
 const props = defineProps({
   metronComicScan: { type: Object, default: null },
   metronComicDiscovery: { type: Object, default: null },
+  cblRepositorySync: { type: Object, default: null },
+  cblRepositoryFiles: { type: Array, default: () => [] },
   saving: { type: Boolean, default: false },
   savingDiscovery: { type: Boolean, default: false },
+  savingCblRepositorySync: { type: Boolean, default: false },
+  loadingCblRepositoryFiles: { type: Boolean, default: false },
   registrationMode: { type: String, default: 'invite_only' },
   savingRegistrationMode: { type: Boolean, default: false },
   publicAccess: { type: Boolean, default: false },
@@ -22,12 +27,36 @@ const emit = defineEmits([
   'save-discovery',
   'trigger-discovery',
   'stop-discovery',
+  'save-cbl-repository-sync',
+  'load-cbl-repository-files',
+  'trigger-cbl-repository-sync',
+  'stop-cbl-repository-sync',
+  'resolve-cbl-metron-issue',
   'update-registration-mode',
   'update-public-access',
   'generate-invite',
 ])
+const route = useRoute()
+const router = useRouter()
+const settingsTabs = [
+  { value: 'general', label: 'General' },
+  { value: 'metron', label: 'Metron' },
+  { value: 'cbl-repositories', label: 'CBL repositories' },
+]
+const activeSettingsTab = computed(() => {
+  const requested = String(route.query.tab || '')
+  return settingsTabs.some((tab) => tab.value === requested) ? requested : 'general'
+})
 const draft = reactive({})
 const discoveryDraft = reactive({})
+const cblDraft = reactive({})
+const repositoryText = ref('')
+const cblFilePickerOpen = ref(false)
+const cblFileSearch = ref('')
+const selectedCBLFileKeys = reactive(new Set())
+const visibleCBLFileLimit = ref(100)
+const resolveMissingCBLIssues = ref(false)
+const cblFileBatchSize = 100
 const weekdays = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday', 'sunday']
 const incompleteFieldOptions = [
   { value: 'comicVineId', label: 'Comic Vine ID' },
@@ -36,6 +65,48 @@ const incompleteFieldOptions = [
   { value: 'coverDate', label: 'Cover date' },
   { value: 'description', label: 'Description' },
 ]
+const indexedCBLRepositoryFiles = computed(() =>
+  props.cblRepositoryFiles.map((file) => ({
+    file,
+    key: cblFileKey(file),
+    searchText: `${file.repositoryUrl} ${file.path} ${file.multipartGroup || ''}`.toLowerCase(),
+  })),
+)
+const cblRepositoryFilesByKey = computed(
+  () => new Map(indexedCBLRepositoryFiles.value.map(({ key, file }) => [key, file])),
+)
+const cblMultipartFileKeys = computed(() => {
+  const groups = new Map()
+  for (const { file, key } of indexedCBLRepositoryFiles.value) {
+    if (!file.multipartGroup) continue
+    const groupKey = `${file.repositoryUrl}\n${file.multipartGroup}`
+    const keys = groups.get(groupKey) || []
+    keys.push(key)
+    groups.set(groupKey, keys)
+  }
+  return groups
+})
+const filteredCBLRepositoryFiles = computed(() => {
+  const query = cblFileSearch.value.trim().toLowerCase()
+  const rows = query
+    ? indexedCBLRepositoryFiles.value.filter(({ searchText }) => searchText.includes(query))
+    : indexedCBLRepositoryFiles.value
+  return rows.map(({ file }) => file)
+})
+const visibleCBLRepositoryFiles = computed(() =>
+  filteredCBLRepositoryFiles.value.slice(0, visibleCBLFileLimit.value),
+)
+const remainingCBLRepositoryFileCount = computed(() =>
+  Math.max(0, filteredCBLRepositoryFiles.value.length - visibleCBLRepositoryFiles.value.length),
+)
+const selectedCBLRepositoryFiles = computed(() => {
+  const files = []
+  for (const key of selectedCBLFileKeys) {
+    const file = cblRepositoryFilesByKey.value.get(key)
+    if (file) files.push(file)
+  }
+  return files
+})
 
 watch(
   () => props.metronComicScan?.settings,
@@ -54,6 +125,34 @@ watch(
   { immediate: true },
 )
 
+watch(
+  () => props.cblRepositorySync?.settings,
+  (settings) => {
+    Object.assign(cblDraft, settings || {})
+    repositoryText.value = (settings?.repositories || []).join('\n')
+  },
+  { immediate: true },
+)
+
+watch(
+  () => [props.cblRepositorySync?.running, props.cblRepositorySync?.resolveMissingOnMetron],
+  ([running, enabled]) => {
+    if (running) resolveMissingCBLIssues.value = Boolean(enabled)
+  },
+  { immediate: true },
+)
+
+watch(cblFileSearch, () => {
+  visibleCBLFileLimit.value = cblFileBatchSize
+})
+
+watch(
+  () => props.cblRepositorySync?.pendingResolution?.id,
+  (resolutionID) => {
+    if (resolutionID) selectSettingsTab('cbl-repositories')
+  },
+)
+
 function toggleWeekday(day, checked) {
   const selected = new Set(draft.weekdays || [])
   if (checked) selected.add(day)
@@ -68,8 +167,8 @@ function toggleIncompleteField(field, checked) {
   draft.incompleteFields = [...selected]
 }
 
-function save() {
-  emit('save', {
+function comicScanPayload() {
+  return {
     enabled: Boolean(draft.enabled),
     scanComics: true,
     schedule: draft.schedule || 'daily',
@@ -79,7 +178,15 @@ function save() {
     minIntervalSeconds: Math.max(0, Number(draft.minIntervalSeconds) || 0),
     recheckCooldownDays: Math.max(0, Number(draft.recheckCooldownDays) || 0),
     incompleteFields: draft.incompleteFields || [],
-  })
+  }
+}
+
+function save() {
+  emit('save', comicScanPayload())
+}
+
+function startComicScan() {
+  emit('trigger', comicScanPayload())
 }
 
 function toggleDiscoveryWeekday(day, checked) {
@@ -89,8 +196,8 @@ function toggleDiscoveryWeekday(day, checked) {
   discoveryDraft.weekdays = [...selected]
 }
 
-function saveDiscovery() {
-  emit('save-discovery', {
+function comicDiscoveryPayload() {
+  return {
     enabled: Boolean(discoveryDraft.enabled),
     pullComics: Boolean(discoveryDraft.pullComics),
     pullReadingLists: Boolean(discoveryDraft.pullReadingLists),
@@ -100,17 +207,166 @@ function saveDiscovery() {
     startTime: discoveryDraft.startTime || '03:00',
     publisherName: String(discoveryDraft.publisherName || '').trim(),
     seriesName: String(discoveryDraft.seriesName || '').trim(),
+  }
+}
+
+function saveDiscovery() {
+  emit('save-discovery', comicDiscoveryPayload())
+}
+
+function startComicDiscovery() {
+  emit('trigger-discovery', comicDiscoveryPayload())
+}
+
+function toggleCBLWeekday(day, checked) {
+  const selected = new Set(cblDraft.weekdays || [])
+  if (checked) selected.add(day)
+  else selected.delete(day)
+  cblDraft.weekdays = [...selected]
+}
+
+function cblRepositorySyncPayload() {
+  return {
+    enabled: Boolean(cblDraft.enabled),
+    repositories: repositoryText.value
+      .split('\n')
+      .map((value) => value.trim())
+      .filter(Boolean),
+    autoSync: Boolean(cblDraft.autoSync),
+    schedule: cblDraft.schedule || 'daily',
+    weekdays: cblDraft.schedule === 'weekly' ? cblDraft.weekdays || [] : [],
+    startTime: cblDraft.startTime || '04:00',
+  }
+}
+
+function saveCBLRepositorySync() {
+  emit('save-cbl-repository-sync', cblRepositorySyncPayload())
+}
+
+function startCBLRepositorySync() {
+  emit('trigger-cbl-repository-sync', {
+    settings: cblRepositorySyncPayload(),
+    resolveMissingOnMetron: resolveMissingCBLIssues.value,
   })
+}
+
+function openCBLFilePicker() {
+  cblFilePickerOpen.value = true
+  cblFileSearch.value = ''
+  selectedCBLFileKeys.clear()
+  visibleCBLFileLimit.value = cblFileBatchSize
+  emit('load-cbl-repository-files', cblRepositorySyncPayload())
+}
+
+function closeCBLFilePicker() {
+  cblFilePickerOpen.value = false
+}
+
+function cblFileKey(file) {
+  return `${file.repositoryUrl}\n${file.path}`
+}
+
+function multipartCBLFileKeys(file) {
+  if (!file.multipartGroup) return [cblFileKey(file)]
+  return (
+    cblMultipartFileKeys.value.get(`${file.repositoryUrl}\n${file.multipartGroup}`) || [
+      cblFileKey(file),
+    ]
+  )
+}
+
+function toggleCBLFile(file, checked) {
+  const key = cblFileKey(file)
+  if (checked) selectedCBLFileKeys.add(key)
+  else selectedCBLFileKeys.delete(key)
+}
+
+function selectAllCBLParts(file) {
+  for (const key of multipartCBLFileKeys(file)) selectedCBLFileKeys.add(key)
+}
+
+function multipartPartCount(file) {
+  return multipartCBLFileKeys(file).length
+}
+
+function allMultipartPartsSelected(file) {
+  return multipartCBLFileKeys(file).every((key) => selectedCBLFileKeys.has(key))
+}
+
+function clearSelectedCBLFiles() {
+  selectedCBLFileKeys.clear()
+}
+
+function showMoreCBLRepositoryFiles() {
+  visibleCBLFileLimit.value += cblFileBatchSize
+}
+
+function startSelectedCBLRepositoryFiles() {
+  if (!selectedCBLRepositoryFiles.value.length) return
+  emit('trigger-cbl-repository-sync', {
+    settings: cblRepositorySyncPayload(),
+    resolveMissingOnMetron: resolveMissingCBLIssues.value,
+    files: selectedCBLRepositoryFiles.value.map((file) => ({
+      repositoryUrl: file.repositoryUrl,
+      path: file.path,
+    })),
+  })
+  closeCBLFilePicker()
+}
+
+function chooseCBLMetronIssue(metronIssueId) {
+  const resolutionId = props.cblRepositorySync?.pendingResolution?.id
+  if (!resolutionId) return
+  emit('resolve-cbl-metron-issue', { resolutionId, metronIssueId })
+}
+
+function repositoryLabel(value) {
+  return String(value || '').replace(/^https:\/\/github\.com\//i, '')
+}
+
+function fileSizeLabel(bytes) {
+  const value = Number(bytes) || 0
+  if (value < 1024) return `${value} B`
+  return `${Math.round(value / 1024)} KB`
 }
 
 function registrationModeLabel(mode) {
   return mode === 'open' ? 'Open registration' : 'Invite only'
 }
+
+function selectSettingsTab(tab) {
+  router.replace({
+    name: 'settings',
+    query: tab === 'general' ? {} : { tab },
+  })
+}
 </script>
 
 <template>
   <section class="browse-view app-settings-view">
-    <section class="user-access-panel">
+    <nav class="settings-tabs" role="tablist" aria-label="App settings sections">
+      <button
+        v-for="tab in settingsTabs"
+        :id="`settings-tab-${tab.value}`"
+        :key="tab.value"
+        type="button"
+        role="tab"
+        :class="{ active: activeSettingsTab === tab.value }"
+        :aria-selected="activeSettingsTab === tab.value"
+        :aria-controls="`settings-panel-${tab.value}`"
+        @click="selectSettingsTab(tab.value)"
+      >
+        {{ tab.label }}
+      </button>
+    </nav>
+
+    <section
+      v-show="activeSettingsTab === 'general'"
+      id="settings-panel-general"
+      class="user-access-panel settings-tab-panel"
+      role="tabpanel"
+      aria-labelledby="settings-tab-general"
+    >
       <div class="user-registration-panel">
         <div>
           <p class="eyebrow">Registration</p>
@@ -210,226 +466,123 @@ function registrationModeLabel(mode) {
       </div>
     </section>
 
-    <section v-if="metronComicDiscovery" class="account-settings-panel metron-scan-panel">
+    <section
+      v-if="cblRepositorySync"
+      v-show="activeSettingsTab === 'cbl-repositories'"
+      id="settings-panel-cbl-repositories"
+      class="account-settings-panel metron-scan-panel settings-tab-panel"
+      role="tabpanel"
+      aria-labelledby="settings-tab-cbl-repositories"
+    >
       <header class="metron-scan-heading">
         <div class="metron-scan-heading-copy">
-          <p class="eyebrow">Metron discovery</p>
-          <h3>Automatic new Metron data</h3>
+          <p class="eyebrow">CBL repositories</p>
+          <h3>Automatic reading-list imports</h3>
           <p class="muted">
-            Import recently modified comics, reading lists, or both from Metron on one schedule.
+            Import public GitHub repositories of CBL files. Changed files update their existing
+            reading orders, and multipart files combine into one reading order with a section for
+            each part.
           </p>
         </div>
         <label class="compact-toggle metron-scan-toggle">
-          <input v-model="discoveryDraft.enabled" type="checkbox" />
-          <span>{{ discoveryDraft.enabled ? 'Enabled' : 'Disabled' }}</span>
+          <input v-model="cblDraft.enabled" type="checkbox" />
+          <span>{{ cblDraft.enabled ? 'Enabled' : 'Disabled' }}</span>
         </label>
       </header>
 
-      <fieldset class="permission-scopes metron-discovery-types">
-        <legend>Pull content</legend>
-        <label>
-          <input v-model="discoveryDraft.pullComics" type="checkbox" />
-          <span>Comics</span>
-        </label>
-        <label>
-          <input v-model="discoveryDraft.pullReadingLists" type="checkbox" />
-          <span>Reading lists</span>
-        </label>
-      </fieldset>
+      <label class="metron-scan-field cbl-repository-list-field">
+        <span>Repositories (one GitHub URL per line)</span>
+        <textarea
+          v-model="repositoryText"
+          rows="4"
+          spellcheck="false"
+          placeholder="https://github.com/DieselTech/CBL-ReadingLists"
+        ></textarea>
+      </label>
+
+      <label class="compact-toggle cbl-auto-sync-toggle">
+        <input v-model="cblDraft.autoSync" type="checkbox" />
+        <span>Regularly check repositories for new and updated files</span>
+      </label>
 
       <div class="metron-scan-fields">
         <label class="metron-scan-field">
           <span>Schedule</span>
-          <select v-model="discoveryDraft.schedule">
-            <option value="daily">Daily</option>
-            <option value="weekly">Weekly</option>
-            <option value="monthly">Monthly</option>
-          </select>
-        </label>
-        <label class="metron-scan-field">
-          <span>Start time (server time)</span>
-          <input v-model="discoveryDraft.startTime" type="time" />
-        </label>
-        <label class="metron-scan-field">
-          <span>Publisher name filter</span>
-          <input
-            v-model="discoveryDraft.publisherName"
-            type="text"
-            placeholder="All publishers"
-            :disabled="!discoveryDraft.pullComics"
-          />
-        </label>
-        <label class="metron-scan-field">
-          <span>Series name filter</span>
-          <input
-            v-model="discoveryDraft.seriesName"
-            type="text"
-            placeholder="All series"
-            :disabled="!discoveryDraft.pullComics"
-          />
-        </label>
-        <label v-if="discoveryDraft.schedule === 'monthly'" class="metron-scan-field">
-          <span>Day of month</span>
-          <input v-model.number="discoveryDraft.monthDay" type="number" min="1" max="31" />
-        </label>
-      </div>
-
-      <fieldset v-if="discoveryDraft.schedule === 'weekly'" class="permission-scopes">
-        <legend>Run on</legend>
-        <label v-for="day in weekdays" :key="`discovery-${day}`">
-          <input
-            type="checkbox"
-            :checked="(discoveryDraft.weekdays || []).includes(day)"
-            @change="toggleDiscoveryWeekday(day, $event.target.checked)"
-          />
-          <span>{{ day.charAt(0).toUpperCase() + day.slice(1) }}</span>
-        </label>
-      </fieldset>
-
-      <div class="metron-scan-status" aria-live="polite">
-        <div>
-          <strong>{{ metronComicDiscovery.found }}</strong>
-          <span>list results found</span>
-        </div>
-        <div>
-          <strong>{{ metronComicDiscovery.imported }}</strong>
-          <span>imported</span>
-        </div>
-        <div v-if="metronComicDiscovery.alreadyPresent">
-          <strong>{{ metronComicDiscovery.alreadyPresent }}</strong>
-          <span>already present</span>
-        </div>
-        <p>
-          <template v-if="metronComicDiscovery.running">Import running</template>
-          <template v-else-if="metronComicDiscovery.stopReason">
-            Last pull: {{ metronComicDiscovery.stopReason }}
-          </template>
-          <template v-else>Not run yet</template>
-        </p>
-      </div>
-
-      <div class="metron-scan-actions">
-        <button
-          type="button"
-          class="primary-button"
-          :disabled="
-            savingDiscovery || (!discoveryDraft.pullComics && !discoveryDraft.pullReadingLists)
-          "
-          @click="saveDiscovery"
-        >
-          {{ savingDiscovery ? 'Saving...' : 'Save settings' }}
-        </button>
-        <button
-          v-if="!metronComicDiscovery.running"
-          type="button"
-          class="secondary-action"
-          :disabled="
-            !discoveryDraft.enabled ||
-            (!discoveryDraft.pullComics && !discoveryDraft.pullReadingLists)
-          "
-          @click="$emit('trigger-discovery')"
-        >
-          Pull now
-        </button>
-        <button v-else type="button" class="danger-text-button" @click="$emit('stop-discovery')">
-          Stop pull
-        </button>
-      </div>
-    </section>
-
-    <section v-if="metronComicScan" class="account-settings-panel metron-scan-panel">
-      <header class="metron-scan-heading">
-        <div class="metron-scan-heading-copy">
-          <p class="eyebrow">Metron maintenance</p>
-          <h3>Incomplete comic data</h3>
-          <p class="muted">
-            Choose which missing fields make a comic incomplete. Issue responses also create missing
-            arc and character links without extra detail calls.
-          </p>
-        </div>
-        <label class="compact-toggle metron-scan-toggle">
-          <input v-model="draft.enabled" type="checkbox" />
-          <span>{{ draft.enabled ? 'Enabled' : 'Disabled' }}</span>
-        </label>
-      </header>
-
-      <fieldset class="permission-scopes metron-incomplete-fields">
-        <legend>Consider a comic incomplete when it has no</legend>
-        <label v-for="option in incompleteFieldOptions" :key="option.value">
-          <input
-            type="checkbox"
-            :checked="(draft.incompleteFields || []).includes(option.value)"
-            @change="toggleIncompleteField(option.value, $event.target.checked)"
-          />
-          <span>{{ option.label }}</span>
-        </label>
-      </fieldset>
-      <p v-if="!(draft.incompleteFields || []).length" class="access-note">
-        Select at least one field before saving or running this scan.
-      </p>
-
-      <div class="metron-scan-fields">
-        <label class="metron-scan-field">
-          <span>Schedule</span>
-          <select v-model="draft.schedule">
+          <select v-model="cblDraft.schedule" :disabled="!cblDraft.autoSync">
             <option value="daily">Daily</option>
             <option value="weekly">Specific weekdays</option>
           </select>
         </label>
         <label class="metron-scan-field">
           <span>Start time (server time)</span>
-          <input v-model="draft.startTime" type="time" />
-        </label>
-        <label class="metron-scan-field">
-          <span>Calls per day</span>
-          <input v-model.number="draft.dailyCallLimit" min="1" step="1" type="number" />
-        </label>
-        <label class="metron-scan-field">
-          <span>Minimum Metron interval (seconds)</span>
-          <input v-model.number="draft.minIntervalSeconds" min="0" step="1" type="number" />
-        </label>
-        <label class="metron-scan-field">
-          <span>Re-check cooldown (days)</span>
-          <input v-model.number="draft.recheckCooldownDays" min="0" step="1" type="number" />
+          <input v-model="cblDraft.startTime" type="time" :disabled="!cblDraft.autoSync" />
         </label>
       </div>
-      <p class="muted metron-scan-hint">
-        Some issues have no publisher, cover date, or synopsis on Metron itself, so they can stay
-        "incomplete" no matter how often they're checked. The cooldown skips a comic for this many
-        days after it was last checked, so those rows stop using up the whole daily call budget. Set
-        to 0 to recheck everything every run.
-      </p>
 
-      <fieldset v-if="draft.schedule === 'weekly'" class="permission-scopes">
+      <fieldset
+        v-if="cblDraft.autoSync && cblDraft.schedule === 'weekly'"
+        class="permission-scopes"
+      >
         <legend>Run on</legend>
-        <label v-for="day in weekdays" :key="day">
+        <label v-for="day in weekdays" :key="`cbl-${day}`">
           <input
             type="checkbox"
-            :checked="(draft.weekdays || []).includes(day)"
-            @change="toggleWeekday(day, $event.target.checked)"
+            :checked="(cblDraft.weekdays || []).includes(day)"
+            @change="toggleCBLWeekday(day, $event.target.checked)"
           />
           <span>{{ day.charAt(0).toUpperCase() + day.slice(1) }}</span>
         </label>
       </fieldset>
 
+      <div class="cbl-manual-metron-option">
+        <label class="compact-toggle">
+          <input
+            v-model="resolveMissingCBLIssues"
+            type="checkbox"
+            :disabled="cblRepositorySync.running"
+          />
+          <span>Search Metron for issues missing from this library</span>
+        </label>
+        <small>
+          Used only by Import now and Choose files. Comic Vine IDs are tried first, then the series
+          name and issue number.
+        </small>
+      </div>
+
       <div class="metron-scan-status" aria-live="polite">
         <div>
-          <strong>{{ metronComicScan.callsUsedToday }} / {{ draft.dailyCallLimit }}</strong>
-          <span>calls used today</span>
+          <strong>{{ cblRepositorySync.filesFound }}</strong>
+          <span>CBL files found</span>
         </div>
-        <div v-if="metronComicScan.running">
-          <strong>{{ metronComicScan.updated }}</strong>
-          <span
-            >updated ({{ metronComicScan.failed }} failed) from
-            {{ metronComicScan.scanned }} scanned</span
-          >
+        <div>
+          <strong>{{ cblRepositorySync.imported }}</strong>
+          <span>new lists imported</span>
         </div>
-        <p v-else>
-          Quota resets daily · {{ metronComicScan.usageDate }}
-          <template v-if="metronComicScan.stopReason">
-            · Last scan: {{ metronComicScan.stopReason }} ({{ metronComicScan.updated }} updated,
-            {{ metronComicScan.failed }} failed)
+        <div>
+          <strong>{{ cblRepositorySync.updated }}</strong>
+          <span>existing lists updated</span>
+        </div>
+        <div v-if="cblRepositorySync.unchanged">
+          <strong>{{ cblRepositorySync.unchanged }}</strong>
+          <span>unchanged</span>
+        </div>
+        <p>
+          <template v-if="cblRepositorySync.pendingResolution">
+            Waiting for a Metron issue selection
           </template>
+          <template v-else-if="cblRepositorySync.running">
+            Importing {{ cblRepositorySync.currentFile || cblRepositorySync.currentRepository }}
+          </template>
+          <template v-else-if="cblRepositorySync.stopReason">
+            Last import: {{ cblRepositorySync.stopReason }}
+            <template v-if="cblRepositorySync.failed">
+              · {{ cblRepositorySync.failed }} failed
+            </template>
+          </template>
+          <template v-else>Not run yet</template>
+        </p>
+        <p v-if="cblRepositorySync.lastError" class="access-note">
+          Last error: {{ cblRepositorySync.lastError }}
         </p>
       </div>
 
@@ -437,25 +590,470 @@ function registrationModeLabel(mode) {
         <button
           type="button"
           class="primary-button"
-          :disabled="saving || !(draft.incompleteFields || []).length"
-          @click="save"
+          :disabled="savingCblRepositorySync || !repositoryText.trim()"
+          @click="saveCBLRepositorySync"
         >
-          {{ saving ? 'Saving...' : 'Save settings' }}
+          {{ savingCblRepositorySync ? 'Saving...' : 'Save settings' }}
         </button>
         <button
-          v-if="!metronComicScan.running"
+          v-if="!cblRepositorySync.running"
           type="button"
           class="secondary-action"
-          :disabled="!draft.enabled || !(draft.incompleteFields || []).length"
-          @click="$emit('trigger')"
+          :disabled="savingCblRepositorySync || !cblDraft.enabled || !repositoryText.trim()"
+          @click="startCBLRepositorySync"
         >
-          Scan now
+          {{ savingCblRepositorySync ? 'Saving and starting...' : 'Import now' }}
         </button>
-        <button v-else type="button" class="danger-text-button" @click="$emit('stop')">
-          Stop scan
+        <button
+          v-if="!cblRepositorySync.running"
+          type="button"
+          class="secondary-action"
+          :disabled="
+            savingCblRepositorySync ||
+            loadingCblRepositoryFiles ||
+            !cblDraft.enabled ||
+            !repositoryText.trim()
+          "
+          @click="openCBLFilePicker"
+        >
+          {{ loadingCblRepositoryFiles ? 'Loading files...' : 'Choose files' }}
+        </button>
+        <button
+          v-else
+          type="button"
+          class="danger-text-button"
+          @click="$emit('stop-cbl-repository-sync')"
+        >
+          Stop import
         </button>
       </div>
+
+      <div v-if="cblFilePickerOpen" class="modal-backdrop" @click.self="closeCBLFilePicker">
+        <section
+          class="cbl-file-picker"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cbl-file-picker-title"
+        >
+          <header class="cbl-file-picker-header">
+            <div>
+              <strong id="cbl-file-picker-title">Choose CBL files</strong>
+              <small
+                >Select one part on its own, or use “Select all parts” for the full list.</small
+              >
+            </div>
+            <button
+              class="icon-button"
+              type="button"
+              aria-label="Close CBL file picker"
+              @click="closeCBLFilePicker"
+            >
+              ×
+            </button>
+          </header>
+
+          <div class="cbl-file-picker-tools">
+            <input v-model="cblFileSearch" type="search" placeholder="Search paths..." />
+            <button
+              type="button"
+              class="secondary-action"
+              :disabled="!selectedCBLFileKeys.size"
+              @click="clearSelectedCBLFiles"
+            >
+              Clear
+            </button>
+          </div>
+
+          <LoadingState v-if="loadingCblRepositoryFiles" compact />
+          <p v-else-if="!filteredCBLRepositoryFiles.length" class="muted">
+            No CBL files match this search.
+          </p>
+          <div v-else class="cbl-file-picker-list">
+            <div
+              v-for="file in visibleCBLRepositoryFiles"
+              :key="cblFileKey(file)"
+              v-memo="[
+                selectedCBLFileKeys.has(cblFileKey(file)),
+                file.multipartGroup ? allMultipartPartsSelected(file) : false,
+              ]"
+            >
+              <label>
+                <input
+                  type="checkbox"
+                  :checked="selectedCBLFileKeys.has(cblFileKey(file))"
+                  @change="toggleCBLFile(file, $event.target.checked)"
+                />
+                <span class="cbl-file-picker-path">
+                  <strong>{{ file.path }}</strong>
+                  <small>
+                    {{ repositoryLabel(file.repositoryUrl) }} · {{ fileSizeLabel(file.size) }}
+                    <template v-if="file.multipartGroup">
+                      · {{ file.multipartGroup }}, part {{ file.part }}
+                    </template>
+                  </small>
+                </span>
+              </label>
+              <button
+                v-if="file.multipartGroup"
+                type="button"
+                class="cbl-select-parts-button"
+                :disabled="allMultipartPartsSelected(file)"
+                @click="selectAllCBLParts(file)"
+              >
+                {{
+                  allMultipartPartsSelected(file)
+                    ? `All ${multipartPartCount(file)} parts selected`
+                    : `Select all ${multipartPartCount(file)} parts`
+                }}
+              </button>
+            </div>
+            <button
+              v-if="remainingCBLRepositoryFileCount"
+              type="button"
+              class="secondary-button cbl-file-picker-more"
+              @click="showMoreCBLRepositoryFiles"
+            >
+              Show {{ Math.min(cblFileBatchSize, remainingCBLRepositoryFileCount) }} more
+              <small>{{ remainingCBLRepositoryFileCount }} matches not shown</small>
+            </button>
+          </div>
+
+          <footer class="cbl-file-picker-actions">
+            <span>{{ selectedCBLRepositoryFiles.length }} files selected</span>
+            <button type="button" class="secondary-button" @click="closeCBLFilePicker">
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="primary-button"
+              :disabled="!selectedCBLRepositoryFiles.length || savingCblRepositorySync"
+              @click="startSelectedCBLRepositoryFiles"
+            >
+              Import selected
+            </button>
+          </footer>
+        </section>
+      </div>
+
+      <div v-if="cblRepositorySync.pendingResolution" class="modal-backdrop">
+        <section
+          class="cbl-file-picker cbl-metron-issue-picker"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cbl-metron-issue-picker-title"
+        >
+          <header class="cbl-file-picker-header">
+            <div>
+              <strong id="cbl-metron-issue-picker-title">Choose the matching Metron issue</strong>
+              <small>
+                {{ cblRepositorySync.pendingResolution.series }}
+                #{{ cblRepositorySync.pendingResolution.number }}
+                <template v-if="cblRepositorySync.pendingResolution.volume">
+                  · volume {{ cblRepositorySync.pendingResolution.volume }}
+                </template>
+                <template v-if="cblRepositorySync.pendingResolution.year">
+                  · {{ cblRepositorySync.pendingResolution.year }}
+                </template>
+              </small>
+            </div>
+          </header>
+
+          <div class="cbl-metron-candidate-list">
+            <button
+              v-for="candidate in cblRepositorySync.pendingResolution.candidates"
+              :key="candidate.id"
+              type="button"
+              class="cbl-metron-candidate"
+              @click="chooseCBLMetronIssue(candidate.id)"
+            >
+              <img v-if="candidate.coverImage" :src="candidate.coverImage" alt="" />
+              <span class="cbl-metron-candidate-copy">
+                <strong>
+                  {{ candidate.series }}
+                  <template v-if="candidate.seriesYear">({{ candidate.seriesYear }})</template>
+                  #{{ candidate.number }}
+                </strong>
+                <small>
+                  {{ candidate.publisher || 'Unknown publisher' }}
+                  <template v-if="candidate.coverDate"> · {{ candidate.coverDate }}</template>
+                </small>
+                <small>
+                  Metron #{{ candidate.id }}
+                  <template v-if="candidate.comicVineId">
+                    · Comic Vine #{{ candidate.comicVineId }}
+                  </template>
+                </small>
+              </span>
+            </button>
+          </div>
+
+          <footer class="cbl-file-picker-actions">
+            <span>Select the issue that should be added to this reading order.</span>
+            <button type="button" class="secondary-button" @click="chooseCBLMetronIssue(0)">
+              Use CBL data only
+            </button>
+          </footer>
+        </section>
+      </div>
     </section>
-    <LoadingState v-else />
+
+    <div
+      v-show="activeSettingsTab === 'metron'"
+      id="settings-panel-metron"
+      class="settings-tab-panel settings-metron-panel"
+      role="tabpanel"
+      aria-labelledby="settings-tab-metron"
+    >
+      <slot name="metron-import"></slot>
+
+      <section v-if="metronComicDiscovery" class="account-settings-panel metron-scan-panel">
+        <header class="metron-scan-heading">
+          <div class="metron-scan-heading-copy">
+            <p class="eyebrow">Metron discovery</p>
+            <h3>Automatic new Metron data</h3>
+            <p class="muted">
+              Import recently modified comics, reading lists, or both from Metron on one schedule.
+            </p>
+          </div>
+          <label class="compact-toggle metron-scan-toggle">
+            <input v-model="discoveryDraft.enabled" type="checkbox" />
+            <span>{{ discoveryDraft.enabled ? 'Enabled' : 'Disabled' }}</span>
+          </label>
+        </header>
+
+        <fieldset class="permission-scopes metron-discovery-types">
+          <legend>Pull content</legend>
+          <label>
+            <input v-model="discoveryDraft.pullComics" type="checkbox" />
+            <span>Comics</span>
+          </label>
+          <label>
+            <input v-model="discoveryDraft.pullReadingLists" type="checkbox" />
+            <span>Reading lists</span>
+          </label>
+        </fieldset>
+
+        <div class="metron-scan-fields">
+          <label class="metron-scan-field">
+            <span>Schedule</span>
+            <select v-model="discoveryDraft.schedule">
+              <option value="daily">Daily</option>
+              <option value="weekly">Weekly</option>
+              <option value="monthly">Monthly</option>
+            </select>
+          </label>
+          <label class="metron-scan-field">
+            <span>Start time (server time)</span>
+            <input v-model="discoveryDraft.startTime" type="time" />
+          </label>
+          <label class="metron-scan-field">
+            <span>Publisher name filter</span>
+            <input
+              v-model="discoveryDraft.publisherName"
+              type="text"
+              placeholder="All publishers"
+              :disabled="!discoveryDraft.pullComics"
+            />
+          </label>
+          <label class="metron-scan-field">
+            <span>Series name filter</span>
+            <input
+              v-model="discoveryDraft.seriesName"
+              type="text"
+              placeholder="All series"
+              :disabled="!discoveryDraft.pullComics"
+            />
+          </label>
+          <label v-if="discoveryDraft.schedule === 'monthly'" class="metron-scan-field">
+            <span>Day of month</span>
+            <input v-model.number="discoveryDraft.monthDay" type="number" min="1" max="31" />
+          </label>
+        </div>
+
+        <fieldset v-if="discoveryDraft.schedule === 'weekly'" class="permission-scopes">
+          <legend>Run on</legend>
+          <label v-for="day in weekdays" :key="`discovery-${day}`">
+            <input
+              type="checkbox"
+              :checked="(discoveryDraft.weekdays || []).includes(day)"
+              @change="toggleDiscoveryWeekday(day, $event.target.checked)"
+            />
+            <span>{{ day.charAt(0).toUpperCase() + day.slice(1) }}</span>
+          </label>
+        </fieldset>
+
+        <div class="metron-scan-status" aria-live="polite">
+          <div>
+            <strong>{{ metronComicDiscovery.found }}</strong>
+            <span>list results found</span>
+          </div>
+          <div>
+            <strong>{{ metronComicDiscovery.imported }}</strong>
+            <span>imported</span>
+          </div>
+          <div v-if="metronComicDiscovery.alreadyPresent">
+            <strong>{{ metronComicDiscovery.alreadyPresent }}</strong>
+            <span>already present</span>
+          </div>
+          <p>
+            <template v-if="metronComicDiscovery.running">Import running</template>
+            <template v-else-if="metronComicDiscovery.stopReason">
+              Last pull: {{ metronComicDiscovery.stopReason }}
+            </template>
+            <template v-else>Not run yet</template>
+          </p>
+        </div>
+
+        <div class="metron-scan-actions">
+          <button
+            type="button"
+            class="primary-button"
+            :disabled="
+              savingDiscovery || (!discoveryDraft.pullComics && !discoveryDraft.pullReadingLists)
+            "
+            @click="saveDiscovery"
+          >
+            {{ savingDiscovery ? 'Saving...' : 'Save settings' }}
+          </button>
+          <button
+            v-if="!metronComicDiscovery.running"
+            type="button"
+            class="secondary-action"
+            :disabled="
+              savingDiscovery ||
+              !discoveryDraft.enabled ||
+              (!discoveryDraft.pullComics && !discoveryDraft.pullReadingLists)
+            "
+            @click="startComicDiscovery"
+          >
+            {{ savingDiscovery ? 'Saving and starting...' : 'Pull now' }}
+          </button>
+          <button v-else type="button" class="danger-text-button" @click="$emit('stop-discovery')">
+            Stop pull
+          </button>
+        </div>
+      </section>
+
+      <section v-if="metronComicScan" class="account-settings-panel metron-scan-panel">
+        <header class="metron-scan-heading">
+          <div class="metron-scan-heading-copy">
+            <p class="eyebrow">Metron maintenance</p>
+            <h3>Incomplete comic data</h3>
+            <p class="muted">
+              Choose which missing fields make a comic incomplete. Issue responses also create
+              missing arc and character links without extra detail calls.
+            </p>
+          </div>
+          <label class="compact-toggle metron-scan-toggle">
+            <input v-model="draft.enabled" type="checkbox" />
+            <span>{{ draft.enabled ? 'Enabled' : 'Disabled' }}</span>
+          </label>
+        </header>
+
+        <fieldset class="permission-scopes metron-incomplete-fields">
+          <legend>Consider a comic incomplete when it has no</legend>
+          <label v-for="option in incompleteFieldOptions" :key="option.value">
+            <input
+              type="checkbox"
+              :checked="(draft.incompleteFields || []).includes(option.value)"
+              @change="toggleIncompleteField(option.value, $event.target.checked)"
+            />
+            <span>{{ option.label }}</span>
+          </label>
+        </fieldset>
+        <p v-if="!(draft.incompleteFields || []).length" class="access-note">
+          Select at least one field before saving or running this scan.
+        </p>
+
+        <div class="metron-scan-fields">
+          <label class="metron-scan-field">
+            <span>Schedule</span>
+            <select v-model="draft.schedule">
+              <option value="daily">Daily</option>
+              <option value="weekly">Specific weekdays</option>
+            </select>
+          </label>
+          <label class="metron-scan-field">
+            <span>Start time (server time)</span>
+            <input v-model="draft.startTime" type="time" />
+          </label>
+          <label class="metron-scan-field">
+            <span>Calls per day</span>
+            <input v-model.number="draft.dailyCallLimit" min="1" step="1" type="number" />
+          </label>
+          <label class="metron-scan-field">
+            <span>Minimum Metron interval (seconds)</span>
+            <input v-model.number="draft.minIntervalSeconds" min="0" step="1" type="number" />
+          </label>
+          <label class="metron-scan-field">
+            <span>Re-check cooldown (days)</span>
+            <input v-model.number="draft.recheckCooldownDays" min="0" step="1" type="number" />
+          </label>
+        </div>
+        <p class="muted metron-scan-hint">
+          Some issues have no publisher, cover date, or synopsis on Metron itself, so they can stay
+          "incomplete" no matter how often they're checked. The cooldown skips a comic for this many
+          days after it was last checked, so those rows stop using up the whole daily call budget.
+          Set to 0 to recheck everything every run.
+        </p>
+
+        <fieldset v-if="draft.schedule === 'weekly'" class="permission-scopes">
+          <legend>Run on</legend>
+          <label v-for="day in weekdays" :key="day">
+            <input
+              type="checkbox"
+              :checked="(draft.weekdays || []).includes(day)"
+              @change="toggleWeekday(day, $event.target.checked)"
+            />
+            <span>{{ day.charAt(0).toUpperCase() + day.slice(1) }}</span>
+          </label>
+        </fieldset>
+
+        <div class="metron-scan-status" aria-live="polite">
+          <div>
+            <strong>{{ metronComicScan.callsUsedToday }} / {{ draft.dailyCallLimit }}</strong>
+            <span>calls used today</span>
+          </div>
+          <div v-if="metronComicScan.running">
+            <strong>{{ metronComicScan.updated }}</strong>
+            <span
+              >updated ({{ metronComicScan.failed }} failed) from
+              {{ metronComicScan.scanned }} scanned</span
+            >
+          </div>
+          <p v-else>
+            Quota resets daily · {{ metronComicScan.usageDate }}
+            <template v-if="metronComicScan.stopReason">
+              · Last scan: {{ metronComicScan.stopReason }} ({{ metronComicScan.updated }} updated,
+              {{ metronComicScan.failed }} failed)
+            </template>
+          </p>
+        </div>
+
+        <div class="metron-scan-actions">
+          <button
+            type="button"
+            class="primary-button"
+            :disabled="saving || !(draft.incompleteFields || []).length"
+            @click="save"
+          >
+            {{ saving ? 'Saving...' : 'Save settings' }}
+          </button>
+          <button
+            v-if="!metronComicScan.running"
+            type="button"
+            class="secondary-action"
+            :disabled="saving || !draft.enabled || !(draft.incompleteFields || []).length"
+            @click="startComicScan"
+          >
+            {{ saving ? 'Saving and starting...' : 'Scan now' }}
+          </button>
+          <button v-else type="button" class="danger-text-button" @click="$emit('stop')">
+            Stop scan
+          </button>
+        </div>
+      </section>
+      <LoadingState v-else />
+    </div>
   </section>
 </template>

--- a/ui/src/features/settings/useMetronSettings.js
+++ b/ui/src/features/settings/useMetronSettings.js
@@ -1,16 +1,23 @@
 import { onUnmounted, ref, watch } from 'vue'
 import {
+  cblRepositorySyncEventsURL,
   createUserInvite,
+  getCBLRepositorySync,
+  listCBLRepositoryFiles,
   getMetronComicDiscovery,
   getMetronComicScan,
   metronComicDiscoveryEventsURL,
   metronComicScanEventsURL,
+  resolveCBLRepositoryMetronIssue,
   stopMetronComicDiscovery,
   stopMetronComicScan,
+  stopCBLRepositorySync,
+  triggerCBLRepositorySync,
   triggerMetronComicDiscovery,
   triggerMetronComicScan,
   updateMetronComicDiscovery,
   updateMetronComicScan,
+  updateCBLRepositorySync,
   updatePublicAccess,
   updateRegistrationMode,
 } from '@/api/client.js'
@@ -24,18 +31,28 @@ export function useMetronSettings({
 }) {
   const comicScan = ref(null)
   const comicDiscovery = ref(null)
+  const cblRepositorySync = ref(null)
+  const cblRepositoryFiles = ref([])
   const savingComicScan = ref(false)
   const savingComicDiscovery = ref(false)
+  const savingCBLRepositorySync = ref(false)
+  const loadingCBLRepositoryFiles = ref(false)
   const generatedInvite = ref(null)
   const generatingInvite = ref(false)
   const savingRegistrationMode = ref(false)
   const savingPublicAccess = ref(false)
   let comicScanEvents = null
   let comicDiscoveryEvents = null
+  let cblRepositorySyncEvents = null
+  let cblRepositorySyncRefreshTimer = null
+  let refreshingCBLRepositorySync = false
 
   async function loadSettings() {
     if (!connectComicScanEvents()) comicScan.value = await getMetronComicScan()
     if (!connectComicDiscoveryEvents()) comicDiscovery.value = await getMetronComicDiscovery()
+    connectCBLRepositorySyncEvents()
+    cblRepositorySync.value = await getCBLRepositorySync()
+    scheduleCBLRepositorySyncRefresh()
   }
 
   async function saveComicScan(settings) {
@@ -44,10 +61,13 @@ export function useMetronSettings({
     })
   }
 
-  async function runComicScan() {
+  async function runComicScan(settings) {
+    savingComicScan.value = true
     await run(async () => {
+      comicScan.value = await updateMetronComicScan(settings)
       comicScan.value = await triggerMetronComicScan()
     })
+    savingComicScan.value = false
   }
 
   async function cancelComicScan() {
@@ -62,15 +82,63 @@ export function useMetronSettings({
     })
   }
 
-  async function runComicDiscovery() {
+  async function runComicDiscovery(settings) {
+    savingComicDiscovery.value = true
     await run(async () => {
+      comicDiscovery.value = await updateMetronComicDiscovery(settings)
       comicDiscovery.value = await triggerMetronComicDiscovery()
     })
+    savingComicDiscovery.value = false
   }
 
   async function cancelComicDiscovery() {
     await run(async () => {
       comicDiscovery.value = await stopMetronComicDiscovery()
+    })
+  }
+
+  async function saveCBLRepositorySync(settings) {
+    await withSaving(savingCBLRepositorySync, async () => {
+      cblRepositorySync.value = await updateCBLRepositorySync(settings)
+    })
+  }
+
+  async function loadCBLRepositoryFiles(settings) {
+    loadingCBLRepositoryFiles.value = true
+    cblRepositoryFiles.value = []
+    await run(async () => {
+      cblRepositorySync.value = await updateCBLRepositorySync(settings)
+      const files = await listCBLRepositoryFiles()
+      cblRepositoryFiles.value = Array.isArray(files) ? files : []
+    })
+    loadingCBLRepositoryFiles.value = false
+  }
+
+  async function runCBLRepositorySync(request) {
+    const settings = request?.settings || request
+    const files = Array.isArray(request?.files) ? request.files : []
+    const resolveMissingOnMetron = Boolean(request?.resolveMissingOnMetron)
+    savingCBLRepositorySync.value = true
+    await run(async () => {
+      cblRepositorySync.value = await updateCBLRepositorySync(settings)
+      cblRepositorySync.value = await triggerCBLRepositorySync({
+        files,
+        resolveMissingOnMetron,
+      })
+      scheduleCBLRepositorySyncRefresh(0)
+    })
+    savingCBLRepositorySync.value = false
+  }
+
+  async function cancelCBLRepositorySync() {
+    await run(async () => {
+      cblRepositorySync.value = await stopCBLRepositorySync()
+    })
+  }
+
+  async function resolveCBLMetronIssue(selection) {
+    await run(async () => {
+      cblRepositorySync.value = await resolveCBLRepositoryMetronIssue(selection)
     })
   }
 
@@ -141,12 +209,27 @@ export function useMetronSettings({
     return true
   }
 
-  function connectEvents({ url, eventName, payloadKey, target, close, fallback }) {
+  function connectCBLRepositorySyncEvents() {
+    if (cblRepositorySyncEvents || typeof EventSource === 'undefined') return false
+    cblRepositorySyncEvents = connectEvents({
+      url: cblRepositorySyncEventsURL(),
+      eventName: 'sync',
+      payloadKey: 'sync',
+      target: cblRepositorySync,
+      close: closeCBLRepositorySyncEvents,
+      fallback: getCBLRepositorySync,
+      onUpdate: scheduleCBLRepositorySyncRefresh,
+    })
+    return true
+  }
+
+  function connectEvents({ url, eventName, payloadKey, target, close, fallback, onUpdate }) {
     const source = new EventSource(url, { withCredentials: true })
     source.addEventListener(eventName, (event) => {
       try {
         const payload = JSON.parse(event.data)
         target.value = payload[payloadKey] || payload
+        onUpdate?.()
       } catch (err) {
         error.value = err.message
       }
@@ -175,6 +258,47 @@ export function useMetronSettings({
     comicDiscoveryEvents = null
   }
 
+  function closeCBLRepositorySyncEvents() {
+    cblRepositorySyncEvents?.close()
+    cblRepositorySyncEvents = null
+  }
+
+  function scheduleCBLRepositorySyncRefresh(delay) {
+    clearTimeout(cblRepositorySyncRefreshTimer)
+    if (activeView.value !== 'settings') return
+    const refreshDelay = delay ?? (cblRepositorySync.value?.running ? 750 : 5000)
+    cblRepositorySyncRefreshTimer = setTimeout(refreshCBLRepositorySyncStatus, refreshDelay)
+  }
+
+  async function refreshCBLRepositorySyncStatus() {
+    if (activeView.value !== 'settings' || refreshingCBLRepositorySync) return
+    refreshingCBLRepositorySync = true
+    try {
+      const status = await getCBLRepositorySync()
+      // Do not let a request started before a manual trigger briefly replace the
+      // new running state with the preceding idle snapshot.
+      if (!(
+        cblRepositorySync.value?.running &&
+        !status.running &&
+        !status.finishedAt &&
+        cblRepositorySync.value?.startedAt
+      )) {
+        cblRepositorySync.value = status
+      }
+    } catch {
+      // The SSE connection remains the primary live update path. A failed
+      // fallback refresh should not replace a more useful settings-page error.
+    } finally {
+      refreshingCBLRepositorySync = false
+      scheduleCBLRepositorySyncRefresh()
+    }
+  }
+
+  function stopCBLRepositorySyncRefresh() {
+    clearTimeout(cblRepositorySyncRefreshTimer)
+    cblRepositorySyncRefreshTimer = null
+  }
+
   async function withSaving(savingRef, action) {
     savingRef.value = true
     await run(action)
@@ -191,21 +315,32 @@ export function useMetronSettings({
   }
 
   watch(activeView, (view) => {
-    if (view === 'settings') return
+    if (view === 'settings') {
+      scheduleCBLRepositorySyncRefresh(0)
+      return
+    }
     closeComicScanEvents()
     closeComicDiscoveryEvents()
+    closeCBLRepositorySyncEvents()
+    stopCBLRepositorySyncRefresh()
   })
 
   onUnmounted(() => {
     closeComicScanEvents()
     closeComicDiscoveryEvents()
+    closeCBLRepositorySyncEvents()
+    stopCBLRepositorySyncRefresh()
   })
 
   return {
     comicScan,
     comicDiscovery,
+    cblRepositorySync,
+    cblRepositoryFiles,
     savingComicScan,
     savingComicDiscovery,
+    savingCBLRepositorySync,
+    loadingCBLRepositoryFiles,
     generatedInvite,
     generatingInvite,
     savingRegistrationMode,
@@ -217,6 +352,11 @@ export function useMetronSettings({
     saveComicDiscovery,
     runComicDiscovery,
     cancelComicDiscovery,
+    saveCBLRepositorySync,
+    loadCBLRepositoryFiles,
+    runCBLRepositorySync,
+    cancelCBLRepositorySync,
+    resolveCBLMetronIssue,
     generateInvite,
     saveRegistration,
     savePublic,

--- a/ui/src/router/appRouteState.js
+++ b/ui/src/router/appRouteState.js
@@ -38,7 +38,6 @@ const BROWSE_ROUTE_NAMES = {
   comics: 'comics',
   series: 'series',
   characters: 'characters',
-  metron: 'metron',
   users: 'users',
   settings: 'settings',
   account: 'account',

--- a/ui/src/router/appRouteState.test.js
+++ b/ui/src/router/appRouteState.test.js
@@ -29,6 +29,7 @@ test('maps valid entity routes and rejects invalid IDs', () => {
 
 test('builds browse, detail, and edit route locations', () => {
   assert.deepEqual(browseRouteLocation('readingOrders'), { name: 'readingOrders' })
+  assert.equal(browseRouteLocation('metron'), null)
   assert.deepEqual(detailRouteLocation('characters', 7), {
     name: 'characterDetail',
     params: { id: 7 },

--- a/ui/src/router/index.js
+++ b/ui/src/router/index.js
@@ -144,9 +144,7 @@ export const router = createRouter({
     },
     {
       path: '/metron',
-      name: 'metron',
-      component: EmptyRouteView,
-      meta: { eyebrow: 'Metron', title: 'Import from Metron', requiresMetron: true },
+      redirect: { name: 'settings', query: { tab: 'metron' } },
     },
     {
       path: '/users',

--- a/ui/src/styles/administration.css
+++ b/ui/src/styles/administration.css
@@ -12,6 +12,41 @@
   max-width: 1160px;
 }
 
+.settings-tabs {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 6px;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  background: var(--panel-soft-bg);
+  padding: 6px;
+}
+
+.settings-tabs button {
+  min-width: 0;
+  min-height: 42px;
+  border: 0;
+  border-radius: 7px;
+  background: transparent;
+  color: var(--label-ink);
+  padding: 9px 12px;
+  font-weight: 800;
+}
+
+.settings-tabs button.active {
+  background: var(--primary);
+  color: #ffffff;
+}
+
+.settings-tab-panel {
+  min-width: 0;
+}
+
+.settings-metron-panel {
+  display: grid;
+  gap: 20px;
+}
+
 .metron-scan-panel {
   gap: 22px;
   border-radius: 12px;
@@ -55,12 +90,232 @@
 }
 
 .metron-scan-field input,
-.metron-scan-field select {
+.metron-scan-field select,
+.metron-scan-field textarea {
   width: 100%;
+}
+
+.metron-scan-field input,
+.metron-scan-field select {
   height: 44px;
   min-height: 44px;
   padding-block: 0;
   line-height: 1.2;
+}
+
+.cbl-repository-list-field {
+  max-width: 760px;
+}
+
+.cbl-repository-list-field textarea {
+  min-height: 104px;
+  resize: vertical;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-weight: 650;
+}
+
+.cbl-auto-sync-toggle {
+  justify-self: start;
+}
+
+.cbl-manual-metron-option {
+  display: grid;
+  justify-items: start;
+  gap: 5px;
+  border-left: 3px solid var(--line-strong);
+  padding-left: 12px;
+}
+
+.cbl-manual-metron-option small {
+  max-width: 720px;
+  color: var(--muted);
+  font-weight: 650;
+}
+
+.cbl-file-picker {
+  width: min(920px, 100%);
+  max-height: min(820px, calc(100vh - 36px));
+  display: grid;
+  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  border: 1px solid var(--line-strong);
+  border-radius: 10px;
+  background: var(--panel-bg);
+  box-shadow: 0 22px 56px var(--shadow-panel);
+  overflow: hidden;
+}
+
+.cbl-file-picker-header,
+.cbl-file-picker-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+}
+
+.cbl-file-picker-header {
+  border-bottom: 1px solid var(--line);
+}
+
+.cbl-file-picker-header > div {
+  display: grid;
+  gap: 3px;
+}
+
+.cbl-file-picker-header small,
+.cbl-file-picker-actions span,
+.cbl-file-picker-path small {
+  color: var(--muted);
+  font-size: 0.82rem;
+  font-weight: 700;
+}
+
+.cbl-file-picker-tools {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) auto;
+  gap: 10px;
+  border-bottom: 1px solid var(--line);
+  padding: 12px 16px;
+}
+
+.cbl-file-picker-tools input {
+  width: 100%;
+  min-height: 42px;
+}
+
+.cbl-file-picker-list {
+  min-height: 0;
+  overflow: auto;
+  display: grid;
+  align-content: start;
+  padding: 6px 16px;
+}
+
+.cbl-file-picker-list > div {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  border-bottom: 1px solid var(--line);
+  padding: 10px 2px;
+}
+
+.cbl-file-picker-list > div > label {
+  min-width: 0;
+  flex: 1 1 auto;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  cursor: pointer;
+}
+
+.cbl-file-picker-list > div:last-of-type {
+  border-bottom: 0;
+}
+
+.cbl-file-picker-list input {
+  margin-top: 3px;
+}
+
+.cbl-file-picker-path {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.cbl-file-picker-path strong {
+  overflow-wrap: anywhere;
+}
+
+.cbl-file-picker-more {
+  justify-self: center;
+  display: grid;
+  gap: 2px;
+  min-width: min(280px, 100%);
+  margin: 12px 0 8px;
+}
+
+.cbl-file-picker-more small {
+  color: var(--muted);
+  font-size: 0.74rem;
+}
+
+.cbl-select-parts-button {
+  flex: 0 0 auto;
+  border: 0;
+  background: transparent;
+  color: var(--accent);
+  padding: 6px 8px;
+  font-size: 0.78rem;
+  font-weight: 850;
+}
+
+.cbl-select-parts-button:disabled {
+  color: var(--muted);
+}
+
+.cbl-file-picker-actions {
+  justify-content: flex-end;
+  border-top: 1px solid var(--line);
+}
+
+.cbl-file-picker-actions span {
+  margin-right: auto;
+}
+
+.cbl-metron-issue-picker {
+  width: min(760px, 100%);
+  grid-template-rows: auto minmax(0, 1fr) auto;
+}
+
+.cbl-metron-candidate-list {
+  min-height: 0;
+  overflow: auto;
+  display: grid;
+  align-content: start;
+  gap: 10px;
+  padding: 16px;
+}
+
+.cbl-metron-candidate {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 10px;
+  color: inherit;
+  text-align: left;
+}
+
+.cbl-metron-candidate:hover,
+.cbl-metron-candidate:focus-visible {
+  border-color: var(--accent);
+}
+
+.cbl-metron-candidate img {
+  width: 58px;
+  height: 82px;
+  flex: 0 0 auto;
+  border-radius: 5px;
+  object-fit: cover;
+}
+
+.cbl-metron-candidate-copy {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.cbl-metron-candidate-copy strong {
+  overflow-wrap: anywhere;
+}
+
+.cbl-metron-candidate-copy small {
+  color: var(--muted);
+  font-weight: 700;
 }
 
 .metron-scan-status {
@@ -98,6 +353,7 @@
 .metron-scan-actions {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 10px;
 }
 

--- a/ui/src/styles/responsive-mobile.css
+++ b/ui/src/styles/responsive-mobile.css
@@ -32,6 +32,36 @@
     width: 100%;
   }
 
+  .cbl-file-picker-tools {
+    grid-template-columns: 1fr;
+  }
+
+  .cbl-file-picker-tools input {
+    grid-column: auto;
+  }
+
+  .cbl-file-picker-list > div {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .cbl-select-parts-button {
+    align-self: flex-start;
+  }
+
+  .cbl-file-picker-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .cbl-file-picker-actions span {
+    margin-right: 0;
+  }
+
+  .cbl-metron-candidate {
+    align-items: flex-start;
+  }
+
   .sidebar {
     padding: 12px;
   }


### PR DESCRIPTION
## Summary
- replace the standalone Metron navigation page with a URL-backed Metron tab in App Settings
- add General, Metron, and CBL repositories settings tabs
- keep old /metron links working by redirecting them to /settings?tab=metron
- place manual Metron imports, automatic discovery, and incomplete-data maintenance together in the Metron tab
- add configurable automatic and manual CBL repository imports, including changed-file updates, multipart lists, selective imports, and optional Metron resolution
- keep CBL import status live and automatically surface ambiguous Metron matches in the CBL repositories tab

## Verification
- GOCACHE=/tmp/comichero-go-cache go test ./...
- npm run format
- npm run lint
- npm run test
- npm run build
- git diff --check