### PR TITLE
Move reading-order entries across editor pages

### DIFF
--- a/ui/src/features/reading-orders/components/ReadingOrderEditor.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrderEditor.vue
@@ -6,6 +6,7 @@ import { comicLabel } from '@/features/comics/model.js'
 import {
   readingOrderEditorPage,
   readingOrderEditorPageSize,
+  reorderReadingOrderEntry,
 } from '@/features/reading-orders/model.js'
 
 const props = defineProps({
@@ -344,15 +345,15 @@ function moveEntry(index, offset) {
 }
 
 function reorderEntry(fromIndex, toIndex) {
-  if (fromIndex === toIndex) return
-  if (fromIndex < 0 || toIndex < 0) return
-  if (fromIndex >= orderEntries.value.length || toIndex >= orderEntries.value.length) return
-
-  const entries = [...orderEntries.value]
-  const [entry] = entries.splice(fromIndex, 1)
-
-  entries.splice(toIndex, 0, entry)
+  const entries = reorderReadingOrderEntry(orderEntries.value, fromIndex, toIndex)
+  if (entries === orderEntries.value) return
   updateForm({ entries })
+}
+
+function moveEntryAcrossPage(index, direction) {
+  const targetPage = entryPageState.value.page + direction
+  reorderEntry(index, index + direction)
+  entryPage.value = targetPage
 }
 
 function startDrag(event, index) {
@@ -714,6 +715,35 @@ function endDrag() {
               >
                 <span aria-hidden="true">×</span>
               </button>
+
+              <div
+                v-if="
+                  (index === entryPageState.start && entryPageState.page > 0) ||
+                  (index === entryPageState.end - 1 &&
+                    entryPageState.page < entryPageState.pageCount - 1)
+                "
+                class="entry-page-move"
+              >
+                <button
+                  v-if="index === entryPageState.start && entryPageState.page > 0"
+                  type="button"
+                  class="secondary-button"
+                  @click="moveEntryAcrossPage(index, -1)"
+                >
+                  Move to previous page
+                </button>
+                <button
+                  v-if="
+                    index === entryPageState.end - 1 &&
+                    entryPageState.page < entryPageState.pageCount - 1
+                  "
+                  type="button"
+                  class="secondary-button"
+                  @click="moveEntryAcrossPage(index, 1)"
+                >
+                  Move to next page
+                </button>
+              </div>
 
               <div v-if="isEntryExpanded(entry, index)" class="entry-edit-panel">
                 <template v-if="entry.type === 'section'">

--- a/ui/src/features/reading-orders/model.js
+++ b/ui/src/features/reading-orders/model.js
@@ -15,6 +15,26 @@ export function emptyReadingOrder() {
 
 export const readingOrderEditorPageSize = 100
 
+export function reorderReadingOrderEntry(entries, fromIndex, toIndex) {
+  const source = Array.isArray(entries) ? entries : []
+  if (
+    !Number.isInteger(fromIndex) ||
+    !Number.isInteger(toIndex) ||
+    fromIndex < 0 ||
+    toIndex < 0 ||
+    fromIndex >= source.length ||
+    toIndex >= source.length ||
+    fromIndex === toIndex
+  ) {
+    return source
+  }
+
+  const reordered = [...source]
+  const [entry] = reordered.splice(fromIndex, 1)
+  reordered.splice(toIndex, 0, entry)
+  return reordered
+}
+
 export function readingOrderEditorPage(
   entries,
   requestedPage,

--- a/ui/src/features/reading-orders/model.test.js
+++ b/ui/src/features/reading-orders/model.test.js
@@ -6,6 +6,7 @@ import {
   readingOrderDisplayComics,
   readingOrderEditorPage,
   readingOrderFormFromDetail,
+  reorderReadingOrderEntry,
 } from './model.js'
 
 test('maps section entries between API detail and editor payloads', () => {
@@ -43,6 +44,17 @@ test('drops untitled sections from the save payload', () => {
   })
 
   assert.deepEqual(payload.entries, [{ type: 'comic', comicId: 2, comment: '', tags: '' }])
+})
+
+test('moves reading-order entries across editor page boundaries', () => {
+  const entries = Array.from({ length: 101 }, (_, index) => ({ comicId: index + 1 }))
+
+  const movedForward = reorderReadingOrderEntry(entries, 99, 100)
+  assert.equal(movedForward[99].comicId, 101)
+  assert.equal(movedForward[100].comicId, 100)
+
+  const movedBack = reorderReadingOrderEntry(movedForward, 100, 99)
+  assert.deepEqual(movedBack, entries)
 })
 
 test('groups nested reading-order issues separately and then resumes the parent section', () => {

--- a/ui/src/styles/reading-order-editor.css
+++ b/ui/src/styles/reading-order-editor.css
@@ -309,6 +309,19 @@
   color: var(--danger);
 }
 
+.entry-page-move {
+  display: flex;
+  grid-column: 1 / -1;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.entry-page-move button {
+  min-height: 36px;
+  padding: 7px 12px;
+  font-size: 0.82rem;
+}
+
 .empty-state {
   display: grid;
   gap: 12px;


### PR DESCRIPTION
## Summary
- add explicit previous-page and next-page controls to boundary entries in the paginated reading-order editor
- follow the moved entry to its destination page
- share the reorder operation through a tested model helper

## Verification
- npm run format
- npm run lint
- npm run test
- npm run build
- git diff --check