### PR TITLE
Close popups when clicking outside

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint src",
     "format": "prettier --check src",
     "format:fix": "prettier --write src",
-    "test": "node --test src/router/appRouteState.test.js src/features/reading-orders/model.test.js",
+    "test": "node --test src/router/appRouteState.test.js src/features/reading-orders/model.test.js src/shared/composables/useClickOutside.test.js",
     "dev": "vite --host 127.0.0.1 --clearScreen false",
     "build": "vite build",
     "preview": "vite preview --host 127.0.0.1"

--- a/ui/src/app/components/AppSidebar.vue
+++ b/ui/src/app/components/AppSidebar.vue
@@ -1,5 +1,6 @@
 <script setup>
 import { computed, ref } from 'vue'
+import { useClickOutside } from '@/shared/composables/useClickOutside.js'
 
 const props = defineProps({
   activeView: {
@@ -43,6 +44,12 @@ const props = defineProps({
 const emit = defineEmits(['set-theme', 'login', 'logout'])
 const menuOpen = ref(false)
 const accountMenuOpen = ref(false)
+const mobileMenuButton = ref(null)
+const primaryNavigation = ref(null)
+const accountMenu = ref(null)
+
+useClickOutside([mobileMenuButton, primaryNavigation], () => (menuOpen.value = false), menuOpen)
+useClickOutside(accountMenu, () => (accountMenuOpen.value = false), accountMenuOpen)
 
 const userInitial = computed(
   () => (props.user?.name || '?').trim().slice(0, 1).toUpperCase() || '?',
@@ -86,6 +93,7 @@ function toggleMobileMenu() {
         <span v-if="version" class="version-tag">{{ version }}</span>
       </div>
       <button
+        ref="mobileMenuButton"
         type="button"
         class="mobile-menu-button"
         :aria-expanded="menuOpen"
@@ -101,7 +109,7 @@ function toggleMobileMenu() {
       </button>
     </div>
 
-    <nav id="primary-navigation" class="nav-tabs" aria-label="Primary">
+    <nav id="primary-navigation" ref="primaryNavigation" class="nav-tabs" aria-label="Primary">
       <router-link
         :to="{ name: 'dashboard' }"
         :class="{ active: activeView === 'dashboard' }"
@@ -147,7 +155,7 @@ function toggleMobileMenu() {
     </nav>
 
     <div class="sidebar-actions">
-      <div v-if="user" class="account-menu" :class="{ open: accountMenuOpen }">
+      <div v-if="user" ref="accountMenu" class="account-menu" :class="{ open: accountMenuOpen }">
         <button
           type="button"
           class="account-menu-trigger"

--- a/ui/src/features/comics/components/ComicListView.vue
+++ b/ui/src/features/comics/components/ComicListView.vue
@@ -3,6 +3,7 @@ import { computed, nextTick, onMounted, onUnmounted, ref, watch } from 'vue'
 
 import { listComics } from '@/api/client.js'
 import IssueListItem from '@/shared/components/browse/IssueListItem.vue'
+import { useClickOutside } from '@/shared/composables/useClickOutside.js'
 
 const props = defineProps({
   comics: {
@@ -121,7 +122,15 @@ const visibleLimit = ref(props.localPageSize)
 const loadMoreSentinel = ref(null)
 const autoLoadSupported = ref(false)
 const comicOptionsOpen = ref(false)
+const comicOptionsTrigger = ref(null)
+const comicFilterControls = ref(null)
 const collapsedSections = ref(new Set())
+
+useClickOutside(
+  [comicOptionsTrigger, comicFilterControls],
+  () => (comicOptionsOpen.value = false),
+  comicOptionsOpen,
+)
 
 let loadMoreObserver = null
 
@@ -530,6 +539,7 @@ watch([visibleComics, canLoadMoreLocal, canLoadMoreServer], () => {
         <input v-model="searchText" type="search" placeholder="Search issues" />
 
         <button
+          ref="comicOptionsTrigger"
           class="mobile-comic-options-trigger"
           type="button"
           :aria-expanded="comicOptionsOpen"
@@ -539,7 +549,11 @@ watch([visibleComics, canLoadMoreLocal, canLoadMoreServer], () => {
           <span aria-hidden="true">⌄</span>
         </button>
 
-        <div class="comic-filter-controls" :class="{ open: comicOptionsOpen }">
+        <div
+          ref="comicFilterControls"
+          class="comic-filter-controls"
+          :class="{ open: comicOptionsOpen }"
+        >
           <div
             class="inline-filter-tabs issue-status-tabs"
             role="group"

--- a/ui/src/features/reading-orders/components/ReadingOrdersBrowseView.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrdersBrowseView.vue
@@ -6,6 +6,7 @@ import BrowseListSection from '@/shared/components/browse/BrowseListSection.vue'
 import BrowseRowStats from '@/shared/components/browse/BrowseRowStats.vue'
 import { ENGAGEMENT_FILTER_OPTIONS } from '@/shared/browseOptions.js'
 import { formatProgress, formatRating, readingOrderCover } from '@/features/reading-orders/model.js'
+import { useClickOutside } from '@/shared/composables/useClickOutside.js'
 
 const props = defineProps({
   orders: {
@@ -63,6 +64,9 @@ const emit = defineEmits([
 
 const cblFileInput = ref(null)
 const orderActionsOpen = ref(false)
+const orderActions = ref(null)
+
+useClickOutside(orderActions, () => (orderActionsOpen.value = false), orderActionsOpen)
 
 const sortOptions = [
   { value: 'name', label: 'Name' },
@@ -116,7 +120,7 @@ function handleCBLFile(event) {
             @update:direction="$emit('update:direction', $event)"
           >
             <template #actions>
-              <div v-if="!readOnly" class="browse-header-actions order-actions">
+              <div v-if="!readOnly" ref="orderActions" class="browse-header-actions order-actions">
                 <button
                   class="secondary-button icon-text-button mobile-order-actions-trigger"
                   type="button"

--- a/ui/src/shared/composables/useClickOutside.js
+++ b/ui/src/shared/composables/useClickOutside.js
@@ -1,0 +1,21 @@
+import { onBeforeUnmount, onMounted, unref } from 'vue'
+
+export function isClickOutside(elements, event) {
+  const eventPath = typeof event.composedPath === 'function' ? event.composedPath() : []
+  return !elements.some((element) => eventPath.includes(element) || element.contains(event.target))
+}
+
+export function useClickOutside(targets, handler, enabled = true) {
+  const targetList = Array.isArray(targets) ? targets : [targets]
+
+  function handlePointerDown(event) {
+    const active = typeof enabled === 'function' ? enabled() : unref(enabled)
+    if (!active) return
+
+    const elements = targetList.map(unref).filter(Boolean)
+    if (isClickOutside(elements, event)) handler(event)
+  }
+
+  onMounted(() => document.addEventListener('pointerdown', handlePointerDown))
+  onBeforeUnmount(() => document.removeEventListener('pointerdown', handlePointerDown))
+}

--- a/ui/src/shared/composables/useClickOutside.test.js
+++ b/ui/src/shared/composables/useClickOutside.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { isClickOutside } from './useClickOutside.js'
+
+test('treats clicks in any popup element as inside', () => {
+  const trigger = { contains: (target) => target === triggerChild }
+  const triggerChild = {}
+  const panel = { contains: () => false }
+
+  assert.equal(
+    isClickOutside([trigger, panel], {
+      target: triggerChild,
+      composedPath: () => [triggerChild, trigger],
+    }),
+    false,
+  )
+})
+
+test('treats clicks beyond all popup elements as outside', () => {
+  const trigger = { contains: () => false }
+  const panel = { contains: () => false }
+
+  assert.equal(
+    isClickOutside([trigger, panel], {
+      target: {},
+      composedPath: () => [],
+    }),
+    true,
+  )
+})


### PR DESCRIPTION
## Summary
- add a shared outside-click composable for popup triggers and panels
- close the account menu and mobile navigation when clicking elsewhere
- apply the same behavior to mobile comic filters and reading-order actions
- keep interactions inside popup triggers and panels open
- add focused coverage for inside and outside pointer events

## Testing
- npm run lint
- npm run format
- npm run test
- npm run build