### PR TITLE
Fix CBL repository sync progress to use SSE

### DIFF
--- a/backend/internal/api/readingorders_repository_sync_test.go
+++ b/backend/internal/api/readingorders_repository_sync_test.go
@@ -55,6 +55,30 @@ func TestValidateCBLRepositorySyncSettingsRejectsFolderFromUnconfiguredRepositor
 	}
 }
 
+func TestCBLRepositorySyncSubscriptionSendsSnapshotAndProgress(t *testing.T) {
+	db := newMetronComicScannerTestDB(t)
+	syncer := NewCBLRepositorySyncer(db, nil, nil)
+	updates, unsubscribe := syncer.subscribe(context.Background())
+	defer unsubscribe()
+
+	initial := <-updates
+	if initial.Imported != 0 || initial.CurrentFile != "" {
+		t.Fatalf("initial status = %+v; want idle snapshot", initial)
+	}
+
+	syncer.setCurrentFile("Marvel/Events/Secret Wars.cbl")
+	progress := <-updates
+	if progress.CurrentFile != "Marvel/Events/Secret Wars.cbl" {
+		t.Fatalf("progress current file = %q; want SSE subscriber update", progress.CurrentFile)
+	}
+
+	syncer.increment("imported")
+	progress = <-updates
+	if progress.Imported != 1 {
+		t.Fatalf("progress imported = %d; want SSE subscriber update", progress.Imported)
+	}
+}
+
 func TestCBLRepositoryFilesInFoldersIncludesDescendantsOnly(t *testing.T) {
 	files := []cblGitHubFile{
 		{Path: "DC/Batman/Year One.cbl"},

--- a/ui/src/features/settings/useMetronSettings.js
+++ b/ui/src/features/settings/useMetronSettings.js
@@ -44,15 +44,13 @@ export function useMetronSettings({
   let comicScanEvents = null
   let comicDiscoveryEvents = null
   let cblRepositorySyncEvents = null
-  let cblRepositorySyncRefreshTimer = null
-  let refreshingCBLRepositorySync = false
 
   async function loadSettings() {
     if (!connectComicScanEvents()) comicScan.value = await getMetronComicScan()
     if (!connectComicDiscoveryEvents()) comicDiscovery.value = await getMetronComicDiscovery()
-    connectCBLRepositorySyncEvents()
-    cblRepositorySync.value = await getCBLRepositorySync()
-    scheduleCBLRepositorySyncRefresh()
+    if (!connectCBLRepositorySyncEvents()) {
+      cblRepositorySync.value = await getCBLRepositorySync()
+    }
   }
 
   async function saveComicScan(settings) {
@@ -125,7 +123,6 @@ export function useMetronSettings({
         files,
         resolveMissingOnMetron,
       })
-      scheduleCBLRepositorySyncRefresh(0)
     })
     savingCBLRepositorySync.value = false
   }
@@ -218,18 +215,16 @@ export function useMetronSettings({
       target: cblRepositorySync,
       close: closeCBLRepositorySyncEvents,
       fallback: getCBLRepositorySync,
-      onUpdate: scheduleCBLRepositorySyncRefresh,
     })
     return true
   }
 
-  function connectEvents({ url, eventName, payloadKey, target, close, fallback, onUpdate }) {
+  function connectEvents({ url, eventName, payloadKey, target, close, fallback }) {
     const source = new EventSource(url, { withCredentials: true })
     source.addEventListener(eventName, (event) => {
       try {
         const payload = JSON.parse(event.data)
         target.value = payload[payloadKey] || payload
-        onUpdate?.()
       } catch (err) {
         error.value = err.message
       }
@@ -263,42 +258,6 @@ export function useMetronSettings({
     cblRepositorySyncEvents = null
   }
 
-  function scheduleCBLRepositorySyncRefresh(delay) {
-    clearTimeout(cblRepositorySyncRefreshTimer)
-    if (activeView.value !== 'settings') return
-    const refreshDelay = delay ?? (cblRepositorySync.value?.running ? 750 : 5000)
-    cblRepositorySyncRefreshTimer = setTimeout(refreshCBLRepositorySyncStatus, refreshDelay)
-  }
-
-  async function refreshCBLRepositorySyncStatus() {
-    if (activeView.value !== 'settings' || refreshingCBLRepositorySync) return
-    refreshingCBLRepositorySync = true
-    try {
-      const status = await getCBLRepositorySync()
-      // Do not let a request started before a manual trigger briefly replace the
-      // new running state with the preceding idle snapshot.
-      if (!(
-        cblRepositorySync.value?.running &&
-        !status.running &&
-        !status.finishedAt &&
-        cblRepositorySync.value?.startedAt
-      )) {
-        cblRepositorySync.value = status
-      }
-    } catch {
-      // The SSE connection remains the primary live update path. A failed
-      // fallback refresh should not replace a more useful settings-page error.
-    } finally {
-      refreshingCBLRepositorySync = false
-      scheduleCBLRepositorySyncRefresh()
-    }
-  }
-
-  function stopCBLRepositorySyncRefresh() {
-    clearTimeout(cblRepositorySyncRefreshTimer)
-    cblRepositorySyncRefreshTimer = null
-  }
-
   async function withSaving(savingRef, action) {
     savingRef.value = true
     await run(action)
@@ -315,21 +274,16 @@ export function useMetronSettings({
   }
 
   watch(activeView, (view) => {
-    if (view === 'settings') {
-      scheduleCBLRepositorySyncRefresh(0)
-      return
-    }
+    if (view === 'settings') return
     closeComicScanEvents()
     closeComicDiscoveryEvents()
     closeCBLRepositorySyncEvents()
-    stopCBLRepositorySyncRefresh()
   })
 
   onUnmounted(() => {
     closeComicScanEvents()
     closeComicDiscoveryEvents()
     closeCBLRepositorySyncEvents()
-    stopCBLRepositorySyncRefresh()
   })
 
   return {


### PR DESCRIPTION
## Summary

- make CBL repository sync progress rely on the existing SSE stream instead of recurring REST polling
- use the status endpoint only when EventSource is unavailable or the stream closes permanently
- add regression coverage proving repository-sync progress changes are broadcast to subscribers

## Root cause

The backend already broadcasts the initial CBL repository-sync snapshot and every progress mutation through `GET /readingOrders/repository-sync/events`. The settings composable nevertheless fetched `GET /readingOrders/repository-sync` on load and continued polling it every 750 ms while a sync was running and every 5 seconds while idle. Each SSE message also scheduled another REST refresh, so the live stream was not the source of truth for UI updates.

## Verification

- `go test ./...`
- `npm test`
- `npm run lint` (passes with one pre-existing `vue/no-v-html` warning)
- `npm run build`
