### PR TITLE
Make Back buttons pop browser history

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -39,6 +39,7 @@ import { useSeries } from '@/features/series/useSeries.js'
 import { useTheme } from '@/shared/composables/useTheme.js'
 import { useUserAdministration } from '@/features/users/useUserAdministration.js'
 import {
+  backFallbackRouteLocation,
   browseRouteLocation,
   detailRouteLocation,
   editRouteLocation,
@@ -525,11 +526,15 @@ async function activateRoute(route) {
 
 async function backToPreviousPage() {
   error.value = ''
+  await popHistoryOrReplace(backFallbackRouteLocation(activeView.value))
+}
+
+async function popHistoryOrReplace(fallback) {
   if (window.history.state?.back) {
     router.back()
     return
   }
-  await router.push(browseRouteLocation(activeView.value) || { name: 'readingOrders' })
+  await router.replace(fallback)
 }
 
 async function loadData(force = false) {
@@ -618,21 +623,19 @@ async function loadMoreActiveViewData() {
   }
 }
 
-function cancelEdit() {
+async function cancelEdit() {
   error.value = ''
+  let selectedID = null
   if (activeView.value === 'readingOrders' && selectedOrder.value) {
-    viewMode.value = 'detail'
-    return
+    selectedID = selectedOrder.value.id
   }
   if (activeView.value === 'arcs' && selectedArc.value) {
-    viewMode.value = 'detail'
-    return
+    selectedID = selectedArc.value.id
   }
   if (activeView.value === 'comics' && selectedComic.value) {
-    viewMode.value = 'detail'
-    return
+    selectedID = selectedComic.value.id
   }
-  viewMode.value = 'browse'
+  await popHistoryOrReplace(backFallbackRouteLocation(activeView.value, selectedID))
 }
 
 function showError(message) {

--- a/ui/src/router/appRouteState.js
+++ b/ui/src/router/appRouteState.js
@@ -25,6 +25,10 @@ export function detailRouteLocation(view, id) {
   return name && id ? { name, params: { id } } : null
 }
 
+export function backFallbackRouteLocation(view, id) {
+  return detailRouteLocation(view, id) || browseRouteLocation(view) || { name: 'readingOrders' }
+}
+
 export function editRouteLocation(view, id) {
   const routes = EDIT_ROUTE_NAMES[view]
   if (!routes) return browseRouteLocation(view)

--- a/ui/src/router/appRouteState.test.js
+++ b/ui/src/router/appRouteState.test.js
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 import {
+  backFallbackRouteLocation,
   browseRouteLocation,
   detailRouteLocation,
   editRouteLocation,
@@ -36,6 +37,15 @@ test('builds browse, detail, and edit route locations', () => {
   })
   assert.deepEqual(editRouteLocation('arcs'), { name: 'arcsNew' })
   assert.deepEqual(editRouteLocation('arcs', 9), { name: 'arcEdit', params: { id: 9 } })
+})
+
+test('builds detail-aware Back fallbacks without creating a second navigation model', () => {
+  assert.deepEqual(backFallbackRouteLocation('comics', 42), {
+    name: 'comicDetail',
+    params: { id: 42 },
+  })
+  assert.deepEqual(backFallbackRouteLocation('comics'), { name: 'comics' })
+  assert.deepEqual(backFallbackRouteLocation('unknown'), { name: 'readingOrders' })
 })
 
 test('falls back to the dashboard for unknown routes', () => {


### PR DESCRIPTION
## Summary
- route all detail and edit Back actions through one pop-or-replace history path
- stop edit cancellation from pushing the detail route back onto history
- replace direct-link fallbacks instead of pushing them
- add regression coverage for detail-aware fallback locations

## Verification
- audited all visible Back controls
- npm run format
- npm run lint
- npm run test
- npm run build
- git diff --check