### PR TITLE
Fix reading-order issue search pagination

### DIFF
--- a/backend/internal/api/comics.go
+++ b/backend/internal/api/comics.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"regexp"
 	"strings"
+	"unicode"
 
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/jmoiron/sqlx"
@@ -157,6 +158,10 @@ func comicListQuery(input *ComicListInput, userID int) (string, []any, error) {
 		terms := strings.Fields(textQuery)
 
 		for _, term := range terms {
+			term = strings.TrimFunc(term, unicode.IsPunct)
+			if term == "" {
+				continue
+			}
 			search := "%" + term + "%"
 			query.where(`(
 				c.series LIKE ?

--- a/backend/internal/api/common_test.go
+++ b/backend/internal/api/common_test.go
@@ -92,3 +92,22 @@ func TestComicListQuery(t *testing.T) {
 		}
 	}
 }
+
+func TestComicListQueryNormalizesTitleStyleYear(t *testing.T) {
+	_, args, err := comicListQuery(&ComicListInput{Query: "Ultimates (2016) #4"}, 1)
+	if err != nil {
+		t.Fatalf("comicListQuery returned error: %v", err)
+	}
+
+	if len(args) != 12 {
+		t.Fatalf("args = %#v; want user, issue, and two five-column search terms", args)
+	}
+	if args[1] != "4" {
+		t.Fatalf("issue arg = %#v; want 4", args[1])
+	}
+	for index, arg := range args[7:] {
+		if arg != "%2016%" {
+			t.Fatalf("year arg %d = %#v; want %%2016%%", index, arg)
+		}
+	}
+}

--- a/ui/src/features/reading-orders/components/ReadingOrderEditor.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrderEditor.vue
@@ -36,6 +36,13 @@ const comicSearch = ref('')
 const comicSearchResults = ref([])
 const comicSearchLoading = ref(false)
 const comicSearchError = ref('')
+const comicSearchPage = ref(0)
+const comicSearchPagination = ref({
+  limit: 8,
+  offset: 0,
+  total: 0,
+  hasMore: false,
+})
 const readingOrderSearch = ref('')
 const sectionTitle = ref('')
 const sectionDescription = ref('')
@@ -48,6 +55,9 @@ let comicSearchRequestId = 0
 
 const orderEntries = computed(() => props.form.entries || props.form.comics || [])
 const entryPageState = computed(() => readingOrderEditorPage(orderEntries.value, entryPage.value))
+const comicSearchPageCount = computed(() =>
+  Math.max(1, Math.ceil(comicSearchPagination.value.total / comicSearchPagination.value.limit)),
+)
 const coverPreview = computed(() => {
   if (props.form.coverImageData) return props.form.coverImageData
   if (props.form.image) return assetURL(props.form.image)
@@ -72,6 +82,7 @@ watch(
 watch(
   comicSearch,
   () => {
+    comicSearchPage.value = 0
     queueComicSearch()
   },
   { immediate: true },
@@ -97,16 +108,28 @@ async function searchComicsForReadingOrder() {
   try {
     const page = await listComics({
       q,
-      limit: 8,
-      offset: 0,
+      limit: comicSearchPagination.value.limit,
+      offset: comicSearchPage.value * comicSearchPagination.value.limit,
     })
 
     if (requestId === comicSearchRequestId) {
       comicSearchResults.value = page.items
+      comicSearchPagination.value = {
+        limit: page.limit,
+        offset: page.offset,
+        total: page.total,
+        hasMore: page.hasMore,
+      }
     }
   } catch (error) {
     if (requestId === comicSearchRequestId) {
       comicSearchResults.value = []
+      comicSearchPagination.value = {
+        ...comicSearchPagination.value,
+        offset: 0,
+        total: 0,
+        hasMore: false,
+      }
       comicSearchError.value = error?.message || 'Could not search comics.'
     }
   } finally {
@@ -325,6 +348,15 @@ function clearComicSearch() {
   comicSearch.value = ''
 }
 
+function goToComicSearchPage(page) {
+  const nextPage = Math.min(Math.max(0, page), comicSearchPageCount.value - 1)
+  if (nextPage === comicSearchPage.value) return
+
+  clearTimeout(comicSearchTimer)
+  comicSearchPage.value = nextPage
+  searchComicsForReadingOrder()
+}
+
 function removeEntry(index) {
   collapseRemovedEntry(index)
 
@@ -520,6 +552,19 @@ function endDrag() {
             </div>
 
             <p v-else class="muted block text-muted">No comics match that search.</p>
+
+            <ReadingOrderEntryPagination
+              v-if="!comicSearchLoading && comicSearchPageCount > 1"
+              class="comic-search-pagination"
+              :page="comicSearchPage"
+              :page-count="comicSearchPageCount"
+              :start="comicSearchPagination.offset"
+              :end="comicSearchPagination.offset + comicSearchResults.length"
+              :total="comicSearchPagination.total"
+              aria-label="Issue search result pages"
+              item-label="Results"
+              @go="goToComicSearchPage"
+            />
           </div>
 
           <div
@@ -855,7 +900,7 @@ function endDrag() {
 }
 
 .reading-order-editor-layout {
-  @apply grid grid-cols-[minmax(320px,420px)_minmax(620px,1fr)] items-start gap-4 border-t border-line pt-3.5 down-laptop:grid-cols-1 [&_.entry-section]:border-t-0 [&_.entry-section]:pt-0;
+  @apply grid grid-cols-[minmax(320px,420px)_minmax(0,1fr)] items-start gap-4 border-t border-line pt-3.5 down-laptop:grid-cols-1 [&_.entry-section]:border-t-0 [&_.entry-section]:pt-0;
 }
 
 .reading-order-search-column {
@@ -892,6 +937,10 @@ function endDrag() {
 
 .comic-add-result.reading-order-add-result {
   @apply flex items-start justify-between gap-3 min-h-20 border border-line rounded bg-surface text-ink py-2.5 px-3 text-left [[draggable='true']]:cursor-grab [&[draggable='true']:active]:cursor-grabbing hover:border-[color-mix(in_srgb,var(--primary)_46%,var(--line-strong))] hover:bg-primary-soft [&_span:first-child]:min-w-0 [&_strong]:[display:-webkit-box] [&_strong]:overflow-hidden [&_strong]:text-ellipsis [&_strong]:whitespace-normal [&_strong]:[-webkit-box-orient:vertical] [&_small]:[display:-webkit-box] [&_small]:overflow-hidden [&_small]:text-ellipsis [&_small]:whitespace-normal [&_small]:[-webkit-box-orient:vertical] [&_strong]:[line-clamp:2] [&_strong]:[-webkit-line-clamp:2] [&_small]:[line-clamp:2] [&_small]:[-webkit-line-clamp:1] [&_small]:text-muted [&_small]:mt-1 [&_.status-pill]:flex-none [&_.status-pill]:mt-0.5;
+}
+
+.comic-search-pagination {
+  @apply mt-0 mb-0;
 }
 
 .section-add-panel {

--- a/ui/src/features/reading-orders/components/ReadingOrderEntryPagination.vue
+++ b/ui/src/features/reading-orders/components/ReadingOrderEntryPagination.vue
@@ -8,6 +8,8 @@ defineProps({
   end: { type: Number, default: 0 },
   total: { type: Number, default: 0 },
   compact: { type: Boolean, default: false },
+  ariaLabel: { type: String, default: 'Reading order entry pages' },
+  itemLabel: { type: String, default: 'Entries' },
 })
 
 defineEmits(['go'])
@@ -17,10 +19,10 @@ defineEmits(['go'])
   <nav
     class="entry-pagination"
     :class="{ 'entry-pagination--compact': compact }"
-    aria-label="Reading order entry pages"
+    :aria-label="ariaLabel"
   >
     <span v-if="compact">Page {{ page + 1 }} of {{ pageCount }}</span>
-    <span v-else>Entries {{ start + 1 }}–{{ end }} of {{ total }}</span>
+    <span v-else>{{ itemLabel }} {{ start + 1 }}–{{ end }} of {{ total }}</span>
     <div>
       <BaseButton
         v-if="!compact"


### PR DESCRIPTION
## Summary

- paginate issue results in the reading-order editor so every library match is reachable
- accept title-style year terms such as Ultimates (2016) #4
- keep the editor grid within mobile, tablet, and desktop viewport widths

## Testing

- [x] make lint
- [x] make test
- [x] make build
- [x] verified result page 2 contains matches 9–12
- [x] verified Ultimates (2016) #4 returns the expected local issue
- [x] verified no horizontal overflow at 375px, 768px, and 1280px

## Security and privacy

- [x] I reviewed logs, screenshots, fixtures, and generated files for credentials, tokens, email addresses, and personal library data.
- [x] This change does not weaken authentication, authorization, input validation, or private-by-default behavior.
