### PR TITLE
feat(ui): open every dashboard content card

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -379,6 +379,14 @@ const {
   markComicSkipped: markDashboardComicSkipped,
 } = useDashboard({ error, quickSavingComicId: quickSavingComicID })
 
+function openDashboardItem(item) {
+  if (item?.type === 'readingOrder') return openReadingOrder(item)
+  if (item?.type === 'arc') return openArc(item)
+  if (item?.type === 'character') return openCharacter(item)
+  if (item?.type === 'characterCollection') return openCollection(item)
+  if (item?.type === 'series') return openSeries(item)
+}
+
 const toolbarResultCount = computed(() => {
   if (activeView.value === 'dashboard') return dashboard.value?.items?.length || 0
   if (activeView.value === 'readingOrders') return visibleOrders.value.length
@@ -888,7 +896,7 @@ onUnmounted(() => {
         :read-only="isReadOnlyGuest"
         @refresh="loadDashboard"
         @open-comic="openComic"
-        @open-reading-order="openReadingOrder"
+        @open-item="openDashboardItem"
         @mark-read="markDashboardComicRead"
         @mark-skipped="markDashboardComicSkipped"
       />

--- a/ui/src/features/dashboard/components/DashboardView.vue
+++ b/ui/src/features/dashboard/components/DashboardView.vue
@@ -25,7 +25,7 @@ const props = defineProps({
   },
 })
 
-defineEmits(['open-comic', 'open-reading-order', 'mark-read', 'mark-skipped'])
+defineEmits(['open-comic', 'open-item', 'mark-read', 'mark-skipped'])
 
 const items = computed(() => props.dashboard?.items || [])
 const recentAchievement = computed(() => props.dashboard?.achievements?.recent || null)
@@ -68,13 +68,12 @@ function achievementProgress(achievement) {
           <div class="dashboard-card-summary">
             <strong>{{ formatProgress(item.progress) }}</strong>
             <BaseButton
-              v-if="item.type === 'readingOrder'"
               variant="neutral"
               size="compact-label"
-              :aria-label="`Open reading order ${item.name}`"
-              @click="$emit('open-reading-order', item)"
+              :aria-label="`Open ${itemTypeLabel(item.type).toLowerCase()} ${item.name}`"
+              @click="$emit('open-item', item)"
             >
-              Open order
+              Open
             </BaseButton>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- rename the dashboard reading-order action from Open order to Open
- add the same Open action to arc, character, character collection, and series cards
- route every dashboard card type to its existing detail view

## Validation
- npm test
- npm run lint
- npm run format
- npm run build