### PR TITLE
Fix page headers to span the full content width

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -848,7 +848,7 @@ onUnmounted(() => {
     />
 
     <section
-      class="content [--content-padding:28px] [--sticky-toolbar-top:0px] [--sticky-toolbar-inline-offset:28px] [--comic-list-sticky-top:82px] [padding:var(--content-padding)] min-w-0 w-full down-tablet:[--content-padding:22px] down-tablet:max-w-none down-tablet:[padding:var(--content-padding)] down-mobile:[--content-padding:14px] down-mobile:[--sticky-toolbar-inline-offset:14px] down-mobile:[padding:var(--content-padding)] down-phone:p-2.5 [&_>_*]:min-w-0 [&_>_*]:max-w-full"
+      class="content [--content-padding:28px] [--sticky-toolbar-top:0px] [--sticky-toolbar-inline-offset:28px] [--comic-list-sticky-top:82px] [padding:var(--content-padding)] min-w-0 w-full down-tablet:[--content-padding:22px] down-tablet:max-w-none down-tablet:[padding:var(--content-padding)] down-mobile:[--content-padding:14px] down-mobile:[--sticky-toolbar-inline-offset:14px] down-mobile:[padding:var(--content-padding)] down-phone:p-2.5 [&_>_*]:min-w-0 [&_>_*]:max-w-full [&_>_.sticky-toolbar]:max-w-none"
     >
       <AppToolbar
         v-if="!isEditing && !isDetail"


### PR DESCRIPTION
## Summary

- allow the shared page toolbar to span the full content-column width
- retain the existing `max-width: 100%` overflow guard for ordinary page content
- fix the right-side header gap across every browse view that uses `AppToolbar`

## Root cause

The content container constrained every direct child to `max-width: 100%`. That rule overrode the toolbar's `max-width: none`, so its negative margins moved it into the left gutter but its width remained capped to the inner content box. The result was a gap on the right equal to both content gutters.

The container now exempts direct `.sticky-toolbar` children with a higher-specificity rule, restoring the intended full-bleed width without relaxing constraints on other content.

## Verification

- `npm test`
- `npm run lint` (passes with one pre-existing `vue/no-v-html` warning)
- `npm run build`
- `npm run format`
- confirmed the production CSS contains `.content > .sticky-toolbar { max-width: none }` after the general direct-child constraint
