### PR TITLE
Open reading orders from dashboard cards

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -877,6 +877,7 @@ onUnmounted(() => {
         :read-only="isReadOnlyGuest"
         @refresh="loadDashboard"
         @open-comic="openComic"
+        @open-reading-order="openReadingOrder"
         @mark-read="markDashboardComicRead"
         @mark-skipped="markDashboardComicSkipped"
       />

--- a/ui/src/features/dashboard/components/DashboardView.vue
+++ b/ui/src/features/dashboard/components/DashboardView.vue
@@ -25,7 +25,7 @@ const props = defineProps({
   },
 })
 
-defineEmits(['open-comic', 'mark-read', 'mark-skipped'])
+defineEmits(['open-comic', 'open-reading-order', 'mark-read', 'mark-skipped'])
 
 const items = computed(() => props.dashboard?.items || [])
 const recentAchievement = computed(() => props.dashboard?.achievements?.recent || null)
@@ -65,7 +65,18 @@ function achievementProgress(achievement) {
             </p>
             <h3>{{ item.name }}</h3>
           </div>
-          <strong>{{ formatProgress(item.progress) }}</strong>
+          <div class="dashboard-card-summary">
+            <strong>{{ formatProgress(item.progress) }}</strong>
+            <BaseButton
+              v-if="item.type === 'readingOrder'"
+              variant="neutral"
+              size="compact-label"
+              :aria-label="`Open reading order ${item.name}`"
+              @click="$emit('open-reading-order', item)"
+            >
+              Open order
+            </BaseButton>
+          </div>
         </div>
 
         <template v-if="item.nextComic">
@@ -156,6 +167,10 @@ function achievementProgress(achievement) {
 
 .dashboard-card-header {
   @apply flex items-start justify-between gap-4 [&_strong]:text-accent [&_strong]:whitespace-nowrap;
+}
+
+.dashboard-card-summary {
+  @apply grid justify-items-end gap-2;
 }
 
 .dashboard-comic {


### PR DESCRIPTION
## Summary

- add an explicit Open order action to reading-order cards in Continue reading
- route the action through the existing reading-order detail flow
- preserve the next-comic action and read/skipped controls

## Testing

- [x] make lint
- [x] make test
- [x] make build

## Security and privacy

- [x] Reviewed changed files for credentials and personal library data
- [x] No authentication, authorization, input validation, or privacy behavior changed