### PR TITLE
feat(comics): merge Metron conflicts instantly

### DIFF
--- a/backend/internal/api/metron_comics.go
+++ b/backend/internal/api/metron_comics.go
@@ -12,6 +12,8 @@ import (
 	"github.com/jmoiron/sqlx"
 )
 
+const metronIssueAlreadyLinkedProblem = "urn:comichero:problem:metron-issue-already-linked"
+
 func registerMetronComicRoutes(api huma.API, db *sqlx.DB, client *metron.Client, covers *CoverCache, importJobs *metronImportJobStore) {
 	huma.Register(api, huma.Operation{
 		OperationID: "searchMetronComics",
@@ -80,13 +82,28 @@ func registerMetronComicRoutes(api huma.API, db *sqlx.DB, client *metron.Client,
 		if err := authorizeMetron(ctx, db, metronScopeImport, "PATCH /comics/{id}/metron"); err != nil {
 			return nil, err
 		}
+		if !input.Body.MergeDuplicate {
+			if err := rejectMetronIssueLinkedToAnotherComic(ctx, db, input.ID, input.Body.MetronIssueID); err != nil {
+				return nil, err
+			}
+		}
 		issue, info, err := fetchMetronIssue(ctx, db, client, input.Body.MetronIssueID, input.Body.Force)
 		if err != nil {
 			return nil, metronAPIError(err)
 		}
+		var merged *ComicDetailOutput
+		if input.Body.MergeDuplicate {
+			merged, err = mergeComicLinkedToMetronIssue(ctx, db, input.ID, input.Body.MetronIssueID)
+			if err != nil {
+				return nil, err
+			}
+		}
 		if info.NotModified {
 			if err := markMetronNotModified(ctx, db, metronResourceIssue, input.Body.MetronIssueID); err != nil {
 				return nil, err
+			}
+			if merged != nil {
+				return withMetronRateLimit(merged, client.CurrentRateLimit()), nil
 			}
 			output, err := getComic(ctx, db, input.ID)
 			if err != nil {
@@ -526,12 +543,40 @@ func rejectMetronIssueLinkedToAnotherComic(ctx context.Context, db *sqlx.DB, com
 		return huma.Error500InternalServerError("failed to check whether the Metron issue is already linked")
 	}
 	log.Printf("Metron comic update rejected: comic_id=%d metron_issue_id=%d already_linked_comic_id=%d", comicID, metronIssueID, linked.ID)
-	return huma.Error409Conflict(fmt.Sprintf(
-		"Metron issue %d is already linked to %s (comic %d). Merge the duplicate comics or choose another Metron issue.",
-		metronIssueID,
-		comicTitle(linked),
-		linked.ID,
-	))
+	return metronIssueLinkConflict(metronIssueID, linked)
+}
+
+func mergeComicLinkedToMetronIssue(ctx context.Context, db *sqlx.DB, comicID, metronIssueID int) (*ComicDetailOutput, error) {
+	if metronIssueID <= 0 {
+		return nil, nil
+	}
+	var linkedID int
+	err := db.GetContext(ctx, &linkedID, `
+		SELECT id
+		FROM comics
+		WHERE metron_issue_id = ? AND id <> ?
+	`, metronIssueID, comicID)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to find the comic linked to this Metron issue")
+	}
+	return mergeComic(ctx, db, comicID, linkedID)
+}
+
+func metronIssueLinkConflict(metronIssueID int, linked Comic) error {
+	return &huma.ErrorModel{
+		Type:   metronIssueAlreadyLinkedProblem,
+		Title:  http.StatusText(http.StatusConflict),
+		Status: http.StatusConflict,
+		Detail: fmt.Sprintf(
+			"Metron issue %d is already linked to %s (comic %d). Merge the duplicate comics or choose another Metron issue.",
+			metronIssueID,
+			comicTitle(linked),
+			linked.ID,
+		),
+	}
 }
 
 func ensureMetronIssueSeriesRow(ctx context.Context, db *sqlx.DB, issue metron.Issue) (int, error) {

--- a/backend/internal/api/metron_import_comics_test.go
+++ b/backend/internal/api/metron_import_comics_test.go
@@ -10,6 +10,7 @@ import (
 	_ "modernc.org/sqlite"
 
 	"github.com/Lofter1/ComicHero/backend/internal/metron"
+	"github.com/danielgtaylor/huma/v2"
 )
 
 func TestSearchMetronIssuesPrefersComicVineID(t *testing.T) {
@@ -62,6 +63,35 @@ func TestUpdateComicFromMetronReportsExistingIssueLink(t *testing.T) {
 	if err.Error() != want {
 		t.Fatalf("error = %q; want %q", err, want)
 	}
+	problem, ok := err.(*huma.ErrorModel)
+	if !ok || problem.Type != metronIssueAlreadyLinkedProblem {
+		t.Fatalf("error problem type = %#v; want %q", problem, metronIssueAlreadyLinkedProblem)
+	}
+}
+
+func TestMergeComicLinkedToMetronIssueKeepsSelectedComic(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	if _, err := db.Exec(`
+		UPDATE users SET is_admin = 1 WHERE id = 1;
+		INSERT INTO comics (id, series, series_year, issue, publisher)
+		VALUES (1, 'Selected', 2026, '1', '');
+		INSERT INTO comics (id, series, series_year, issue, publisher, metron_issue_id)
+		VALUES (2, 'Linked duplicate', 2020, '7', 'Publisher', 77);
+	`); err != nil {
+		t.Fatal(err)
+	}
+
+	merged, err := mergeComicLinkedToMetronIssue(deletionUserContext(1), db, 1, 77)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if merged == nil || merged.Body.ID != 1 {
+		t.Fatalf("merged comic = %#v; want selected comic 1", merged)
+	}
+	if merged.Body.MetronIssueID == nil || *merged.Body.MetronIssueID != 77 {
+		t.Fatalf("Metron issue ID = %#v; want 77", merged.Body.MetronIssueID)
+	}
+	assertComicMergeCount(t, db, `SELECT COUNT(*) FROM comics WHERE id = 2`, 0)
 }
 
 func TestImportMetronComicReusesExistingMetronComic(t *testing.T) {

--- a/backend/internal/api/models_comics.go
+++ b/backend/internal/api/models_comics.go
@@ -97,7 +97,8 @@ type MergeComicInput struct {
 type UpdateComicFromMetronInput struct {
 	ID   int `path:"id" doc:"Local comic identifier." example:"42"`
 	Body struct {
-		MetronIssueID int  `json:"metronIssueId" minimum:"1" doc:"Metron issue identifier to copy metadata from." example:"123456"`
-		Force         bool `json:"force,omitempty" doc:"Bypass Metron conditional requests and download fresh issue metadata." example:"false"`
+		MetronIssueID  int  `json:"metronIssueId" minimum:"1" doc:"Metron issue identifier to copy metadata from." example:"123456"`
+		Force          bool `json:"force,omitempty" doc:"Bypass Metron conditional requests and download fresh issue metadata." example:"false"`
+		MergeDuplicate bool `json:"mergeDuplicate,omitempty" doc:"Merge a comic already linked to this Metron issue into the selected comic before updating it. Admin access is required when a duplicate exists." example:"false"`
 	}
 }

--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -332,6 +332,8 @@ const {
   metronMetadataApplyingID,
   metronMetadataStatus,
   metronMetadataResults,
+  metronMergeConflict,
+  metronMergeSaving,
   mergeOpen: comicMergeOpen,
   mergeCandidates: comicMergeCandidates,
   mergeSearching: comicMergeSearching,
@@ -351,6 +353,8 @@ const {
   resetMetronMetadata,
   searchSelectedComicMetron,
   applyMetronMetadata,
+  mergeMetronConflict,
+  clearMetronMergeConflict,
 } = useComics({
   activeView,
   viewMode,
@@ -691,6 +695,7 @@ function showError(message) {
 
 function clearError() {
   error.value = ''
+  clearMetronMergeConflict()
 }
 
 async function handleMetronImported() {
@@ -856,7 +861,13 @@ onUnmounted(() => {
         :total-count="toolbarTotalCount"
       />
 
-      <ErrorToast :message="error" @dismiss="clearError" />
+      <ErrorToast
+        :message="error"
+        :action-label="isAdmin && metronMergeConflict?.message === error ? 'Merge now' : ''"
+        :action-busy="metronMergeSaving"
+        @action="mergeMetronConflict"
+        @dismiss="clearError"
+      />
 
       <MetronImportMonitor
         v-model:open="metronImportMonitorOpen"

--- a/ui/src/api/client.js
+++ b/ui/src/api/client.js
@@ -1,11 +1,12 @@
 const API_BASE = normalizeApiBase(import.meta.env.VITE_API_BASE)
 
 class ApiError extends Error {
-  constructor(message, { status, rateLimit } = {}) {
+  constructor(message, { status, rateLimit, problemType } = {}) {
     super(message)
     this.name = 'ApiError'
     this.status = status
     this.rateLimit = rateLimit
+    this.problemType = problemType
   }
 }
 
@@ -31,9 +32,11 @@ async function requestWithMeta(path, options = {}) {
 
   if (!response.ok) {
     let message = `Request failed: ${response.status}`
+    let problemType = ''
     try {
       const body = await response.json()
       message = body.detail || body.title || message
+      problemType = body.type || ''
     } catch {
       // Keep the status-based message for empty error responses.
     }
@@ -42,7 +45,7 @@ async function requestWithMeta(path, options = {}) {
         ? `Metron rate limit reached. Try again ${resetLabel(rateLimit)}.`
         : message
     }
-    throw new ApiError(message, { status: response.status, rateLimit })
+    throw new ApiError(message, { status: response.status, rateLimit, problemType })
   }
 
   if (response.status === 204) return { data: null, rateLimit, pagination }
@@ -518,9 +521,10 @@ export function continueMetronImportJob(id) {
   return send(`/metron/imports/${id}/continue`, 'POST', {})
 }
 
-export function updateComicFromMetron(id, metronIssueId) {
+export function updateComicFromMetron(id, metronIssueId, options = {}) {
   return sendWithMeta(`/comics/${id}/metron`, 'PATCH', {
     metronIssueId,
+    ...(options.mergeDuplicate ? { mergeDuplicate: true } : {}),
   })
 }
 

--- a/ui/src/features/comics/useComics.js
+++ b/ui/src/features/comics/useComics.js
@@ -12,6 +12,8 @@ import {
 } from '@/api/client.js'
 import { comicPayload, emptyComic } from '@/features/comics/model.js'
 
+const METRON_ISSUE_ALREADY_LINKED = 'urn:comichero:problem:metron-issue-already-linked'
+
 export function useComics({
   activeView,
   viewMode,
@@ -37,6 +39,8 @@ export function useComics({
   const metronMetadataApplyingID = ref(null)
   const metronMetadataStatus = ref('')
   const metronMetadataResults = ref([])
+  const metronMergeConflict = ref(null)
+  const metronMergeSaving = ref(false)
   const mergeOpen = ref(false)
   const mergeCandidates = ref([])
   const mergeSearching = ref(false)
@@ -348,6 +352,7 @@ export function useComics({
     metronMetadataApplyingID.value = null
     metronMetadataStatus.value = ''
     metronMetadataResults.value = []
+    metronMergeConflict.value = null
   }
 
   async function searchSelectedComicMetron() {
@@ -395,6 +400,7 @@ export function useComics({
     metronMetadataApplyingID.value = metronIssueID
     metronMetadataStatus.value = 'Updating comic metadata from Metron...'
     error.value = ''
+    metronMergeConflict.value = null
 
     try {
       const { data } = await updateComicFromMetron(selectedComic.value.id, metronIssueID)
@@ -406,9 +412,51 @@ export function useComics({
     } catch (err) {
       error.value = err.message
       metronMetadataStatus.value = err.message
+      if (err.problemType === METRON_ISSUE_ALREADY_LINKED) {
+        metronMergeConflict.value = {
+          message: err.message,
+          comicID: selectedComic.value.id,
+          metronIssueID,
+        }
+      }
     } finally {
       metronMetadataApplyingID.value = null
     }
+  }
+
+  async function mergeMetronConflict() {
+    const conflict = metronMergeConflict.value
+    if (!conflict || metronMergeSaving.value) return
+
+    metronMergeSaving.value = true
+    metronMetadataApplyingID.value = conflict.metronIssueID
+    metronMetadataStatus.value = 'Merging duplicate comics and updating Metron metadata...'
+    error.value = conflict.message
+
+    try {
+      const { data } = await updateComicFromMetron(conflict.comicID, conflict.metronIssueID, {
+        mergeDuplicate: true,
+      })
+      applyComicDetailState(data)
+      await loadComics({ force: true })
+      metronMetadataStatus.value = 'Duplicate merged and metadata updated from Metron.'
+      metronMetadataOpen.value = false
+      metronMetadataResults.value = []
+      metronMergeConflict.value = null
+      error.value = ''
+    } catch (err) {
+      metronMergeConflict.value = null
+      error.value = err.message
+      metronMetadataStatus.value = err.message
+    } finally {
+      metronMergeSaving.value = false
+      metronMetadataApplyingID.value = null
+    }
+  }
+
+  function clearMetronMergeConflict() {
+    if (metronMergeSaving.value) return
+    metronMergeConflict.value = null
   }
 
   return {
@@ -421,6 +469,8 @@ export function useComics({
     metronMetadataApplyingID,
     metronMetadataStatus,
     metronMetadataResults,
+    metronMergeConflict,
+    metronMergeSaving,
     mergeOpen,
     mergeCandidates,
     mergeSearching,
@@ -441,5 +491,7 @@ export function useComics({
     resetMetronMetadata,
     searchSelectedComicMetron,
     applyMetronMetadata,
+    mergeMetronConflict,
+    clearMetronMergeConflict,
   }
 }

--- a/ui/src/shared/components/feedback/ErrorToast.vue
+++ b/ui/src/shared/components/feedback/ErrorToast.vue
@@ -4,23 +4,43 @@ defineProps({
     type: String,
     default: '',
   },
+  actionLabel: {
+    type: String,
+    default: '',
+  },
+  actionBusy: {
+    type: Boolean,
+    default: false,
+  },
 })
 
-defineEmits(['dismiss'])
+defineEmits(['action', 'dismiss'])
 </script>
 
 <template>
   <div v-if="message" class="error-toast" role="alert" aria-live="assertive">
     <span>{{ message }}</span>
-    <!-- Native button: toast dismissal inherits the toast's compact contextual styling. -->
-    <button
-      class="dismiss-button"
-      type="button"
-      aria-label="Dismiss error"
-      @click="$emit('dismiss')"
-    >
-      Dismiss
-    </button>
+    <span class="error-toast-actions">
+      <button
+        v-if="actionLabel"
+        class="action-button"
+        type="button"
+        :disabled="actionBusy"
+        @click="$emit('action')"
+      >
+        {{ actionBusy ? 'Merging...' : actionLabel }}
+      </button>
+      <!-- Native button: toast dismissal inherits the toast's compact contextual styling. -->
+      <button
+        class="dismiss-button"
+        type="button"
+        aria-label="Dismiss error"
+        :disabled="actionBusy"
+        @click="$emit('dismiss')"
+      >
+        Dismiss
+      </button>
+    </span>
   </div>
 </template>
 
@@ -36,7 +56,16 @@ defineEmits(['dismiss'])
   overflow-wrap: anywhere;
 }
 
+.error-toast-actions {
+  @apply flex flex-none items-center gap-3;
+}
+
+.action-button,
 .dismiss-button {
   @apply min-h-0 flex-none border-0 bg-transparent p-0 text-sm font-extrabold text-inherit;
+}
+
+.action-button {
+  @apply underline underline-offset-2;
 }
 </style>


### PR DESCRIPTION
## Summary
- add a contextual Merge now action for Metron duplicate-link conflicts
- preserve comic relationships and update Metron metadata in one explicit workflow
- identify the conflict through a structured API problem type

## Validation
- go test ./...
- npm test
- npm run lint
- npm run format
- npm run build