### PR TITLE
Fix responsive UI consistency

### DIFF
--- a/ui/src/App.vue
+++ b/ui/src/App.vue
@@ -1279,7 +1279,7 @@ onUnmounted(() => {
 }
 
 .content {
-  @apply [--content-padding:28px] [--sticky-toolbar-top:0px] [--sticky-toolbar-inline-offset:28px] [--comic-list-sticky-top:82px] p-(--content-padding) min-w-0 w-full down-tablet:[--content-padding:22px] down-tablet:max-w-none down-tablet:p-(--content-padding) down-mobile:[--content-padding:14px] down-mobile:[--sticky-toolbar-inline-offset:14px] down-mobile:p-(--content-padding) down-phone:p-2.5 *:min-w-0 *:max-w-full [&_>_.sticky-toolbar]:max-w-none;
+  @apply [--content-padding:28px] [--sticky-toolbar-top:0px] [--sticky-toolbar-inline-offset:28px] [--comic-list-sticky-top:82px] p-(--content-padding) min-w-0 w-full down-tablet:[--content-padding:22px] down-tablet:[--sticky-toolbar-top:65px] down-tablet:[--sticky-toolbar-inline-offset:22px] down-tablet:[--comic-list-sticky-top:146px] down-tablet:max-w-none down-tablet:p-(--content-padding) down-mobile:[--content-padding:14px] down-mobile:[--sticky-toolbar-top:0px] down-mobile:[--sticky-toolbar-inline-offset:14px] down-mobile:[--comic-list-sticky-top:0px] down-mobile:p-(--content-padding) down-phone:p-2.5 *:min-w-0 *:max-w-full [&_>_.sticky-toolbar]:max-w-none;
 }
 
 .primary-button {

--- a/ui/src/app/components/AppSidebar.vue
+++ b/ui/src/app/components/AppSidebar.vue
@@ -298,11 +298,23 @@ function toggleMobileMenu() {
 @reference '../../styles.css';
 
 .sidebar {
-  @apply sticky top-0 z-30 h-screen border-r border-line [background:var(--sidebar-bg)] p-7 flex flex-col gap-7 [backdrop-filter:blur(12px)] down-tablet:sticky down-tablet:top-0 down-tablet:z-30 down-tablet:h-auto down-tablet:border-r-0 down-tablet:border-b down-tablet:border-line down-tablet:py-3 down-tablet:px-4 down-tablet:gap-3 down-tablet:[box-shadow:0_6px_18px_var(--shadow-soft)] down-tablet:overflow-visible down-mobile:p-3 down-phone:p-2.5 down-tablet:[&:not(.menu-open)_.nav-tabs]:hidden down-tablet:[&.menu-open_.nav-tabs]:grid down-tablet:[&.menu-open_.nav-tabs]:absolute down-tablet:[&.menu-open_.nav-tabs]:top-[calc(100%+8px)] down-tablet:[&.menu-open_.nav-tabs]:right-4 down-tablet:[&.menu-open_.nav-tabs]:w-[min(360px,calc(100vw-36px))] down-tablet:[&.menu-open_.nav-tabs]:grid-cols-1 down-tablet:[&.menu-open_.nav-tabs]:gap-2 down-tablet:[&.menu-open_.nav-tabs]:border down-tablet:[&.menu-open_.nav-tabs]:border-line-strong down-tablet:[&.menu-open_.nav-tabs]:rounded-lg down-tablet:[&.menu-open_.nav-tabs]:z-40 down-tablet:[&.menu-open_.nav-tabs]:bg-surface down-tablet:[&.menu-open_.nav-tabs]:p-2.5 down-tablet:[&.menu-open_.nav-tabs]:[box-shadow:0_18px_40px_var(--shadow-panel)] down-tablet:[&.menu-open_.nav-tabs]:backdrop-filter-none down-tablet:[&.menu-open_.nav-tabs]:isolate down-mobile:[&_.eyebrow]:m-0 down-mobile:[&.menu-open_.nav-tabs]:right-3 down-mobile:[&.menu-open_.nav-tabs]:w-[min(360px,calc(100vw-24px))] down-mobile:[&.menu-open_.sidebar-actions]:grid-cols-1;
+  @apply sticky top-0 z-30 h-screen border-r border-line [background:var(--sidebar-bg)] p-7 flex flex-col gap-7 [backdrop-filter:blur(12px)] down-tablet:sticky down-tablet:top-0 down-tablet:z-30 down-tablet:h-auto down-tablet:border-r-0 down-tablet:border-b down-tablet:border-line down-tablet:py-3 down-tablet:px-4 down-tablet:gap-3 down-tablet:[box-shadow:0_6px_18px_var(--shadow-soft)] down-tablet:overflow-visible down-mobile:p-3 down-phone:p-2.5 down-tablet:[&:not(.menu-open)_.nav-tabs]:hidden down-tablet:[&.menu-open_.nav-tabs]:grid down-tablet:[&.menu-open_.nav-tabs]:absolute down-tablet:[&.menu-open_.nav-tabs]:top-[calc(100%+8px)] down-tablet:[&.menu-open_.nav-tabs]:right-4 down-tablet:[&.menu-open_.nav-tabs]:w-[min(360px,calc(100vw-36px))] down-tablet:[&.menu-open_.nav-tabs]:max-h-[calc(100dvh-88px)] down-tablet:[&.menu-open_.nav-tabs]:overflow-y-auto down-tablet:[&.menu-open_.nav-tabs]:overscroll-contain down-tablet:[&.menu-open_.nav-tabs]:grid-cols-1 down-tablet:[&.menu-open_.nav-tabs]:gap-2 down-tablet:[&.menu-open_.nav-tabs]:border down-tablet:[&.menu-open_.nav-tabs]:border-line-strong down-tablet:[&.menu-open_.nav-tabs]:rounded-lg down-tablet:[&.menu-open_.nav-tabs]:z-40 down-tablet:[&.menu-open_.nav-tabs]:bg-surface down-tablet:[&.menu-open_.nav-tabs]:p-2.5 down-tablet:[&.menu-open_.nav-tabs]:[box-shadow:0_18px_40px_var(--shadow-panel)] down-tablet:[&.menu-open_.nav-tabs]:backdrop-filter-none down-tablet:[&.menu-open_.nav-tabs]:isolate down-mobile:[&_.eyebrow]:m-0 down-mobile:[&.menu-open_.nav-tabs]:right-3 down-mobile:[&.menu-open_.nav-tabs]:w-[min(360px,calc(100vw-24px))] down-mobile:[&.menu-open_.sidebar-actions]:grid-cols-1;
 }
 
 .version-tag {
-  @apply inline-flex border border-line-strong rounded-full bg-surface text-muted py-0.5 px-2 text-xs font-bold leading-tight;
+  @apply inline-flex border border-line-strong rounded-full bg-surface text-muted py-0.5 px-2 text-xs font-bold leading-tight down-tablet:py-0;
+}
+
+.sidebar-header {
+  @apply down-tablet:min-h-10;
+}
+
+.sidebar-branding {
+  @apply down-tablet:flex down-tablet:min-w-0 down-tablet:items-center down-tablet:gap-2.5;
+}
+
+.sidebar-branding h1 {
+  @apply down-tablet:text-2xl down-mobile:text-lg;
 }
 
 .mobile-menu-button {
@@ -338,7 +350,7 @@ function toggleMobileMenu() {
 }
 
 .account-menu-panel {
-  @apply absolute left-0 bottom-[calc(100%+10px)] z-40 w-[min(320px,calc(100vw-36px))] border border-line rounded bg-surface shadow-panel p-2.5 grid gap-2 down-tablet:absolute down-tablet:top-[calc(100%+8px)] down-tablet:right-0 down-tablet:bottom-auto down-tablet:left-auto down-tablet:w-[min(320px,calc(100vw-36px))];
+  @apply absolute left-0 bottom-[calc(100%+10px)] z-40 w-[min(320px,calc(100vw-36px))] border border-line rounded bg-surface shadow-panel p-2.5 grid gap-2 down-tablet:absolute down-tablet:top-[calc(100%+8px)] down-tablet:right-[-64px] down-tablet:bottom-auto down-tablet:left-auto down-tablet:w-[min(320px,calc(100vw-32px))] down-tablet:max-h-[calc(100dvh-88px)] down-tablet:overflow-y-auto down-tablet:overscroll-contain down-mobile:right-[-54px] down-mobile:w-[min(320px,calc(100vw-24px))] down-phone:right-[-54px] down-phone:w-[calc(100vw-20px)];
 }
 
 .account-menu-profile {

--- a/ui/src/features/dashboard/components/DashboardView.vue
+++ b/ui/src/features/dashboard/components/DashboardView.vue
@@ -161,7 +161,7 @@ function achievementProgress(achievement) {
 }
 
 .dashboard-card {
-  @apply grid gap-3.5 border border-line rounded bg-surface p-4 [&_h3]:my-1 [&_h3]:mx-2 [&_p]:m-0;
+  @apply grid gap-3.5 border border-line rounded-xl bg-panel p-4 shadow-soft [&_h3]:my-1 [&_h3]:mx-2 [&_p]:m-0;
 }
 
 .dashboard-card-header {
@@ -181,7 +181,7 @@ function achievementProgress(achievement) {
 }
 
 .empty-panel {
-  @apply border border-dashed border-line-strong rounded bg-surface-soft text-muted p-5 font-extrabold;
+  @apply border border-dashed border-line-strong rounded-xl bg-panel-soft text-muted p-5 font-extrabold;
 }
 
 .dashboard-achievements {
@@ -189,7 +189,7 @@ function achievementProgress(achievement) {
 }
 
 .achievement-summary-card {
-  @apply border border-line rounded bg-surface p-4 [&_h3]:my-1 [&_h3]:mx-2 [&_p]:m-0;
+  @apply border border-line rounded-xl bg-panel p-4 shadow-soft [&_h3]:my-1 [&_h3]:mx-2 [&_p]:m-0;
 }
 
 .dashboard-comic strong {

--- a/ui/src/features/settings/components/AppSettingsView.vue
+++ b/ui/src/features/settings/components/AppSettingsView.vue
@@ -1319,7 +1319,11 @@ function selectSettingsTab(tab) {
 }
 
 .settings-tabs {
-  @apply grid grid-cols-3 gap-1.5 border border-line-strong rounded-lg bg-panel-soft p-1.5;
+  @apply grid grid-cols-3 gap-1.5 border border-line-strong rounded-lg bg-panel-soft p-1.5 down-phone:grid-cols-2;
+}
+
+.settings-tab-button:last-child {
+  @apply down-phone:col-span-2;
 }
 
 .account-settings-panel.metron-scan-panel.settings-tab-panel {

--- a/ui/src/features/settings/components/UserAccessSettings.vue
+++ b/ui/src/features/settings/components/UserAccessSettings.vue
@@ -119,7 +119,14 @@ defineEmits(['update-registration-mode', 'update-public-access', 'generate-invit
 @reference '../../../styles.css';
 
 .user-access-panel {
-  @apply min-w-0 grid grid-cols-3 gap-4 items-stretch down-tablet:grid-cols-1;
+  @apply min-w-0 grid grid-cols-[repeat(auto-fit,minmax(min(100%,280px),1fr))] gap-4 items-stretch;
+  container: user-access / inline-size;
+}
+
+@container user-access (width < 872px) {
+  .access-panel:last-child {
+    @apply col-span-full;
+  }
 }
 
 .access-panel {

--- a/ui/src/features/users/components/UserManagementView.vue
+++ b/ui/src/features/users/components/UserManagementView.vue
@@ -589,7 +589,7 @@ function formatTimestamp(value) {
 }
 
 .detail-panel {
-  @apply min-w-0 max-w-full min-h-panel border border-line rounded bg-panel p-5 shadow-detail down-mobile:min-h-0 down-mobile:p-3.5;
+  @apply min-w-0 max-w-full min-h-panel border border-line rounded-xl bg-panel p-5 shadow-detail down-mobile:min-h-0 down-mobile:p-3.5;
 }
 
 .section-heading {

--- a/ui/src/shared/components/browse/BrowseListTools.vue
+++ b/ui/src/shared/components/browse/BrowseListTools.vue
@@ -186,10 +186,6 @@ const searchModel = computed({
   @apply bg-primary text-white;
 }
 
-.inline-filter-tabs--four {
-  @apply grid-cols-4;
-}
-
 @container browse-tools (width <= 1050px) {
   .browse-list-tools > :is(.inline-filter-tabs, .list-sort-select, .list-direction-select) {
     @apply hidden;
@@ -245,5 +241,9 @@ const searchModel = computed({
 
 .inline-filter-tabs {
   @apply inline-grid grid-cols-3 gap-1 rounded border border-line bg-panel-soft p-1 down-mobile:w-full;
+}
+
+.inline-filter-tabs--four {
+  @apply grid-cols-4;
 }
 </style>

--- a/ui/src/shared/components/feedback/EmptyState.vue
+++ b/ui/src/shared/components/feedback/EmptyState.vue
@@ -15,7 +15,7 @@ defineProps({
 @reference '../../../styles.css';
 
 .empty-state {
-  @apply grid justify-items-start gap-3 rounded border border-dashed border-line-strong bg-panel-soft p-4 text-muted;
+  @apply grid justify-items-start gap-3 rounded-xl border border-dashed border-line-strong bg-panel-soft p-5 text-muted;
 }
 
 .empty-state--roomy {

--- a/ui/src/shared/components/layout/DetailPanel.vue
+++ b/ui/src/shared/components/layout/DetailPanel.vue
@@ -8,7 +8,7 @@
 @reference '../../../styles.css';
 
 .detail-panel {
-  @apply min-h-panel rounded border border-line bg-panel p-5 shadow-detail;
+  @apply min-h-panel rounded-xl border border-line bg-panel p-5 shadow-detail;
 }
 
 @media (width <= 720px) {

--- a/ui/src/styles.css
+++ b/ui/src/styles.css
@@ -1,6 +1,14 @@
 @import 'tailwindcss';
 @config '../tailwind.config.js';
 
+/* Keep overlapping max-width variants in cascade order: narrowest wins. */
+@custom-variant down-laptop (@media (width <= 1180px));
+@custom-variant down-tablet (@media (width <= 960px));
+@custom-variant down-narrow (@media (width <= 760px));
+@custom-variant down-mobile (@media (width <= 720px));
+@custom-variant down-compact (@media (width <= 620px));
+@custom-variant down-phone (@media (width <= 420px));
+
 @layer base {
   body {
     @apply m-0 min-w-80 overflow-x-hidden bg-app font-sans text-ink;

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -145,12 +145,6 @@ export default {
         panel: '22rem',
       },
       screens: {
-        'down-phone': { max: '420px' },
-        'down-compact': { max: '620px' },
-        'down-narrow': { max: '760px' },
-        'down-mobile': { max: '720px' },
-        'down-tablet': { max: '960px' },
-        'down-laptop': { max: '1180px' },
         'desktop-compact': { min: '961px', max: '1440px' },
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- restore correct max-width breakpoint cascade after the Tailwind upgrade
- keep mobile and tablet navigation, account menus, and sticky headers within the viewport
- align tablet and desktop panels, empty states, settings grids, and browse controls with the shared design language

## Verification
- npm run format
- npm run lint
- npm test
- npm run build
- rendered overflow audit across all main routes at 320px, 768px, and 1440px