### PR TITLE
Hide reading-order memberships on comic details

### DIFF
--- a/ui/src/features/comics/components/ComicDetailView.vue
+++ b/ui/src/features/comics/components/ComicDetailView.vue
@@ -241,15 +241,6 @@ function seriesLabel(comic) {
             </button>
           </div>
         </div>
-
-        <div v-if="selectedComic.readingOrders?.length" class="preview-list">
-          <p class="eyebrow">Reading Orders</p>
-          <ul>
-            <li v-for="order in selectedComic.readingOrders" :key="order.id">
-              {{ order.name }}
-            </li>
-          </ul>
-        </div>
       </div>
       <p v-else class="empty-state">Select a comic to view it.</p>
     </article>


### PR DESCRIPTION
## Summary
- remove the Reading Orders membership list from comic detail pages
- leave reading-order relationships and API data unchanged

## Verification
- npm run format
- npm run lint
- npm run test
- npm run build
- git diff --check