### PR TITLE
Add spacing below the App Settings toolbar

### DIFF
--- a/ui/src/styles/administration.css
+++ b/ui/src/styles/administration.css
@@ -10,6 +10,7 @@
   display: grid;
   gap: 20px;
   max-width: 1160px;
+  padding-top: 18px;
 }
 
 .settings-tabs {


### PR DESCRIPTION
## Summary
- add the missing post-toolbar spacing above the App Settings tab bar
- match the established dashboard section spacing

## Verification
- npm run format
- npm run lint
- npm run test
- npm run build
- git diff --check