### PR TITLE
Fix App Settings tab navigation

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -399,7 +399,10 @@ async function enforceCurrentRouteAccess() {
 
 function routeLocationForCurrentState() {
   if (activeView.value === 'notFound') return route.fullPath
-  if (viewMode.value === 'browse') return browseRouteLocation(activeView.value)
+  if (viewMode.value === 'browse') {
+    const query = activeView.value === 'settings' && route.name === 'settings' ? route.query : null
+    return browseRouteLocation(activeView.value, query)
+  }
   if (viewMode.value === 'detail') {
     if (activeView.value === 'readingOrders')
       return detailRouteLocation(activeView.value, selectedOrder.value?.id)

--- a/ui/src/router/appRouteState.js
+++ b/ui/src/router/appRouteState.js
@@ -15,9 +15,10 @@ export function routeToAppState(route) {
   return { view: 'dashboard', mode: 'browse', replace: true }
 }
 
-export function browseRouteLocation(view) {
+export function browseRouteLocation(view, query) {
   const name = BROWSE_ROUTE_NAMES[view]
-  return name ? { name } : null
+  if (!name) return null
+  return query && Object.keys(query).length ? { name, query } : { name }
 }
 
 export function detailRouteLocation(view, id) {

--- a/ui/src/router/appRouteState.test.js
+++ b/ui/src/router/appRouteState.test.js
@@ -29,6 +29,10 @@ test('maps valid entity routes and rejects invalid IDs', () => {
 
 test('builds browse, detail, and edit route locations', () => {
   assert.deepEqual(browseRouteLocation('readingOrders'), { name: 'readingOrders' })
+  assert.deepEqual(browseRouteLocation('settings', { tab: 'metron' }), {
+    name: 'settings',
+    query: { tab: 'metron' },
+  })
   assert.equal(browseRouteLocation('metron'), null)
   assert.deepEqual(detailRouteLocation('characters', 7), {
     name: 'characterDetail',


### PR DESCRIPTION
## Summary
- preserve the App Settings tab query during route-state synchronization
- stop Metron and CBL repository tab selections from immediately reverting to General
- add regression coverage for query-backed settings route locations

## Verification
- npm run format
- npm run lint
- npm run test
- npm run build
- git diff --check