### PR TITLE
Remove unused space above edit toolbars

### DIFF
--- a/ui/src/styles/app-shell.css
+++ b/ui/src/styles/app-shell.css
@@ -547,7 +547,8 @@ h4 {
   margin-top: calc(var(--content-padding) * -1);
 }
 
-.detail-nav.sticky-toolbar {
+.detail-nav.sticky-toolbar,
+.editor-header.sticky-toolbar {
   margin-top: calc(var(--content-padding) * -1);
 }
 


### PR DESCRIPTION
## Summary
- apply the shared top content-padding offset to sticky edit headers
- align edit views with the already-corrected detail-view toolbar placement
- preserve the responsive content-padding values across desktop, tablet, and mobile

## Verification
- npm run format
- npm run lint
- npm run test
- npm run build
- git diff --check