### PR TITLE
Let edit views use the full page width

### DIFF
--- a/ui/src/styles/browse-detail.css
+++ b/ui/src/styles/browse-detail.css
@@ -97,7 +97,7 @@
 .editor-view {
   display: grid;
   gap: 18px;
-  max-width: 960px;
+  width: 100%;
 }
 
 .editor-header {


### PR DESCRIPTION
## Summary
- remove the 960px width cap from edit views
- let editor toolbars and forms fill the available content area

## Verification
- npm run format
- npm run lint
- npm run test
- npm run build
- git diff --check