### PR TITLE
Scope CBL repository imports to selected folders

### DIFF
--- a/backend/internal/api/readingorders_repository_sync.go
+++ b/backend/internal/api/readingorders_repository_sync.go
@@ -28,12 +28,13 @@ const (
 )
 
 type CBLRepositorySyncSettings struct {
-	Enabled      bool     `json:"enabled" doc:"Whether repository imports can run."`
-	Repositories []string `json:"repositories" doc:"Public GitHub repository URLs containing CBL files."`
-	AutoSync     bool     `json:"autoSync" doc:"Whether repositories are checked on a schedule."`
-	Schedule     string   `json:"schedule" enum:"daily,weekly"`
-	Weekdays     []string `json:"weekdays,omitempty"`
-	StartTime    string   `json:"startTime" example:"04:00"`
+	Enabled      bool                           `json:"enabled" doc:"Whether repository imports can run."`
+	Repositories []string                       `json:"repositories" doc:"Public GitHub repository URLs containing CBL files."`
+	Folders      []CBLRepositoryFolderSelection `json:"folders,omitempty" doc:"Optional repository subfolders to import recursively. When set, only repositories and folders in this list are imported."`
+	AutoSync     bool                           `json:"autoSync" doc:"Whether repositories are checked on a schedule."`
+	Schedule     string                         `json:"schedule" enum:"daily,weekly"`
+	Weekdays     []string                       `json:"weekdays,omitempty"`
+	StartTime    string                         `json:"startTime" example:"04:00"`
 }
 
 type CBLRepositorySyncStatus struct {
@@ -70,6 +71,11 @@ type CBLRepositoryFile struct {
 type CBLRepositoryFileSelection struct {
 	RepositoryURL string `json:"repositoryUrl"`
 	Path          string `json:"path"`
+}
+
+type CBLRepositoryFolderSelection struct {
+	RepositoryURL string `json:"repositoryUrl" doc:"Configured GitHub repository URL."`
+	Path          string `json:"path" doc:"Repository-relative folder path. CBL files in this folder and its descendants are included." example:"Marvel/Events"`
 }
 
 type CBLMetronIssueCandidate struct {
@@ -203,6 +209,7 @@ func validateCBLRepositorySyncSettings(settings *CBLRepositorySyncSettings) erro
 		return errors.New("at least one repository is required")
 	}
 	seenRepositories := map[string]bool{}
+	configuredRepositories := map[string]string{}
 	repositories := make([]string, 0, len(settings.Repositories))
 	for _, value := range settings.Repositories {
 		repository, err := parseCBLGitHubRepository(value)
@@ -214,8 +221,38 @@ func validateCBLRepositorySyncSettings(settings *CBLRepositorySyncSettings) erro
 			seenRepositories[key] = true
 			repositories = append(repositories, repository.URL)
 		}
+		configuredRepositories[key] = repository.URL
 	}
 	settings.Repositories = repositories
+	folders := make([]CBLRepositoryFolderSelection, 0, len(settings.Folders))
+	seenFolders := map[string]bool{}
+	for _, selection := range settings.Folders {
+		repository, err := parseCBLGitHubRepository(selection.RepositoryURL)
+		if err != nil {
+			return err
+		}
+		repositoryURL, ok := configuredRepositories[strings.ToLower(repository.URL)]
+		if !ok {
+			return fmt.Errorf("folder repository %q is not configured", repository.URL)
+		}
+		folderPath, err := normalizeCBLRepositoryFolder(selection.Path)
+		if err != nil {
+			return err
+		}
+		key := strings.ToLower(repositoryURL) + "\n" + folderPath
+		if seenFolders[key] {
+			continue
+		}
+		seenFolders[key] = true
+		folders = append(folders, CBLRepositoryFolderSelection{RepositoryURL: repositoryURL, Path: folderPath})
+	}
+	sort.Slice(folders, func(i, j int) bool {
+		if !strings.EqualFold(folders[i].RepositoryURL, folders[j].RepositoryURL) {
+			return strings.ToLower(folders[i].RepositoryURL) < strings.ToLower(folders[j].RepositoryURL)
+		}
+		return strings.ToLower(folders[i].Path) < strings.ToLower(folders[j].Path)
+	})
+	settings.Folders = removeRedundantCBLRepositoryFolders(folders)
 	seenDays := map[string]bool{}
 	days := make([]string, 0, len(settings.Weekdays))
 	for _, value := range settings.Weekdays {
@@ -234,6 +271,35 @@ func validateCBLRepositorySyncSettings(settings *CBLRepositorySyncSettings) erro
 		return errors.New("weekly schedules need at least one weekday")
 	}
 	return nil
+}
+
+func normalizeCBLRepositoryFolder(value string) (string, error) {
+	value = strings.Trim(strings.TrimSpace(value), "/")
+	if value == "" || strings.Contains(value, "\\") {
+		return "", fmt.Errorf("folder path %q must be a repository-relative subfolder", value)
+	}
+	cleaned := path.Clean(value)
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, "../") {
+		return "", fmt.Errorf("folder path %q must be a repository-relative subfolder", value)
+	}
+	return cleaned, nil
+}
+
+func removeRedundantCBLRepositoryFolders(folders []CBLRepositoryFolderSelection) []CBLRepositoryFolderSelection {
+	filtered := make([]CBLRepositoryFolderSelection, 0, len(folders))
+	for _, folder := range folders {
+		redundant := false
+		for _, selected := range filtered {
+			if strings.EqualFold(selected.RepositoryURL, folder.RepositoryURL) && pathIsInCBLRepositoryFolder(folder.Path, selected.Path) {
+				redundant = true
+				break
+			}
+		}
+		if !redundant {
+			filtered = append(filtered, folder)
+		}
+	}
+	return filtered
 }
 
 func parseCBLGitHubRepository(value string) (cblGitHubRepository, error) {
@@ -405,11 +471,17 @@ func (s *cblRepositorySyncer) run(ctx context.Context, settings CBLRepositorySyn
 			if selectedFiles != nil && len(selection) == 0 {
 				continue
 			}
+			folderPaths := cblRepositoryFolderPaths(settings, repository.URL)
+			if selectedFiles != nil {
+				folderPaths = nil
+			} else if len(settings.Folders) > 0 && len(folderPaths) == 0 {
+				continue
+			}
 			s.update(func(status *CBLRepositorySyncStatus) {
 				status.CurrentRepository = repository.URL
 				status.CurrentFile = ""
 			})
-			if syncErr := s.syncRepositoryWithResolver(ctx, repository, selection, resolveMissing); syncErr != nil {
+			if syncErr := s.syncRepositoryWithResolver(ctx, repository, selection, folderPaths, resolveMissing); syncErr != nil {
 				s.recordFailure(syncErr)
 			}
 			s.update(func(status *CBLRepositorySyncStatus) { status.RepositoriesProcessed++ })
@@ -439,11 +511,21 @@ func (s *cblRepositorySyncer) run(ctx context.Context, settings CBLRepositorySyn
 	s.broadcast()
 }
 
-func (s *cblRepositorySyncer) syncRepository(ctx context.Context, repository cblGitHubRepository, selectedPaths map[string]bool) error {
-	return s.syncRepositoryWithResolver(ctx, repository, selectedPaths, nil)
+func cblRepositoryFolderPaths(settings CBLRepositorySyncSettings, repositoryURL string) []string {
+	folders := make([]string, 0)
+	for _, selection := range settings.Folders {
+		if strings.EqualFold(selection.RepositoryURL, repositoryURL) {
+			folders = append(folders, selection.Path)
+		}
+	}
+	return folders
 }
 
-func (s *cblRepositorySyncer) syncRepositoryWithResolver(ctx context.Context, repository cblGitHubRepository, selectedPaths map[string]bool, resolveMissing cblMissingComicResolver) error {
+func (s *cblRepositorySyncer) syncRepository(ctx context.Context, repository cblGitHubRepository, selectedPaths map[string]bool) error {
+	return s.syncRepositoryWithResolver(ctx, repository, selectedPaths, nil, nil)
+}
+
+func (s *cblRepositorySyncer) syncRepositoryWithResolver(ctx context.Context, repository cblGitHubRepository, selectedPaths map[string]bool, folderPaths []string, resolveMissing cblMissingComicResolver) error {
 	branch, files, err := s.listRepositoryFiles(ctx, repository)
 	if err != nil {
 		return err
@@ -451,6 +533,9 @@ func (s *cblRepositorySyncer) syncRepositoryWithResolver(ctx context.Context, re
 	states, err := s.repositoryFileStates(ctx, repository.URL)
 	if err != nil {
 		return err
+	}
+	if selectedPaths == nil {
+		files = cblRepositoryFilesInFolders(files, folderPaths)
 	}
 	selectedPaths = expandManagedMultipartSelections(files, selectedPaths, states)
 	files, err = selectedRepositoryFiles(files, selectedPaths, repository.URL)
@@ -504,6 +589,26 @@ func (s *cblRepositorySyncer) syncRepositoryWithResolver(ctx context.Context, re
 		s.syncMultipartGroup(ctx, repository, branch, key, parentNames[key], group, states, resolveMissing)
 	}
 	return nil
+}
+
+func cblRepositoryFilesInFolders(files []cblGitHubFile, folderPaths []string) []cblGitHubFile {
+	if len(folderPaths) == 0 {
+		return files
+	}
+	filtered := make([]cblGitHubFile, 0, len(files))
+	for _, file := range files {
+		for _, folderPath := range folderPaths {
+			if pathIsInCBLRepositoryFolder(file.Path, folderPath) {
+				filtered = append(filtered, file)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+func pathIsInCBLRepositoryFolder(filePath, folderPath string) bool {
+	return filePath == folderPath || strings.HasPrefix(filePath, folderPath+"/")
 }
 
 func expandManagedMultipartSelections(files []cblGitHubFile, selectedPaths map[string]bool, states map[string]cblRepositoryFileState) map[string]bool {

--- a/backend/internal/api/readingorders_repository_sync_test.go
+++ b/backend/internal/api/readingorders_repository_sync_test.go
@@ -20,6 +20,11 @@ func TestValidateCBLRepositorySyncSettingsNormalizesRepositories(t *testing.T) {
 			"https://github.com/DieselTech/CBL-ReadingLists.git",
 			"https://github.com/example/other",
 		},
+		Folders: []CBLRepositoryFolderSelection{
+			{RepositoryURL: "https://github.com/DieselTech/CBL-ReadingLists.git", Path: "/Marvel/Events/"},
+			{RepositoryURL: "https://github.com/DieselTech/CBL-ReadingLists", Path: "Marvel/Events/Secret Wars"},
+			{RepositoryURL: "https://github.com/example/other", Path: "DC"},
+		},
 		Schedule:  "weekly",
 		Weekdays:  []string{"Friday", "friday"},
 		StartTime: "04:30",
@@ -33,6 +38,33 @@ func TestValidateCBLRepositorySyncSettingsNormalizesRepositories(t *testing.T) {
 	}
 	if len(settings.Weekdays) != 1 || settings.Weekdays[0] != "friday" {
 		t.Fatalf("weekdays = %#v; want one normalized Friday", settings.Weekdays)
+	}
+	if len(settings.Folders) != 2 || settings.Folders[0].Path != "Marvel/Events" || settings.Folders[1].Path != "DC" {
+		t.Fatalf("folders = %#v; want canonical folders without redundant descendants", settings.Folders)
+	}
+}
+
+func TestValidateCBLRepositorySyncSettingsRejectsFolderFromUnconfiguredRepository(t *testing.T) {
+	settings := defaultCBLRepositorySyncSettings()
+	settings.Folders = []CBLRepositoryFolderSelection{{
+		RepositoryURL: "https://github.com/example/other",
+		Path:          "Marvel",
+	}}
+	if err := validateCBLRepositorySyncSettings(&settings); err == nil {
+		t.Fatal("validate settings succeeded; want unconfigured folder repository rejected")
+	}
+}
+
+func TestCBLRepositoryFilesInFoldersIncludesDescendantsOnly(t *testing.T) {
+	files := []cblGitHubFile{
+		{Path: "DC/Batman/Year One.cbl"},
+		{Path: "DC/Batman Beyond/Neo Year.cbl"},
+		{Path: "DC/Batman/Modern/Court of Owls.cbl"},
+		{Path: "Marvel/Events/Secret Wars.cbl"},
+	}
+	filtered := cblRepositoryFilesInFolders(files, []string{"DC/Batman", "Marvel/Events"})
+	if len(filtered) != 3 || filtered[0].Path != "DC/Batman/Year One.cbl" || filtered[1].Path != "DC/Batman/Modern/Court of Owls.cbl" || filtered[2].Path != "Marvel/Events/Secret Wars.cbl" {
+		t.Fatalf("filtered files = %#v; want only files inside selected folder boundaries", filtered)
 	}
 }
 

--- a/ui/src/features/settings/components/AppSettingsView.vue
+++ b/ui/src/features/settings/components/AppSettingsView.vue
@@ -51,6 +51,10 @@ const draft = reactive({})
 const discoveryDraft = reactive({})
 const cblDraft = reactive({})
 const repositoryText = ref('')
+const cblFolderPickerOpen = ref(false)
+const cblFolderSearch = ref('')
+const selectedCBLFolderKeys = reactive(new Set())
+const visibleCBLFolderLimit = ref(100)
 const cblFilePickerOpen = ref(false)
 const cblFileSearch = ref('')
 const selectedCBLFileKeys = reactive(new Set())
@@ -72,6 +76,59 @@ const indexedCBLRepositoryFiles = computed(() =>
     searchText: `${file.repositoryUrl} ${file.path} ${file.multipartGroup || ''}`.toLowerCase(),
   })),
 )
+const indexedCBLRepositoryFolders = computed(() => {
+  const folders = new Map()
+  for (const file of props.cblRepositoryFiles) {
+    const parts = String(file.path || '').split('/')
+    parts.pop()
+    for (let index = 1; index <= parts.length; index += 1) {
+      const folder = {
+        repositoryUrl: file.repositoryUrl,
+        path: parts.slice(0, index).join('/'),
+      }
+      const key = cblFolderKey(folder)
+      const existing = folders.get(key)
+      if (existing) existing.fileCount += 1
+      else folders.set(key, { ...folder, fileCount: 1 })
+    }
+  }
+  return [...folders.entries()]
+    .map(([key, folder]) => ({
+      folder,
+      key,
+      searchText: `${folder.repositoryUrl} ${folder.path}`.toLowerCase(),
+    }))
+    .sort((left, right) => left.searchText.localeCompare(right.searchText))
+})
+const cblRepositoryFoldersByKey = computed(
+  () => new Map(indexedCBLRepositoryFolders.value.map(({ key, folder }) => [key, folder])),
+)
+const filteredCBLRepositoryFolders = computed(() => {
+  const query = cblFolderSearch.value.trim().toLowerCase()
+  const rows = query
+    ? indexedCBLRepositoryFolders.value.filter(({ searchText }) => searchText.includes(query))
+    : indexedCBLRepositoryFolders.value
+  return rows.map(({ folder }) => folder)
+})
+const visibleCBLRepositoryFolders = computed(() =>
+  filteredCBLRepositoryFolders.value.slice(0, visibleCBLFolderLimit.value),
+)
+const remainingCBLRepositoryFolderCount = computed(() =>
+  Math.max(0, filteredCBLRepositoryFolders.value.length - visibleCBLRepositoryFolders.value.length),
+)
+const selectedCBLRepositoryFolders = computed(() => {
+  const folders = []
+  for (const key of selectedCBLFolderKeys) {
+    const folder = cblRepositoryFoldersByKey.value.get(key)
+    if (folder) folders.push(folder)
+  }
+  return folders
+})
+const cblFolderScopeLabel = computed(() => {
+  const count = Array.isArray(cblDraft.folders) ? cblDraft.folders.length : 0
+  if (!count) return 'All repository folders'
+  return `${count} selected ${count === 1 ? 'folder' : 'folders'}`
+})
 const cblRepositoryFilesByKey = computed(
   () => new Map(indexedCBLRepositoryFiles.value.map(({ key, file }) => [key, file])),
 )
@@ -129,6 +186,9 @@ watch(
   () => props.cblRepositorySync?.settings,
   (settings) => {
     Object.assign(cblDraft, settings || {})
+    cblDraft.folders = Array.isArray(settings?.folders)
+      ? settings.folders.map((folder) => ({ ...folder }))
+      : []
     repositoryText.value = (settings?.repositories || []).join('\n')
   },
   { immediate: true },
@@ -144,6 +204,10 @@ watch(
 
 watch(cblFileSearch, () => {
   visibleCBLFileLimit.value = cblFileBatchSize
+})
+
+watch(cblFolderSearch, () => {
+  visibleCBLFolderLimit.value = cblFileBatchSize
 })
 
 watch(
@@ -226,17 +290,61 @@ function toggleCBLWeekday(day, checked) {
 }
 
 function cblRepositorySyncPayload() {
+  const repositories = repositoryText.value
+    .split('\n')
+    .map((value) => value.trim())
+    .filter(Boolean)
+  const repositoryKeys = new Set(repositories.map(normalizedRepositoryKey))
   return {
     enabled: Boolean(cblDraft.enabled),
-    repositories: repositoryText.value
-      .split('\n')
-      .map((value) => value.trim())
-      .filter(Boolean),
+    repositories,
+    folders: (cblDraft.folders || [])
+      .filter((folder) => repositoryKeys.has(normalizedRepositoryKey(folder.repositoryUrl)))
+      .map((folder) => ({ repositoryUrl: folder.repositoryUrl, path: folder.path })),
     autoSync: Boolean(cblDraft.autoSync),
     schedule: cblDraft.schedule || 'daily',
     weekdays: cblDraft.schedule === 'weekly' ? cblDraft.weekdays || [] : [],
     startTime: cblDraft.startTime || '04:00',
   }
+}
+
+function openCBLFolderPicker() {
+  cblFolderPickerOpen.value = true
+  cblFolderSearch.value = ''
+  selectedCBLFolderKeys.clear()
+  for (const folder of cblDraft.folders || []) selectedCBLFolderKeys.add(cblFolderKey(folder))
+  visibleCBLFolderLimit.value = cblFileBatchSize
+  emit('load-cbl-repository-files', cblRepositorySyncPayload())
+}
+
+function closeCBLFolderPicker() {
+  cblFolderPickerOpen.value = false
+}
+
+function cblFolderKey(folder) {
+  return `${folder.repositoryUrl}\n${folder.path}`
+}
+
+function toggleCBLFolder(folder, checked) {
+  const key = cblFolderKey(folder)
+  if (checked) selectedCBLFolderKeys.add(key)
+  else selectedCBLFolderKeys.delete(key)
+}
+
+function clearSelectedCBLFolders() {
+  selectedCBLFolderKeys.clear()
+}
+
+function showMoreCBLRepositoryFolders() {
+  visibleCBLFolderLimit.value += cblFileBatchSize
+}
+
+function applySelectedCBLRepositoryFolders() {
+  cblDraft.folders = selectedCBLRepositoryFolders.value.map((folder) => ({
+    repositoryUrl: folder.repositoryUrl,
+    path: folder.path,
+  }))
+  closeCBLFolderPicker()
 }
 
 function saveCBLRepositorySync() {
@@ -322,6 +430,14 @@ function chooseCBLMetronIssue(metronIssueId) {
 
 function repositoryLabel(value) {
   return String(value || '').replace(/^https:\/\/github\.com\//i, '')
+}
+
+function normalizedRepositoryKey(value) {
+  return String(value || '')
+    .trim()
+    .replace(/\.git\/?$/i, '')
+    .replace(/\/$/, '')
+    .toLowerCase()
 }
 
 function fileSizeLabel(bytes) {
@@ -500,6 +616,25 @@ function selectSettingsTab(tab) {
         ></textarea>
       </label>
 
+      <div class="cbl-folder-scope">
+        <div>
+          <strong>Repository scope</strong>
+          <span>{{ cblFolderScopeLabel }}</span>
+          <small>
+            Applies to regular checks and Import now. Only selected folders and their nested folders
+            are downloaded.
+          </small>
+        </div>
+        <button
+          type="button"
+          class="secondary-action"
+          :disabled="loadingCblRepositoryFiles || !repositoryText.trim()"
+          @click="openCBLFolderPicker"
+        >
+          {{ loadingCblRepositoryFiles ? 'Loading folders...' : 'Choose folders' }}
+        </button>
+      </div>
+
       <label class="compact-toggle cbl-auto-sync-toggle">
         <input v-model="cblDraft.autoSync" type="checkbox" />
         <span>Regularly check repositories for new and updated files</span>
@@ -626,6 +761,101 @@ function selectSettingsTab(tab) {
         >
           Stop import
         </button>
+      </div>
+
+      <div v-if="cblFolderPickerOpen" class="modal-backdrop" @click.self="closeCBLFolderPicker">
+        <section
+          class="cbl-file-picker"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="cbl-folder-picker-title"
+        >
+          <header class="cbl-file-picker-header">
+            <div>
+              <strong id="cbl-folder-picker-title">Choose repository folders</strong>
+              <small>
+                Choose one or more folders. Clear the selection to use the entire repository.
+              </small>
+            </div>
+            <button
+              class="icon-button"
+              type="button"
+              aria-label="Close CBL folder picker"
+              @click="closeCBLFolderPicker"
+            >
+              ×
+            </button>
+          </header>
+
+          <div class="cbl-file-picker-tools">
+            <input v-model="cblFolderSearch" type="search" placeholder="Search folders..." />
+            <button
+              type="button"
+              class="secondary-action"
+              :disabled="!selectedCBLFolderKeys.size"
+              @click="clearSelectedCBLFolders"
+            >
+              Use all folders
+            </button>
+          </div>
+
+          <LoadingState v-if="loadingCblRepositoryFiles" compact />
+          <p v-else-if="!filteredCBLRepositoryFolders.length" class="muted cbl-picker-empty">
+            No folders containing CBL files match this search.
+          </p>
+          <div v-else class="cbl-file-picker-list">
+            <div
+              v-for="folder in visibleCBLRepositoryFolders"
+              :key="cblFolderKey(folder)"
+              v-memo="[selectedCBLFolderKeys.has(cblFolderKey(folder))]"
+            >
+              <label>
+                <input
+                  type="checkbox"
+                  :checked="selectedCBLFolderKeys.has(cblFolderKey(folder))"
+                  @change="toggleCBLFolder(folder, $event.target.checked)"
+                />
+                <span class="cbl-file-picker-path">
+                  <strong>{{ folder.path }}</strong>
+                  <small>
+                    {{ repositoryLabel(folder.repositoryUrl) }} · {{ folder.fileCount }}
+                    {{ folder.fileCount === 1 ? 'CBL file' : 'CBL files' }}
+                  </small>
+                </span>
+              </label>
+            </div>
+            <button
+              v-if="remainingCBLRepositoryFolderCount"
+              type="button"
+              class="secondary-button cbl-file-picker-more"
+              @click="showMoreCBLRepositoryFolders"
+            >
+              Show {{ Math.min(cblFileBatchSize, remainingCBLRepositoryFolderCount) }} more
+              <small>{{ remainingCBLRepositoryFolderCount }} matches not shown</small>
+            </button>
+          </div>
+
+          <footer class="cbl-file-picker-actions">
+            <span>
+              {{
+                selectedCBLRepositoryFolders.length
+                  ? `${selectedCBLRepositoryFolders.length} folders selected`
+                  : 'Entire repositories selected'
+              }}
+            </span>
+            <button type="button" class="secondary-button" @click="closeCBLFolderPicker">
+              Cancel
+            </button>
+            <button
+              type="button"
+              class="primary-button"
+              :disabled="loadingCblRepositoryFiles"
+              @click="applySelectedCBLRepositoryFolders"
+            >
+              Apply scope
+            </button>
+          </footer>
+        </section>
       </div>
 
       <div v-if="cblFilePickerOpen" class="modal-backdrop" @click.self="closeCBLFilePicker">

--- a/ui/src/styles/administration.css
+++ b/ui/src/styles/administration.css
@@ -119,6 +119,38 @@
   justify-self: start;
 }
 
+.cbl-folder-scope {
+  max-width: 760px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  background: var(--surface);
+  padding: 12px 14px;
+}
+
+.cbl-folder-scope > div {
+  min-width: 0;
+  display: grid;
+  gap: 3px;
+}
+
+.cbl-folder-scope span {
+  font-weight: 800;
+}
+
+.cbl-folder-scope small,
+.cbl-picker-empty {
+  color: var(--muted);
+  font-weight: 650;
+}
+
+.cbl-picker-empty {
+  padding: 16px;
+}
+
 .cbl-manual-metron-option {
   display: grid;
   justify-items: start;

--- a/ui/src/styles/responsive-mobile.css
+++ b/ui/src/styles/responsive-mobile.css
@@ -40,6 +40,15 @@
     grid-column: auto;
   }
 
+  .cbl-folder-scope {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .cbl-folder-scope > button {
+    width: 100%;
+  }
+
   .cbl-file-picker-list > div {
     align-items: stretch;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- persist one or more repository-relative CBL folder scopes
- apply the saved scope to scheduled checks and the main Import now flow
- add a responsive folder picker with recursive file counts while keeping an empty selection as the full-repository default
- keep Choose files as a one-off explicit-file override
- validate and normalize folder paths and ignore repositories outside the selected scope

## Testing
- go test ./...
- go vet ./...
- go build ./...
- npm run lint
- npm run format
- npm run test
- npm run build