### PR TITLE
Fix automatic Metron comic refresh imports

### DIFF
--- a/backend/internal/api/metron_comic_scanner.go
+++ b/backend/internal/api/metron_comic_scanner.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"sort"
 	"strings"
@@ -67,6 +68,7 @@ type MetronComicScanStatus struct {
 	Scanned        int                     `json:"scanned"`
 	Updated        int                     `json:"updated"`
 	Failed         int                     `json:"failed"`
+	LastError      string                  `json:"lastError,omitempty"`
 	CallsUsedToday int                     `json:"callsUsedToday"`
 	CallsLeftToday int                     `json:"callsLeftToday"`
 	UsageDate      string                  `json:"usageDate"`
@@ -324,8 +326,8 @@ func (s *metronComicScanner) run(ctx context.Context, settings MetronComicScanSe
 				if searchErr != nil {
 					fetchErr = searchErr
 				} else if len(matches) == 0 {
-					if markIncompleteComicChecked(ctx, s.db, row.ID, time.Now()) != nil {
-						s.incrementFailed()
+					if markErr := markIncompleteComicChecked(ctx, s.db, row.ID, time.Now()); markErr != nil {
+						s.recordFailure(row.ID, fmt.Errorf("mark unmatched comic as checked: %w", markErr))
 					}
 					continue
 				} else if len(matches) > 1 {
@@ -349,11 +351,11 @@ func (s *metronComicScanner) run(ctx context.Context, settings MetronComicScanSe
 				if ctx.Err() != nil {
 					break
 				}
-				s.incrementFailed()
+				s.recordFailure(row.ID, fmt.Errorf("fetch Metron issue: %w", fetchErr))
 				continue
 			}
-			if enrichIncompleteComicFromMetron(ctx, s.db, s.covers, row.ID, *issue) != nil {
-				s.incrementFailed()
+			if enrichErr := enrichIncompleteComicFromMetron(ctx, s.db, s.covers, row.ID, *issue); enrichErr != nil {
+				s.recordFailure(row.ID, enrichErr)
 			} else {
 				s.incrementUpdated()
 			}
@@ -435,24 +437,50 @@ func enrichIncompleteComicFromMetron(ctx context.Context, db *sqlx.DB, covers *C
 			var err error
 			cover, err = localCoverURL(ctx, covers, cover)
 			if err != nil {
-				return err
+				return fmt.Errorf("cache cover: %w", err)
 			}
 		} else {
 			cover = current
 		}
 	}
-	syncedAt := time.Now().UTC().Format(time.RFC3339)
-	_, err := db.ExecContext(ctx, `UPDATE comics SET metron_issue_id = COALESCE(metron_issue_id, ?), comic_vine_id = COALESCE(comic_vine_id, ?), publisher = CASE WHEN TRIM(publisher) = '' THEN ? ELSE publisher END, cover_date = CASE WHEN TRIM(cover_date) = '' THEN ? ELSE cover_date END, cover_image = CASE WHEN TRIM(cover_image) = '' THEN ? ELSE cover_image END, description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END, metron_synced_at = ? WHERE id = ?`, nullablePositiveID(issue.ID), nullablePositiveID(issue.ComicVineID), issue.Publisher, issue.CoverDate, cover, issue.Description, syncedAt, comicID)
+	_, err := db.ExecContext(ctx, `
+		UPDATE comics SET
+			metron_issue_id = COALESCE(metron_issue_id, (
+				SELECT ? WHERE NOT EXISTS (
+					SELECT 1 FROM comics linked
+					WHERE linked.metron_issue_id = ? AND linked.id <> ?
+				)
+			)),
+			comic_vine_id = COALESCE(comic_vine_id, (
+				SELECT ? WHERE NOT EXISTS (
+					SELECT 1 FROM comics linked
+					WHERE linked.comic_vine_id = ? AND linked.id <> ?
+				)
+			)),
+			publisher = CASE WHEN TRIM(publisher) = '' THEN ? ELSE publisher END,
+			cover_date = CASE WHEN TRIM(cover_date) = '' THEN ? ELSE cover_date END,
+			cover_image = CASE WHEN TRIM(cover_image) = '' THEN ? ELSE cover_image END,
+			description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END
+		WHERE id = ?
+	`, nullablePositiveID(issue.ID), issue.ID, comicID,
+		nullablePositiveID(issue.ComicVineID), issue.ComicVineID, comicID,
+		issue.Publisher, issue.CoverDate, cover, issue.Description, comicID)
 	if err != nil {
-		return err
+		return fmt.Errorf("update comic metadata: %w", err)
 	}
 	// The issue response already contains lightweight arc and character data. A
 	// nil client prevents these helpers from making any detail requests.
 	options := MetronImportOptions{Mode: "basic"}
 	if err := syncMetronIssueArcsWithOptions(ctx, db, nil, comicID, issue, options); err != nil {
-		return err
+		return fmt.Errorf("sync comic arcs: %w", err)
 	}
-	return syncMetronIssueCharactersWithOptions(ctx, db, nil, covers, comicID, issue, options)
+	if err := syncMetronIssueCharactersWithOptions(ctx, db, nil, covers, comicID, issue, options); err != nil {
+		return fmt.Errorf("sync comic characters: %w", err)
+	}
+	if err := markIncompleteComicChecked(ctx, db, comicID, time.Now()); err != nil {
+		return fmt.Errorf("mark comic as synced: %w", err)
+	}
+	return nil
 }
 
 func markIncompleteComicChecked(ctx context.Context, db *sqlx.DB, comicID int, checkedAt time.Time) error {
@@ -528,9 +556,12 @@ func (s *metronComicScanner) incrementUpdated() {
 	s.mu.Unlock()
 	s.broadcastSnapshot()
 }
-func (s *metronComicScanner) incrementFailed() {
+func (s *metronComicScanner) recordFailure(comicID int, err error) {
+	message := fmt.Sprintf("comic %d: %v", comicID, err)
+	log.Printf("Metron comic scan failed: %s", message)
 	s.mu.Lock()
 	s.status.Failed++
+	s.status.LastError = message
 	s.mu.Unlock()
 	s.broadcastSnapshot()
 }

--- a/backend/internal/api/metron_comic_scanner_test.go
+++ b/backend/internal/api/metron_comic_scanner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -338,6 +339,108 @@ func TestEnrichIncompleteComicStoresComicVineID(t *testing.T) {
 	}
 	if comicVineID != 9988 {
 		t.Fatalf("Comic Vine ID = %d; want 9988", comicVineID)
+	}
+}
+
+func TestEnrichIncompleteComicSkipsConflictingComicVineID(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	ctx := testUserContext()
+	if _, err := db.Exec(`
+		INSERT INTO comics (id, series, series_year, issue, publisher, metron_issue_id)
+		VALUES (1, 'Target', 2026, '1', '', 77);
+		INSERT INTO comics (id, series, series_year, issue, publisher, comic_vine_id)
+		VALUES (2, 'Existing Comic Vine row', 2026, '1', 'Publisher', 9988);
+	`); err != nil {
+		t.Fatalf("seed comics: %v", err)
+	}
+
+	if err := enrichIncompleteComicFromMetron(ctx, db, nil, 1, metron.Issue{
+		ID:          77,
+		ComicVineID: 9988,
+		Publisher:   "Publisher",
+	}); err != nil {
+		t.Fatalf("enrich comic with conflicting Comic Vine ID: %v", err)
+	}
+
+	var comic struct {
+		ComicVineID *int   `db:"comic_vine_id"`
+		Publisher   string `db:"publisher"`
+	}
+	if err := db.Get(&comic, `SELECT comic_vine_id, publisher FROM comics WHERE id = 1`); err != nil {
+		t.Fatalf("read enriched comic: %v", err)
+	}
+	if comic.ComicVineID != nil {
+		t.Fatalf("conflicting Comic Vine ID was attached: %d", *comic.ComicVineID)
+	}
+	if comic.Publisher != "Publisher" {
+		t.Fatalf("publisher = %q; want metadata enrichment to succeed", comic.Publisher)
+	}
+}
+
+func TestEnrichIncompleteComicSkipsConflictingMetronID(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	ctx := testUserContext()
+	if _, err := db.Exec(`
+		INSERT INTO comics (id, series, series_year, issue, publisher, comic_vine_id)
+		VALUES (1, 'Target', 2026, '1', '', 9988);
+		INSERT INTO comics (id, series, series_year, issue, publisher, metron_issue_id)
+		VALUES (2, 'Existing Metron row', 2026, '1', 'Publisher', 77);
+	`); err != nil {
+		t.Fatalf("seed comics: %v", err)
+	}
+
+	if err := enrichIncompleteComicFromMetron(ctx, db, nil, 1, metron.Issue{
+		ID:          77,
+		ComicVineID: 9988,
+		Publisher:   "Publisher",
+	}); err != nil {
+		t.Fatalf("enrich comic with conflicting Metron ID: %v", err)
+	}
+
+	var comic struct {
+		MetronID  *int   `db:"metron_issue_id"`
+		Publisher string `db:"publisher"`
+	}
+	if err := db.Get(&comic, `SELECT metron_issue_id, publisher FROM comics WHERE id = 1`); err != nil {
+		t.Fatalf("read enriched comic: %v", err)
+	}
+	if comic.MetronID != nil {
+		t.Fatalf("conflicting Metron ID was attached: %d", *comic.MetronID)
+	}
+	if comic.Publisher != "Publisher" {
+		t.Fatalf("publisher = %q; want metadata enrichment to succeed", comic.Publisher)
+	}
+}
+
+func TestMetronComicScanReportsLastFailure(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	if _, err := db.Exec(`
+		CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+		INSERT INTO comics (id, series, issue, publisher, metron_issue_id)
+		VALUES (1, 'Target', '1', '', 77);
+	`); err != nil {
+		t.Fatalf("seed scanner data: %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "Metron unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	settings := defaultMetronComicScanSettings()
+	settings.DailyCallLimit = 10
+	settings.MinIntervalSeconds = 0
+	settings.RecheckCooldownDays = 0
+	settings.IncompleteFields = []string{"publisher"}
+	scanner := NewMetronComicScanner(db, metron.New(metron.Config{BaseURL: server.URL}), nil)
+	scanner.run(context.Background(), settings)
+
+	status := scanner.snapshot(context.Background())
+	if status.Failed != 1 {
+		t.Fatalf("failed = %d; want 1", status.Failed)
+	}
+	if !strings.Contains(status.LastError, "comic 1: fetch Metron issue") {
+		t.Fatalf("last error = %q; want comic and failure stage", status.LastError)
 	}
 }
 

--- a/ui/src/features/settings/components/AppSettingsView.vue
+++ b/ui/src/features/settings/components/AppSettingsView.vue
@@ -501,6 +501,7 @@ function selectSettingsTab(tab) {
             }}
           </p>
         </div>
+
         <div
           class="registration-mode-toggle grid grid-cols-2 gap-1 border border-line rounded bg-surface p-1 [&_button]:min-w-0 [&_button]:min-h-10 [&_button]:border-0 [&_button]:rounded-[7px] [&_button]:bg-transparent [&_button]:text-control [&_button]:py-2 [&_button]:px-2.5 [&_button]:text-sm [&_button]:font-black [&_button]:leading-tight [&_button]:whitespace-normal [&_button]:break-anywhere [&_button.active]:bg-primary [&_button.active]:[color:var(--primary-ink)]"
           role="group"
@@ -1260,7 +1261,6 @@ function selectSettingsTab(tab) {
             <template v-else>Not run yet</template>
           </p>
         </div>
-
         <div
           class="metron-scan-actions flex items-center flex-wrap gap-2.5 down-mobile:items-stretch down-mobile:flex-col [&_>_button]:w-40 [&_>_button]:min-h-11 down-mobile:[&_>_button]:w-full"
         >
@@ -1415,6 +1415,9 @@ function selectSettingsTab(tab) {
             </template>
           </p>
         </div>
+        <p v-if="metronComicScan.lastError" class="text-danger text-sm m-0">
+          Last error: {{ metronComicScan.lastError }}
+        </p>
 
         <div
           class="metron-scan-actions flex items-center flex-wrap gap-2.5 down-mobile:items-stretch down-mobile:flex-col [&_>_button]:w-40 [&_>_button]:min-h-11 down-mobile:[&_>_button]:w-full"


### PR DESCRIPTION
## Summary

- prevent automatic Metron comic refreshes from failing when a returned Metron or Comic Vine identifier already belongs to another local comic
- continue enriching non-conflicting metadata while preserving the existing identity owner for later duplicate review/merge
- record the sync timestamp only after arc and character relationship updates succeed
- expose the last per-comic scanner error in logs, the scan API, and the settings UI

## Root cause

The refresh query used COALESCE to attach every returned Metron and Comic Vine identifier directly. Libraries containing the same issue through different import paths can have one row linked by Metron ID and another linked by Comic Vine ID. Refreshing either row then violated the unique identity index and failed the entire update:

    UNIQUE constraint failed: comics.comic_vine_id

The scanner discarded that error and only incremented its failed counter, which made the failures appear unexplained.

## Verification

- reproduced the original unique-constraint failure with a focused regression test
- added coverage for conflicting Comic Vine IDs and conflicting Metron IDs
- added coverage for scanner failure-stage reporting
- go test -count=1 ./...
- npm test -- --run
- npm run lint (passes with one existing unrelated vue/no-v-html warning)
- npm run build
