### PR TITLE
Use first comic cover for reading orders without artwork

### DIFF
--- a/backend/internal/api/models_reading_orders.go
+++ b/backend/internal/api/models_reading_orders.go
@@ -5,9 +5,10 @@ type ReadingOrder struct {
 	MetronReadingListID *int `json:"metronReadingListId,omitempty"       db:"metron_reading_list_id" doc:"Linked Metron reading-list identifier, when imported." example:"9876"`
 	AuthorUserID        *int `json:"authorUserId,omitempty"              db:"author_user_id"         doc:"User who created or owns this reading order." example:"1"`
 
-	Name          string   `json:"name"        db:"name"        doc:"Reading-order name." example:"Batman: Court of Owls"`
-	Description   string   `json:"description" db:"description" doc:"Reading-order description or notes."`
-	Image         string   `json:"image"       db:"image"       doc:"Reading-list thumbnail image URL from Metron, when imported." format:"uri"`
+	Name          string   `json:"name"         db:"name"          doc:"Reading-order name." example:"Batman: Court of Owls"`
+	Description   string   `json:"description"  db:"description"   doc:"Reading-order description or notes."`
+	Image         string   `json:"image"        db:"image"         doc:"Explicit reading-order thumbnail image URL, when set." format:"uri"`
+	DisplayImage  string   `json:"displayImage" db:"display_image" doc:"Image shown in the UI: the explicit reading-order image, or the first available comic cover in reading order." format:"uri"`
 	IsPublic      bool     `json:"isPublic"    db:"is_public"   doc:"Whether users other than the creator may view this reading order." example:"true"`
 	Favorite      bool     `json:"favorite"    db:"favorite"    doc:"Whether this reading order is marked as a favorite." example:"true"`
 	FavoriteCount int      `json:"favoriteCount" db:"favorite_count" doc:"Number of users who favorited this reading order." example:"12"`

--- a/backend/internal/api/readingorders_detail.go
+++ b/backend/internal/api/readingorders_detail.go
@@ -36,6 +36,15 @@ func getReadingOrderRow(ctx context.Context, db *sqlx.DB, id int) (ReadingOrder,
 			ro.name,
 			ro.description,
 			ro.image,
+			COALESCE(NULLIF(TRIM(ro.image), ''), (
+				SELECT cover_comic.cover_image
+				FROM reading_order_comics cover_entry
+				JOIN comics cover_comic ON cover_comic.id = cover_entry.comic_id
+				WHERE cover_entry.reading_order_id = ro.id
+					AND TRIM(cover_comic.cover_image) <> ''
+				ORDER BY cover_entry.position, cover_entry.rowid
+				LIMIT 1
+			), '') AS display_image,
 			ro.is_public,
 			COALESCE(preference.favorite, 0) AS favorite,
 			(SELECT COUNT(*) FROM user_reading_orders stats WHERE stats.reading_order_id = ro.id AND stats.favorite = 1) AS favorite_count,
@@ -184,6 +193,15 @@ func fetchReadingOrderEntries(ctx context.Context, db *sqlx.DB, readingOrderID i
 			ro.name,
 			ro.description,
 			ro.image,
+			COALESCE(NULLIF(TRIM(ro.image), ''), (
+				SELECT cover_comic.cover_image
+				FROM reading_order_comics cover_entry
+				JOIN comics cover_comic ON cover_comic.id = cover_entry.comic_id
+				WHERE cover_entry.reading_order_id = ro.id
+					AND TRIM(cover_comic.cover_image) <> ''
+				ORDER BY cover_entry.position, cover_entry.rowid
+				LIMIT 1
+			), '') AS display_image,
 			ro.is_public,
 			COALESCE(preference.favorite, 0) AS favorite,
 			0.0 AS progress,

--- a/backend/internal/api/readingorders_list.go
+++ b/backend/internal/api/readingorders_list.go
@@ -64,6 +64,15 @@ func readingOrderListQuery(input *ReadingOrderListInput, userID int, editUserID 
 			ro.name,
 			ro.description,
 			ro.image,
+			COALESCE(NULLIF(TRIM(ro.image), ''), (
+				SELECT cover_comic.cover_image
+				FROM reading_order_comics cover_entry
+				JOIN comics cover_comic ON cover_comic.id = cover_entry.comic_id
+				WHERE cover_entry.reading_order_id = ro.id
+					AND TRIM(cover_comic.cover_image) <> ''
+				ORDER BY cover_entry.position, cover_entry.rowid
+				LIMIT 1
+			), '') AS display_image,
 			ro.is_public,
 			COALESCE(preference.favorite, 0) AS favorite,
 			(SELECT COUNT(*) FROM user_reading_orders stats WHERE stats.reading_order_id = ro.id AND stats.favorite = 1) AS favorite_count,

--- a/backend/internal/api/readingorders_test.go
+++ b/backend/internal/api/readingorders_test.go
@@ -57,6 +57,49 @@ func TestReadingOrderHelpers(t *testing.T) {
 	}
 }
 
+func TestReadingOrderDisplayImageFallsBackToFirstComicCover(t *testing.T) {
+	db := setupReadingOrderCBLTestDB(t)
+	ctx := testUserContext()
+	if _, err := db.ExecContext(ctx, `
+		INSERT INTO comics (id, series, series_year, issue, publisher, cover_image) VALUES
+			(1, 'Fallback', 2026, '1', 'Publisher', ''),
+			(2, 'Fallback', 2026, '2', 'Publisher', '/covers/second.jpg'),
+			(3, 'Explicit', 2026, '1', 'Publisher', '/covers/comic.jpg');
+		INSERT INTO reading_orders (id, name, image, author_user_id) VALUES
+			(10, 'Fallback order', '', 1),
+			(11, 'Explicit order', '/covers/custom.jpg', 1);
+		INSERT INTO reading_order_comics (reading_order_id, comic_id, position) VALUES
+			(10, 2, 2),
+			(10, 1, 1),
+			(11, 3, 1);
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	listed, err := listReadingOrders(ctx, db, &ReadingOrderListInput{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	byID := map[int]ReadingOrder{}
+	for _, order := range listed.Body {
+		byID[order.ID] = order
+	}
+	if byID[10].Image != "" || byID[10].DisplayImage != "/covers/second.jpg" {
+		t.Fatalf("fallback list image = image %q display %q", byID[10].Image, byID[10].DisplayImage)
+	}
+	if byID[11].DisplayImage != "/covers/custom.jpg" {
+		t.Fatalf("explicit list display image = %q; want custom cover", byID[11].DisplayImage)
+	}
+
+	detail, err := getReadingOrder(ctx, db, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if detail.Body.Image != "" || detail.Body.DisplayImage != "/covers/second.jpg" {
+		t.Fatalf("fallback detail image = image %q display %q", detail.Body.Image, detail.Body.DisplayImage)
+	}
+}
+
 func TestReadingOrderEntriesCanNestOrdersBetweenComics(t *testing.T) {
 	ctx := testUserContext()
 	db, err := sqlx.Open("sqlite", ":memory:")

--- a/ui/src/features/reading-orders/components/ReadingOrderDetailView.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrderDetailView.vue
@@ -7,6 +7,7 @@ import ComicListView from '@/features/comics/components/ComicListView.vue'
 import {
   formatProgress,
   formatRating,
+  readingOrderCover,
   readingOrderDisplayComics,
 } from '@/features/reading-orders/model.js'
 
@@ -137,9 +138,9 @@ const displayComics = computed(() => readingOrderDisplayComics(props.selectedOrd
         </header>
 
         <div class="reading-order-summary">
-          <div v-if="selectedOrder.image" class="reading-order-thumbnail">
+          <div v-if="readingOrderCover(selectedOrder)" class="reading-order-thumbnail">
             <img
-              :src="assetURL(selectedOrder.image)"
+              :src="assetURL(readingOrderCover(selectedOrder))"
               :alt="`${selectedOrder.name} thumbnail`"
               loading="lazy"
             />

--- a/ui/src/features/reading-orders/components/ReadingOrdersBrowseView.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrdersBrowseView.vue
@@ -5,7 +5,7 @@ import BrowseEntityRow from '@/shared/components/browse/BrowseEntityRow.vue'
 import BrowseListSection from '@/shared/components/browse/BrowseListSection.vue'
 import BrowseRowStats from '@/shared/components/browse/BrowseRowStats.vue'
 import { ENGAGEMENT_FILTER_OPTIONS } from '@/shared/browseOptions.js'
-import { formatProgress, formatRating } from '@/features/reading-orders/model.js'
+import { formatProgress, formatRating, readingOrderCover } from '@/features/reading-orders/model.js'
 
 const props = defineProps({
   orders: {
@@ -172,7 +172,7 @@ function handleCBLFile(event) {
             <BrowseEntityRow
               :title="order.name"
               :subtitle="order.description || 'No description'"
-              :image="order.image"
+              :image="readingOrderCover(order)"
               main-class="arc-row-main"
               :selected="selectedOrderId === order.id"
               :favorite="order.favorite"

--- a/ui/src/features/reading-orders/model.js
+++ b/ui/src/features/reading-orders/model.js
@@ -15,6 +15,10 @@ export function emptyReadingOrder() {
 
 export const readingOrderEditorPageSize = 100
 
+export function readingOrderCover(order) {
+  return order?.image || order?.displayImage || ''
+}
+
 export function reorderReadingOrderEntry(entries, fromIndex, toIndex) {
   const source = Array.isArray(entries) ? entries : []
   if (

--- a/ui/src/features/reading-orders/model.test.js
+++ b/ui/src/features/reading-orders/model.test.js
@@ -3,11 +3,24 @@ import test from 'node:test'
 
 import {
   readingOrderComicsPayload,
+  readingOrderCover,
   readingOrderDisplayComics,
   readingOrderEditorPage,
   readingOrderFormFromDetail,
   reorderReadingOrderEntry,
 } from './model.js'
+
+test('uses the computed comic cover only when no explicit reading-order cover exists', () => {
+  assert.equal(
+    readingOrderCover({ image: '/covers/custom.jpg', displayImage: '/covers/custom.jpg' }),
+    '/covers/custom.jpg',
+  )
+  assert.equal(
+    readingOrderCover({ image: '', displayImage: '/covers/first-comic.jpg' }),
+    '/covers/first-comic.jpg',
+  )
+  assert.equal(readingOrderCover({ image: '', displayImage: '' }), '')
+})
 
 test('maps section entries between API detail and editor payloads', () => {
   const form = readingOrderFormFromDetail({


### PR DESCRIPTION
## Summary
- add a computed reading-order display image that preserves explicitly configured covers
- fall back to the first available comic cover by reading-order position
- use the fallback consistently in reading-order browse and detail views
- keep the fallback separate from the stored image so editing does not persist it as a custom cover

## Verification
- `GOCACHE=/tmp/comichero-go-cache go test ./...`
- `npm run lint`
- `npm run format`
- `npm run test`
- `npm run build`