### PR TITLE
feat: extend Metron maintenance resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Join the Discord to ask questions, share feedback and reading orders, and follow
 - Continue active reading from the dashboard and review statistics and achievements.
 - Search and import comics, reading lists, series, arcs, and characters from Metron.
 - Run scheduled Metron discovery jobs for new comics and reading lists.
-- Fill incomplete comic metadata automatically while respecting configurable call limits and retry cooldowns.
+- Fill incomplete comic, character, series, and arc metadata automatically, with optional full comic-list pulls for linked resources.
 - Choose single-user or multi-user setup, invite users, or enable open registration.
 - Optionally give visitors read-only access to shared ComicHero content.
 - Run as a single container or standalone binary backed by SQLite.
@@ -131,7 +131,9 @@ Public read-only access can be enabled separately. Because comics, reading order
 - search for and import individual records;
 - import complete Metron series and reading lists in background jobs;
 - discover newly modified comics and reading lists on a daily, weekly, or monthly schedule;
-- repair missing publisher, cover, cover-date, and description fields on a schedule;
+- repair configurable missing fields on comics, characters, series, and arcs on one shared schedule;
+- optionally pull complete character appearance, series issue, and arc issue lists during maintenance;
+- prioritize the order in which maintenance processes comics, characters, series, and arcs;
 - apply call limits, minimum request intervals, and cooldowns for incomplete records.
 
 Imports and scans are rate-limited upstream. Use your own Metron account, choose conservative schedules, and review Metron’s terms before enabling automation.

--- a/backend/internal/api/metron_comic_scanner.go
+++ b/backend/internal/api/metron_comic_scanner.go
@@ -47,35 +47,93 @@ var metronComicIncompleteConditions = map[string]string{
 	"description": "TRIM(description) = ''",
 }
 
+var metronCharacterIncompleteFields = []string{
+	"description",
+	"image",
+	"aliases",
+}
+
+var metronCharacterIncompleteConditions = map[string]string{
+	"description": "TRIM(ch.description) = ''",
+	"image":       "TRIM(ch.image) = ''",
+	"aliases":     "NOT EXISTS (SELECT 1 FROM character_aliases ca WHERE ca.character_id = ch.id)",
+}
+
+var metronSeriesIncompleteFields = []string{
+	"publisher",
+	"seriesYear",
+	"volume",
+	"yearEnd",
+	"issueCount",
+	"description",
+}
+
+var metronSeriesIncompleteConditions = map[string]string{
+	"publisher":   "TRIM(s.publisher) = ''",
+	"seriesYear":  "s.series_year = 0",
+	"volume":      "s.volume = 0",
+	"yearEnd":     "s.year_end = 0",
+	"issueCount":  "s.issue_count = 0",
+	"description": "TRIM(s.description) = ''",
+}
+
+var metronArcIncompleteFields = []string{
+	"description",
+	"image",
+}
+
+var metronArcIncompleteConditions = map[string]string{
+	"description": "TRIM(a.description) = ''",
+	"image":       "TRIM(a.image) = ''",
+}
+
+var metronMaintenanceResourceOrder = []string{
+	"comics",
+	"characters",
+	"series",
+	"arcs",
+}
+
 type MetronComicScanSettings struct {
-	Enabled             bool     `json:"enabled" doc:"Whether automatic and manual incomplete-data scans are enabled."`
-	ScanComics          bool     `json:"scanComics" doc:"Whether the comics table is included in scans."`
-	Schedule            string   `json:"schedule" enum:"daily,weekly" doc:"Run every day or only on selected weekdays."`
-	Weekdays            []string `json:"weekdays,omitempty" doc:"Lowercase weekday names used by a weekly schedule."`
-	StartTime           string   `json:"startTime" doc:"Server-local scan start time in HH:MM format." example:"02:00"`
-	DailyCallLimit      int      `json:"dailyCallLimit" minimum:"1" doc:"Maximum Metron issue calls shared by all scans during one server-local calendar day." example:"100"`
-	MinIntervalSeconds  int      `json:"minIntervalSeconds" minimum:"0" doc:"Minimum seconds between Metron issue calls made by this incomplete-comic scan." example:"20"`
-	RecheckCooldownDays int      `json:"recheckCooldownDays" minimum:"0" doc:"Days to wait before re-checking a comic after a Metron lookup, including Comic Vine IDs with no match and fields Metron may not provide. 0 disables the cooldown and rechecks every run." example:"30"`
-	IncompleteFields    []string `json:"incompleteFields" doc:"Comic fields whose absence makes a comic eligible for enrichment."`
+	Enabled                   bool     `json:"enabled" doc:"Whether automatic and manual incomplete-data scans are enabled."`
+	ScanComics                bool     `json:"scanComics" doc:"Whether comics are included in scans."`
+	ScanCharacters            bool     `json:"scanCharacters" doc:"Whether Metron-linked characters are included in scans."`
+	ScanSeries                bool     `json:"scanSeries" doc:"Whether Metron-linked series are included in scans."`
+	ScanArcs                  bool     `json:"scanArcs" doc:"Whether Metron-linked story arcs are included in scans."`
+	PullCharacterComics       bool     `json:"pullCharacterComics" doc:"Whether character maintenance also pulls and imports the complete Metron appearance list."`
+	PullSeriesComics          bool     `json:"pullSeriesComics" doc:"Whether series maintenance also pulls and imports the complete Metron issue list."`
+	PullArcComics             bool     `json:"pullArcComics" doc:"Whether story-arc maintenance also pulls and imports the complete Metron issue list."`
+	Schedule                  string   `json:"schedule" enum:"daily,weekly" doc:"Run every day or only on selected weekdays."`
+	Weekdays                  []string `json:"weekdays,omitempty" doc:"Lowercase weekday names used by a weekly schedule."`
+	StartTime                 string   `json:"startTime" doc:"Server-local scan start time in HH:MM format." example:"02:00"`
+	DailyCallLimit            int      `json:"dailyCallLimit" minimum:"1" doc:"Maximum Metron calls shared by all maintenance resource types during one server-local calendar day." example:"100"`
+	MinIntervalSeconds        int      `json:"minIntervalSeconds" minimum:"0" doc:"Minimum seconds between Metron calls made by this maintenance scan." example:"20"`
+	RecheckCooldownDays       int      `json:"recheckCooldownDays" minimum:"0" doc:"Days to wait before re-checking an incomplete record after a Metron lookup. 0 disables the cooldown and rechecks every run." example:"30"`
+	IncompleteFields          []string `json:"incompleteFields" doc:"Comic fields whose absence makes a comic eligible for enrichment."`
+	CharacterIncompleteFields []string `json:"characterIncompleteFields" doc:"Character fields whose absence makes a Metron-linked character eligible for enrichment."`
+	SeriesIncompleteFields    []string `json:"seriesIncompleteFields" doc:"Series fields whose absence makes a Metron-linked series eligible for enrichment."`
+	ArcIncompleteFields       []string `json:"arcIncompleteFields" doc:"Story-arc fields whose absence makes a Metron-linked arc eligible for enrichment."`
+	ResourceOrder             []string `json:"resourceOrder" doc:"Maintenance resource processing order. Contains comics, characters, series, and arcs exactly once."`
 }
 
 type MetronComicScanStatus struct {
-	Settings       MetronComicScanSettings `json:"settings"`
-	Running        bool                    `json:"running"`
-	StartedAt      string                  `json:"startedAt,omitempty"`
-	FinishedAt     string                  `json:"finishedAt,omitempty"`
-	StopReason     string                  `json:"stopReason,omitempty"`
-	Scanned        int                     `json:"scanned"`
-	Updated        int                     `json:"updated"`
-	Failed         int                     `json:"failed"`
-	LastError      string                  `json:"lastError,omitempty"`
-	CallsUsedToday int                     `json:"callsUsedToday"`
-	CallsLeftToday int                     `json:"callsLeftToday"`
-	UsageDate      string                  `json:"usageDate"`
+	Settings        MetronComicScanSettings `json:"settings"`
+	Running         bool                    `json:"running"`
+	StartedAt       string                  `json:"startedAt,omitempty"`
+	FinishedAt      string                  `json:"finishedAt,omitempty"`
+	StopReason      string                  `json:"stopReason,omitempty"`
+	Scanned         int                     `json:"scanned"`
+	Updated         int                     `json:"updated"`
+	Failed          int                     `json:"failed"`
+	LastError       string                  `json:"lastError,omitempty"`
+	CurrentResource string                  `json:"currentResource,omitempty"`
+	CallsUsedToday  int                     `json:"callsUsedToday"`
+	CallsLeftToday  int                     `json:"callsLeftToday"`
+	UsageDate       string                  `json:"usageDate"`
 }
 
 type MetronComicScanEvent struct {
-	Scan MetronComicScanStatus `json:"scan" doc:"Current comic scan settings, quota, and progress."`
+	Scan MetronComicScanStatus `json:"scan" doc:"Current Metron maintenance settings, quota, and progress."`
 }
 
 type metronComicScanUsage struct {
@@ -123,6 +181,13 @@ func defaultMetronComicScanSettings() MetronComicScanSettings {
 		MinIntervalSeconds:  20,
 		RecheckCooldownDays: 30,
 		IncompleteFields:    append([]string(nil), metronComicIncompleteFields...),
+		CharacterIncompleteFields: append(
+			[]string(nil),
+			metronCharacterIncompleteFields...,
+		),
+		SeriesIncompleteFields: append([]string(nil), metronSeriesIncompleteFields...),
+		ArcIncompleteFields:    append([]string(nil), metronArcIncompleteFields...),
+		ResourceOrder:          append([]string(nil), metronMaintenanceResourceOrder...),
 	}
 }
 
@@ -158,21 +223,45 @@ func validateMetronComicScanSettings(settings *MetronComicScanSettings) error {
 	if settings.RecheckCooldownDays < 0 {
 		return errors.New("recheckCooldownDays cannot be negative")
 	}
-	selectedFields := map[string]bool{}
-	for _, field := range settings.IncompleteFields {
-		if _, ok := metronComicIncompleteConditions[field]; !ok {
-			return fmt.Errorf("invalid incomplete field %q", field)
-		}
-		selectedFields[field] = true
+	var err error
+	if settings.IncompleteFields, err = normalizeIncompleteFields(
+		settings.IncompleteFields,
+		metronComicIncompleteFields,
+		metronComicIncompleteConditions,
+		settings.ScanComics,
+		"incompleteFields",
+	); err != nil {
+		return err
 	}
-	if len(selectedFields) == 0 {
-		return errors.New("incompleteFields must contain at least one field")
+	if settings.CharacterIncompleteFields, err = normalizeIncompleteFields(
+		settings.CharacterIncompleteFields,
+		metronCharacterIncompleteFields,
+		metronCharacterIncompleteConditions,
+		settings.ScanCharacters,
+		"characterIncompleteFields",
+	); err != nil {
+		return err
 	}
-	settings.IncompleteFields = settings.IncompleteFields[:0]
-	for _, field := range metronComicIncompleteFields {
-		if selectedFields[field] {
-			settings.IncompleteFields = append(settings.IncompleteFields, field)
-		}
+	if settings.SeriesIncompleteFields, err = normalizeIncompleteFields(
+		settings.SeriesIncompleteFields,
+		metronSeriesIncompleteFields,
+		metronSeriesIncompleteConditions,
+		settings.ScanSeries,
+		"seriesIncompleteFields",
+	); err != nil {
+		return err
+	}
+	if settings.ArcIncompleteFields, err = normalizeIncompleteFields(
+		settings.ArcIncompleteFields,
+		metronArcIncompleteFields,
+		metronArcIncompleteConditions,
+		settings.ScanArcs,
+		"arcIncompleteFields",
+	); err != nil {
+		return err
+	}
+	if settings.ResourceOrder, err = normalizeMetronMaintenanceResourceOrder(settings.ResourceOrder); err != nil {
+		return err
 	}
 	seen := map[string]bool{}
 	weekdays := make([]string, 0, len(settings.Weekdays))
@@ -191,10 +280,61 @@ func validateMetronComicScanSettings(settings *MetronComicScanSettings) error {
 	if settings.Schedule == "weekly" && len(weekdays) == 0 {
 		return errors.New("weekly schedules need at least one weekday")
 	}
-	if !settings.ScanComics {
-		return errors.New("scanComics must be enabled while comics are the only supported data type")
+	if !settings.ScanComics && !settings.ScanCharacters && !settings.ScanSeries && !settings.ScanArcs {
+		return errors.New("at least one maintenance data type must be enabled")
 	}
 	return nil
+}
+
+func normalizeIncompleteFields(
+	values []string,
+	ordered []string,
+	conditions map[string]string,
+	required bool,
+	fieldName string,
+) ([]string, error) {
+	selected := map[string]bool{}
+	for _, field := range values {
+		if _, ok := conditions[field]; !ok {
+			return nil, fmt.Errorf("invalid %s field %q", fieldName, field)
+		}
+		selected[field] = true
+	}
+	if required && len(selected) == 0 {
+		return nil, fmt.Errorf("%s must contain at least one field", fieldName)
+	}
+	normalized := make([]string, 0, len(selected))
+	for _, field := range ordered {
+		if selected[field] {
+			normalized = append(normalized, field)
+		}
+	}
+	return normalized, nil
+}
+
+func normalizeMetronMaintenanceResourceOrder(values []string) ([]string, error) {
+	known := map[string]bool{}
+	for _, resource := range metronMaintenanceResourceOrder {
+		known[resource] = true
+	}
+	seen := map[string]bool{}
+	normalized := make([]string, 0, len(metronMaintenanceResourceOrder))
+	for _, resource := range values {
+		resource = strings.ToLower(strings.TrimSpace(resource))
+		if !known[resource] {
+			return nil, fmt.Errorf("invalid maintenance resource %q", resource)
+		}
+		if !seen[resource] {
+			seen[resource] = true
+			normalized = append(normalized, resource)
+		}
+	}
+	for _, resource := range metronMaintenanceResourceOrder {
+		if !seen[resource] {
+			normalized = append(normalized, resource)
+		}
+	}
+	return normalized, nil
 }
 
 func saveMetronComicScanSettings(ctx context.Context, db *sqlx.DB, settings MetronComicScanSettings) error {
@@ -223,7 +363,7 @@ func (s *metronComicScanner) scheduleLoop(ctx context.Context) {
 
 func (s *metronComicScanner) checkSchedule(ctx context.Context, now time.Time) {
 	settings, err := loadMetronComicScanSettings(ctx, s.db)
-	if err != nil || !settings.Enabled || !settings.ScanComics || now.Format("15:04") != settings.StartTime {
+	if err != nil || !settings.Enabled || now.Format("15:04") != settings.StartTime {
 		return
 	}
 	if settings.Schedule == "weekly" {
@@ -257,8 +397,8 @@ func (s *metronComicScanner) trigger(reason string) error {
 	if err != nil {
 		return err
 	}
-	if !settings.Enabled || !settings.ScanComics {
-		return errors.New("comic scanning is disabled")
+	if !settings.Enabled {
+		return errors.New("Metron maintenance is disabled")
 	}
 	s.mu.Lock()
 	if s.status.Running {
@@ -288,81 +428,83 @@ func (s *metronComicScanner) stopScan(reason string) bool {
 }
 
 func (s *metronComicScanner) run(ctx context.Context, settings MetronComicScanSettings) {
-	rows, err := selectIncompleteComics(ctx, s.db, settings, time.Now())
-	if err == nil {
-		s.setScanned(len(rows))
-		var nextRequest time.Time
-		interval := time.Duration(settings.MinIntervalSeconds) * time.Second
-		claimRequest := func() (bool, error) {
-			if waitErr := waitForComicScanInterval(ctx, &nextRequest, interval); waitErr != nil {
-				return false, waitErr
-			}
-			return claimMetronComicScanCall(ctx, s.db, settings.DailyCallLimit, time.Now())
-		}
-	scanRows:
-		for _, row := range rows {
-			if ctx.Err() != nil {
-				break
-			}
-			claimed, claimErr := claimRequest()
-			if claimErr != nil {
-				if ctx.Err() != nil {
-					break
-				}
-				err = claimErr
-				break
-			}
-			if !claimed {
-				s.setStopReason("daily quota used")
-				break
-			}
+	now := time.Now()
+	var err error
+	comics := []incompleteComicRow{}
+	characters := []incompleteMetronRow{}
+	series := []incompleteMetronRow{}
+	arcs := []incompleteMetronRow{}
 
-			var issue *metron.Issue
-			var fetchErr error
-			if row.MetronID.Valid {
-				issue, fetchErr = s.client.GetIssue(ctx, int(row.MetronID.Int64))
-			} else {
-				matches, searchErr := s.client.SearchIssuesByComicVineID(ctx, int(row.ComicVineID.Int64))
-				if searchErr != nil {
-					fetchErr = searchErr
-				} else if len(matches) == 0 {
-					if markErr := markIncompleteComicChecked(ctx, s.db, row.ID, time.Now()); markErr != nil {
-						s.recordFailure(row.ID, fmt.Errorf("mark unmatched comic as checked: %w", markErr))
-					}
-					continue
-				} else if len(matches) > 1 {
-					fetchErr = fmt.Errorf("Comic Vine ID %d returned %d Metron issues", row.ComicVineID.Int64, len(matches))
-				} else {
-					claimed, claimErr = claimRequest()
-					if claimErr != nil {
-						if ctx.Err() == nil {
-							err = claimErr
-						}
-						break scanRows
-					}
-					if !claimed {
-						s.setStopReason("daily quota used")
-						break scanRows
-					}
-					issue, fetchErr = s.client.GetIssue(ctx, matches[0].ID)
+	if settings.ScanComics {
+		comics, err = selectIncompleteComics(ctx, s.db, settings, now)
+	}
+	if err == nil && settings.ScanCharacters {
+		characters, err = selectIncompleteCharacters(ctx, s.db, settings, now)
+	}
+	if err == nil && settings.ScanSeries {
+		series, err = selectIncompleteSeries(ctx, s.db, settings, now)
+	}
+	if err == nil && settings.ScanArcs {
+		arcs, err = selectIncompleteArcs(ctx, s.db, settings, now)
+	}
+
+	if err == nil {
+		s.setScanned(len(comics) + len(characters) + len(series) + len(arcs))
+		budget := metronMaintenanceBudget{
+			db:       s.db,
+			limit:    settings.DailyCallLimit,
+			interval: time.Duration(settings.MinIntervalSeconds) * time.Second,
+		}
+		scanCtx := ctx
+		needsUser := (settings.PullCharacterComics && len(characters) > 0) ||
+			(settings.PullSeriesComics && len(series) > 0) ||
+			(settings.PullArcComics && len(arcs) > 0)
+		if needsUser {
+			var userID int
+			userID, err = ensureDefaultUser(ctx, s.db)
+			if err == nil {
+				scanCtx = context.WithValue(ctx, contextUserIDKey{}, userID)
+			}
+		}
+		resourceOrder, orderErr := normalizeMetronMaintenanceResourceOrder(settings.ResourceOrder)
+		if err == nil {
+			err = orderErr
+		}
+		for _, resource := range resourceOrder {
+			if err != nil {
+				break
+			}
+			switch resource {
+			case "comics":
+				if len(comics) > 0 {
+					s.setCurrentResource(resource)
+					err = s.scanIncompleteComics(scanCtx, comics, &budget)
+				}
+			case "characters":
+				if len(characters) > 0 {
+					s.setCurrentResource(resource)
+					err = s.scanIncompleteCharacters(scanCtx, characters, settings.PullCharacterComics, &budget)
+				}
+			case "series":
+				if len(series) > 0 {
+					s.setCurrentResource(resource)
+					err = s.scanIncompleteSeries(scanCtx, series, settings.PullSeriesComics, &budget)
+				}
+			case "arcs":
+				if len(arcs) > 0 {
+					s.setCurrentResource(resource)
+					err = s.scanIncompleteArcs(scanCtx, arcs, settings.PullArcComics, &budget)
 				}
 			}
-			if fetchErr != nil {
-				if ctx.Err() != nil {
-					break
-				}
-				s.recordFailure(row.ID, fmt.Errorf("fetch Metron issue: %w", fetchErr))
-				continue
-			}
-			if enrichErr := enrichIncompleteComicFromMetron(ctx, s.db, s.covers, row.ID, *issue); enrichErr != nil {
-				s.recordFailure(row.ID, enrichErr)
-			} else {
-				s.incrementUpdated()
-			}
+		}
+		if errors.Is(err, errMetronMaintenanceQuotaUsed) {
+			s.setStopReason("daily quota used")
+			err = nil
 		}
 	}
 	s.mu.Lock()
 	s.status.Running = false
+	s.status.CurrentResource = ""
 	s.status.FinishedAt = time.Now().UTC().Format(time.RFC3339)
 	if err != nil {
 		s.status.StopReason = err.Error()
@@ -376,10 +518,286 @@ func (s *metronComicScanner) run(ctx context.Context, settings MetronComicScanSe
 	s.broadcastSnapshot()
 }
 
+var errMetronMaintenanceQuotaUsed = errors.New("daily Metron maintenance quota used")
+
+type metronMaintenanceBudget struct {
+	db          *sqlx.DB
+	limit       int
+	interval    time.Duration
+	nextRequest time.Time
+}
+
+func (b *metronMaintenanceBudget) claim(ctx context.Context) error {
+	if err := waitForComicScanInterval(ctx, &b.nextRequest, b.interval); err != nil {
+		return err
+	}
+	claimed, err := claimMetronComicScanCall(ctx, b.db, b.limit, time.Now())
+	if err != nil {
+		return err
+	}
+	if !claimed {
+		return errMetronMaintenanceQuotaUsed
+	}
+	return nil
+}
+
+func (s *metronComicScanner) scanIncompleteComics(ctx context.Context, rows []incompleteComicRow, budget *metronMaintenanceBudget) error {
+	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := budget.claim(ctx); err != nil {
+			return err
+		}
+
+		var issue *metron.Issue
+		var fetchErr error
+		if row.MetronID.Valid {
+			issue, fetchErr = s.client.GetIssue(ctx, int(row.MetronID.Int64))
+		} else {
+			matches, searchErr := s.client.SearchIssuesByComicVineID(ctx, int(row.ComicVineID.Int64))
+			if searchErr != nil {
+				fetchErr = searchErr
+			} else if len(matches) == 0 {
+				if markErr := markIncompleteComicChecked(ctx, s.db, row.ID, time.Now()); markErr != nil {
+					s.recordFailure("comic", row.ID, fmt.Errorf("mark unmatched comic as checked: %w", markErr))
+				}
+				continue
+			} else if len(matches) > 1 {
+				fetchErr = fmt.Errorf("Comic Vine ID %d returned %d Metron issues", row.ComicVineID.Int64, len(matches))
+			} else {
+				if err := budget.claim(ctx); err != nil {
+					return err
+				}
+				issue, fetchErr = s.client.GetIssue(ctx, matches[0].ID)
+			}
+		}
+		if fetchErr != nil {
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			s.recordFailure("comic", row.ID, fmt.Errorf("fetch Metron issue: %w", fetchErr))
+			continue
+		}
+		if enrichErr := enrichIncompleteComicFromMetron(ctx, s.db, s.covers, row.ID, *issue); enrichErr != nil {
+			s.recordFailure("comic", row.ID, enrichErr)
+		} else {
+			s.incrementUpdated()
+		}
+	}
+	return nil
+}
+
+func (s *metronComicScanner) scanIncompleteCharacters(ctx context.Context, rows []incompleteMetronRow, pullComics bool, budget *metronMaintenanceBudget) error {
+	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := budget.claim(ctx); err != nil {
+			return err
+		}
+		character, fetchErr := s.client.GetCharacter(ctx, row.MetronID)
+		if fetchErr != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			s.recordFailure("character", row.ID, fmt.Errorf("fetch Metron character: %w", fetchErr))
+			continue
+		}
+		if enrichErr := enrichIncompleteCharacterFromMetron(ctx, s.db, s.covers, row.ID, *character); enrichErr != nil {
+			s.recordFailure("character", row.ID, enrichErr)
+			continue
+		}
+		if pullComics {
+			if importErr := s.pullCharacterComicList(ctx, row, budget); importErr != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				if errors.Is(importErr, errMetronMaintenanceQuotaUsed) {
+					return importErr
+				}
+				s.recordFailure("character", row.ID, fmt.Errorf("pull character comic list: %w", importErr))
+				continue
+			}
+		}
+		if markErr := markMetronSynced(ctx, s.db, metronResourceCharacter, row.MetronID, metron.FetchInfo{}); markErr != nil {
+			s.recordFailure("character", row.ID, markErr)
+			continue
+		}
+		s.incrementUpdated()
+	}
+	return nil
+}
+
+func (s *metronComicScanner) scanIncompleteSeries(ctx context.Context, rows []incompleteMetronRow, pullComics bool, budget *metronMaintenanceBudget) error {
+	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := budget.claim(ctx); err != nil {
+			return err
+		}
+		metadata, fetchErr := s.client.GetSeries(ctx, row.MetronID)
+		if fetchErr != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			s.recordFailure("series", row.ID, fmt.Errorf("fetch Metron series: %w", fetchErr))
+			continue
+		}
+		if enrichErr := enrichIncompleteSeriesFromMetron(ctx, s.db, row.ID, *metadata); enrichErr != nil {
+			s.recordFailure("series", row.ID, enrichErr)
+			continue
+		}
+		if pullComics {
+			if listErr := s.pullSeriesComicList(ctx, row, budget); listErr != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				if errors.Is(listErr, errMetronMaintenanceQuotaUsed) {
+					return listErr
+				}
+				s.recordFailure("series", row.ID, fmt.Errorf("pull series comic list: %w", listErr))
+				continue
+			}
+		}
+		if markErr := markMetronSynced(ctx, s.db, metronResourceSeries, row.MetronID, metron.FetchInfo{}); markErr != nil {
+			s.recordFailure("series", row.ID, markErr)
+			continue
+		}
+		s.incrementUpdated()
+	}
+	return nil
+}
+
+func (s *metronComicScanner) scanIncompleteArcs(ctx context.Context, rows []incompleteMetronRow, pullComics bool, budget *metronMaintenanceBudget) error {
+	for _, row := range rows {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if err := budget.claim(ctx); err != nil {
+			return err
+		}
+		metadata, fetchErr := s.client.GetArcMetadata(ctx, row.MetronID)
+		if fetchErr != nil {
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return ctxErr
+			}
+			s.recordFailure("arc", row.ID, fmt.Errorf("fetch Metron arc: %w", fetchErr))
+			continue
+		}
+		if enrichErr := enrichIncompleteArcFromMetron(ctx, s.db, row.ID, *metadata); enrichErr != nil {
+			s.recordFailure("arc", row.ID, enrichErr)
+			continue
+		}
+		if pullComics {
+			issues := []metron.Issue{}
+			listErr := s.client.EachArcIssuePageWithRequest(
+				ctx,
+				row.MetronID,
+				func() error { return budget.claim(ctx) },
+				func(page []metron.Issue, _ int) error {
+					issues = append(issues, page...)
+					return nil
+				},
+			)
+			if listErr != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				if errors.Is(listErr, errMetronMaintenanceQuotaUsed) {
+					return listErr
+				}
+				s.recordFailure("arc", row.ID, fmt.Errorf("pull arc comic list: %w", listErr))
+				continue
+			}
+			if importErr := importMetronArcWithOptions(
+				ctx,
+				s.db,
+				s.client,
+				s.covers,
+				metron.MetronArc{ID: row.MetronID, Issues: issues},
+				true,
+				func(int, int, string) {},
+				defaultMetronImportOptions(),
+			); importErr != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return ctxErr
+				}
+				s.recordFailure("arc", row.ID, fmt.Errorf("import arc comic list: %w", importErr))
+				continue
+			}
+		}
+		if markErr := markMetronSynced(ctx, s.db, metronResourceArc, row.MetronID, metron.FetchInfo{}); markErr != nil {
+			s.recordFailure("arc", row.ID, markErr)
+			continue
+		}
+		s.incrementUpdated()
+	}
+	return nil
+}
+
+func (s *metronComicScanner) pullCharacterComicList(ctx context.Context, row incompleteMetronRow, budget *metronMaintenanceBudget) error {
+	options := defaultMetronImportOptions()
+	return s.client.EachCharacterIssuePageWithRequest(
+		ctx,
+		row.MetronID,
+		func() error { return budget.claim(ctx) },
+		func(issues []metron.Issue, _ int) error {
+			for _, issue := range issues {
+				if err := ctx.Err(); err != nil {
+					return err
+				}
+				comic, err := importMetronCharacterAppearanceIssueWithOptions(
+					ctx,
+					s.db,
+					s.client,
+					s.covers,
+					issue,
+					options,
+				)
+				if err != nil {
+					return err
+				}
+				if err := linkCharacterAppearance(ctx, s.db, row.ID, comic.ID); err != nil {
+					return err
+				}
+			}
+			return nil
+		},
+	)
+}
+
+func (s *metronComicScanner) pullSeriesComicList(ctx context.Context, row incompleteMetronRow, budget *metronMaintenanceBudget) error {
+	options := defaultMetronImportOptions()
+	return s.client.EachSeriesIssuePageWithRequest(
+		ctx,
+		row.MetronID,
+		func() error { return budget.claim(ctx) },
+		func(issues []metron.Issue, _ int) error {
+			_, err := importMetronSeriesWithProgressOptions(
+				ctx,
+				s.db,
+				s.client,
+				s.covers,
+				issues,
+				func(int, int, string) {},
+				options,
+			)
+			return err
+		},
+	)
+}
+
 type incompleteComicRow struct {
 	ID          int           `db:"id"`
 	MetronID    sql.NullInt64 `db:"metron_issue_id"`
 	ComicVineID sql.NullInt64 `db:"comic_vine_id"`
+}
+
+type incompleteMetronRow struct {
+	ID       int `db:"id"`
+	MetronID int `db:"metron_id"`
 }
 
 func selectIncompleteComics(ctx context.Context, db *sqlx.DB, settings MetronComicScanSettings, now time.Time) ([]incompleteComicRow, error) {
@@ -409,6 +827,96 @@ func selectIncompleteComics(ctx context.Context, db *sqlx.DB, settings MetronCom
 	return rows, nil
 }
 
+func selectIncompleteCharacters(ctx context.Context, db *sqlx.DB, settings MetronComicScanSettings, now time.Time) ([]incompleteMetronRow, error) {
+	return selectIncompleteMetronRows(
+		ctx,
+		db,
+		"characters",
+		"ch",
+		"metron_character_id",
+		metronResourceCharacter,
+		settings.CharacterIncompleteFields,
+		metronCharacterIncompleteConditions,
+		settings.RecheckCooldownDays,
+		now,
+	)
+}
+
+func selectIncompleteSeries(ctx context.Context, db *sqlx.DB, settings MetronComicScanSettings, now time.Time) ([]incompleteMetronRow, error) {
+	return selectIncompleteMetronRows(
+		ctx,
+		db,
+		"series",
+		"s",
+		"metron_series_id",
+		metronResourceSeries,
+		settings.SeriesIncompleteFields,
+		metronSeriesIncompleteConditions,
+		settings.RecheckCooldownDays,
+		now,
+	)
+}
+
+func selectIncompleteArcs(ctx context.Context, db *sqlx.DB, settings MetronComicScanSettings, now time.Time) ([]incompleteMetronRow, error) {
+	return selectIncompleteMetronRows(
+		ctx,
+		db,
+		"arcs",
+		"a",
+		"metron_arc_id",
+		metronResourceArc,
+		settings.ArcIncompleteFields,
+		metronArcIncompleteConditions,
+		settings.RecheckCooldownDays,
+		now,
+	)
+}
+
+func selectIncompleteMetronRows(
+	ctx context.Context,
+	db *sqlx.DB,
+	table string,
+	alias string,
+	metronIDColumn string,
+	resourceType string,
+	fields []string,
+	availableConditions map[string]string,
+	cooldownDays int,
+	now time.Time,
+) ([]incompleteMetronRow, error) {
+	conditions := make([]string, 0, len(fields))
+	for _, field := range fields {
+		if condition, ok := availableConditions[field]; ok {
+			conditions = append(conditions, condition)
+		}
+	}
+	if len(conditions) == 0 {
+		return []incompleteMetronRow{}, nil
+	}
+
+	query := fmt.Sprintf(`
+		SELECT %[1]s.id, %[1]s.%[2]s AS metron_id
+		FROM %[3]s %[1]s
+		LEFT JOIN metron_sync_states ms
+			ON ms.resource_type = ? AND ms.metron_id = %[1]s.%[2]s
+		WHERE %[1]s.%[2]s IS NOT NULL
+			AND (%[4]s)
+	`, alias, metronIDColumn, table, strings.Join(conditions, " OR "))
+	args := []any{resourceType}
+	if cooldownDays > 0 {
+		cutoff := now.Add(-time.Duration(cooldownDays) * 24 * time.Hour).UTC().Format(time.RFC3339)
+		query += ` AND (COALESCE(ms.synced_at, '') = '' OR ms.synced_at <= ?)`
+		args = append(args, cutoff)
+	}
+	query += fmt.Sprintf(` ORDER BY %s.id`, alias)
+
+	rows := []incompleteMetronRow{}
+	if err := db.SelectContext(ctx, &rows, query, args...); err != nil {
+		return nil, err
+	}
+	return rows, nil
+}
+
 func waitForComicScanInterval(ctx context.Context, nextRequest *time.Time, interval time.Duration) error {
 	if interval <= 0 {
 		return nil
@@ -423,6 +931,99 @@ func waitForComicScanInterval(ctx context.Context, nextRequest *time.Time, inter
 		}
 	}
 	*nextRequest = time.Now().Add(interval)
+	return nil
+}
+
+func enrichIncompleteCharacterFromMetron(ctx context.Context, db *sqlx.DB, covers *CoverCache, characterID int, character metron.MetronCharacter) error {
+	image := ""
+	if strings.TrimSpace(character.Image) != "" {
+		var current string
+		if err := db.GetContext(ctx, &current, `SELECT image FROM characters WHERE id = ?`, characterID); err != nil {
+			return fmt.Errorf("read character image: %w", err)
+		}
+		if strings.TrimSpace(current) == "" {
+			var err error
+			image, err = localCoverURL(ctx, covers, character.Image)
+			if err != nil {
+				return fmt.Errorf("cache character image: %w", err)
+			}
+		}
+	}
+	tx, err := db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("start character metadata update: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE characters
+		SET description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END,
+			image = CASE WHEN TRIM(image) = '' THEN ? ELSE image END
+		WHERE id = ?
+	`, character.Description, image, characterID); err != nil {
+		return fmt.Errorf("update character metadata: %w", err)
+	}
+	for _, alias := range cleanAliases(character.Aliases) {
+		if _, err := tx.ExecContext(ctx, `
+			INSERT OR IGNORE INTO character_aliases (character_id, alias)
+			VALUES (?, ?)
+		`, characterID, alias); err != nil {
+			return fmt.Errorf("update character aliases: %w", err)
+		}
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("save character metadata: %w", err)
+	}
+	return nil
+}
+
+func enrichIncompleteSeriesFromMetron(ctx context.Context, db *sqlx.DB, seriesID int, series metron.Series) error {
+	tx, err := db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("start series metadata update: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE series
+		SET publisher = CASE WHEN TRIM(publisher) = '' THEN ? ELSE publisher END,
+			series_year = CASE WHEN series_year = 0 AND ? > 0 THEN ? ELSE series_year END,
+			volume = CASE WHEN volume = 0 AND ? > 0 THEN ? ELSE volume END,
+			year_end = CASE WHEN year_end = 0 AND ? > 0 THEN ? ELSE year_end END,
+			issue_count = CASE WHEN issue_count = 0 AND ? > 0 THEN ? ELSE issue_count END,
+			description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END
+		WHERE id = ?
+	`, series.Publisher,
+		series.YearBegan, series.YearBegan,
+		series.Volume, series.Volume,
+		series.YearEnd, series.YearEnd,
+		series.IssueCount, series.IssueCount,
+		series.Description,
+		seriesID,
+	); err != nil {
+		return fmt.Errorf("update series metadata: %w", err)
+	}
+	if _, err := tx.ExecContext(ctx, `
+		UPDATE comics
+		SET series = (SELECT name FROM series WHERE id = ?),
+			series_year = (SELECT series_year FROM series WHERE id = ?)
+		WHERE series_id = ?
+	`, seriesID, seriesID, seriesID); err != nil {
+		return fmt.Errorf("update series comics: %w", err)
+	}
+	if err := tx.Commit(); err != nil {
+		return fmt.Errorf("save series metadata: %w", err)
+	}
+	return nil
+}
+
+func enrichIncompleteArcFromMetron(ctx context.Context, db *sqlx.DB, arcID int, arc metron.MetronArc) error {
+	if _, err := db.ExecContext(ctx, `
+		UPDATE arcs
+		SET description = CASE WHEN TRIM(description) = '' THEN ? ELSE description END,
+			image = CASE WHEN TRIM(image) = '' THEN ? ELSE image END
+		WHERE id = ?
+	`, arc.Description, arc.Image, arcID); err != nil {
+		return fmt.Errorf("update arc metadata: %w", err)
+	}
 	return nil
 }
 
@@ -556,9 +1157,15 @@ func (s *metronComicScanner) incrementUpdated() {
 	s.mu.Unlock()
 	s.broadcastSnapshot()
 }
-func (s *metronComicScanner) recordFailure(comicID int, err error) {
-	message := fmt.Sprintf("comic %d: %v", comicID, err)
-	log.Printf("Metron comic scan failed: %s", message)
+func (s *metronComicScanner) setCurrentResource(resource string) {
+	s.mu.Lock()
+	s.status.CurrentResource = resource
+	s.mu.Unlock()
+	s.broadcastSnapshot()
+}
+func (s *metronComicScanner) recordFailure(resourceType string, localID int, err error) {
+	message := fmt.Sprintf("%s %d: %v", resourceType, localID, err)
+	log.Printf("Metron maintenance failed: %s", message)
 	s.mu.Lock()
 	s.status.Failed++
 	s.status.LastError = message
@@ -629,19 +1236,19 @@ type MetronComicScanStatusOutput struct{ Body MetronComicScanStatus }
 type UpdateMetronComicScanSettingsInput struct{ Body MetronComicScanSettings }
 
 func registerMetronComicScannerRoutes(api huma.API, db *sqlx.DB, scanner *metronComicScanner) {
-	huma.Register(api, huma.Operation{OperationID: "getMetronComicScan", Tags: []string{tagMetron}, Summary: "Get comic scan settings and status", Method: http.MethodGet, Path: "/metron/scans/comics", Errors: []int{401, 403, 500}}, func(ctx context.Context, _ *struct{}) (*MetronComicScanStatusOutput, error) {
+	huma.Register(api, huma.Operation{OperationID: "getMetronComicScan", Tags: []string{tagMetron}, Summary: "Get Metron maintenance settings and status", Method: http.MethodGet, Path: "/metron/scans/comics", Errors: []int{401, 403, 500}}, func(ctx context.Context, _ *struct{}) (*MetronComicScanStatusOutput, error) {
 		if _, err := requireAdminUser(ctx, db); err != nil {
 			return nil, err
 		}
 		return &MetronComicScanStatusOutput{Body: scanner.snapshot(ctx)}, nil
 	})
-	sse.Register(api, huma.Operation{OperationID: "streamMetronComicScan", Tags: []string{tagMetron}, Summary: "Stream comic scan status", Description: "Streams an initial snapshot and live comic scan settings, quota, and progress updates.", Method: http.MethodGet, Path: "/metron/scans/comics/events", Errors: []int{401, 403, 500}}, map[string]any{"scan": MetronComicScanEvent{}}, func(ctx context.Context, _ *struct{}, send sse.Sender) {
+	sse.Register(api, huma.Operation{OperationID: "streamMetronComicScan", Tags: []string{tagMetron}, Summary: "Stream Metron maintenance status", Description: "Streams an initial snapshot and live Metron maintenance settings, quota, and progress updates.", Method: http.MethodGet, Path: "/metron/scans/comics/events", Errors: []int{401, 403, 500}}, map[string]any{"scan": MetronComicScanEvent{}}, func(ctx context.Context, _ *struct{}, send sse.Sender) {
 		if _, err := requireAdminUser(ctx, db); err != nil {
 			return
 		}
 		streamMetronComicScan(ctx, scanner, func(event MetronComicScanEvent) error { return send.Data(event) })
 	})
-	huma.Register(api, huma.Operation{OperationID: "updateMetronComicScan", Tags: []string{tagMetron}, Summary: "Update comic scan settings", Method: http.MethodPut, Path: "/metron/scans/comics", Errors: []int{400, 401, 403, 500}}, func(ctx context.Context, input *UpdateMetronComicScanSettingsInput) (*MetronComicScanStatusOutput, error) {
+	huma.Register(api, huma.Operation{OperationID: "updateMetronComicScan", Tags: []string{tagMetron}, Summary: "Update Metron maintenance settings", Method: http.MethodPut, Path: "/metron/scans/comics", Errors: []int{400, 401, 403, 500}}, func(ctx context.Context, input *UpdateMetronComicScanSettingsInput) (*MetronComicScanStatusOutput, error) {
 		if _, err := requireAdminUser(ctx, db); err != nil {
 			return nil, err
 		}
@@ -649,7 +1256,7 @@ func registerMetronComicScannerRoutes(api huma.API, db *sqlx.DB, scanner *metron
 			return nil, huma.Error400BadRequest(err.Error())
 		}
 		if err := saveMetronComicScanSettings(ctx, db, input.Body); err != nil {
-			return nil, huma.Error500InternalServerError("failed to save comic scan settings")
+			return nil, huma.Error500InternalServerError("failed to save Metron maintenance settings")
 		}
 		select {
 		case scanner.wake <- struct{}{}:
@@ -658,7 +1265,7 @@ func registerMetronComicScannerRoutes(api huma.API, db *sqlx.DB, scanner *metron
 		scanner.broadcastSnapshot()
 		return &MetronComicScanStatusOutput{Body: scanner.snapshot(ctx)}, nil
 	})
-	huma.Register(api, huma.Operation{OperationID: "triggerMetronComicScan", Tags: []string{tagMetron}, Summary: "Trigger comic scan", Method: http.MethodPost, Path: "/metron/scans/comics/trigger", DefaultStatus: http.StatusAccepted, Errors: []int{400, 401, 403, 409, 500}}, func(ctx context.Context, _ *struct{}) (*MetronComicScanStatusOutput, error) {
+	huma.Register(api, huma.Operation{OperationID: "triggerMetronComicScan", Tags: []string{tagMetron}, Summary: "Trigger Metron maintenance", Method: http.MethodPost, Path: "/metron/scans/comics/trigger", DefaultStatus: http.StatusAccepted, Errors: []int{400, 401, 403, 409, 500}}, func(ctx context.Context, _ *struct{}) (*MetronComicScanStatusOutput, error) {
 		if _, err := requireAdminUser(ctx, db); err != nil {
 			return nil, err
 		}
@@ -670,7 +1277,7 @@ func registerMetronComicScannerRoutes(api huma.API, db *sqlx.DB, scanner *metron
 		}
 		return &MetronComicScanStatusOutput{Body: scanner.snapshot(ctx)}, nil
 	})
-	huma.Register(api, huma.Operation{OperationID: "stopMetronComicScan", Tags: []string{tagMetron}, Summary: "Stop comic scan", Method: http.MethodPost, Path: "/metron/scans/comics/stop", Errors: []int{401, 403, 500}}, func(ctx context.Context, _ *struct{}) (*MetronComicScanStatusOutput, error) {
+	huma.Register(api, huma.Operation{OperationID: "stopMetronComicScan", Tags: []string{tagMetron}, Summary: "Stop Metron maintenance", Method: http.MethodPost, Path: "/metron/scans/comics/stop", Errors: []int{401, 403, 500}}, func(ctx context.Context, _ *struct{}) (*MetronComicScanStatusOutput, error) {
 		if _, err := requireAdminUser(ctx, db); err != nil {
 			return nil, err
 		}

--- a/backend/internal/api/metron_comic_scanner.go
+++ b/backend/internal/api/metron_comic_scanner.go
@@ -398,7 +398,7 @@ func (s *metronComicScanner) trigger(reason string) error {
 		return err
 	}
 	if !settings.Enabled {
-		return errors.New("Metron maintenance is disabled")
+		return errors.New("metron maintenance is disabled")
 	}
 	s.mu.Lock()
 	if s.status.Running {

--- a/backend/internal/api/metron_comic_scanner_test.go
+++ b/backend/internal/api/metron_comic_scanner_test.go
@@ -29,7 +29,17 @@ func newMetronComicScannerTestDB(t *testing.T) *sqlx.DB {
 
 func TestMetronComicScanSettingsRoundTrip(t *testing.T) {
 	db := newMetronComicScannerTestDB(t)
-	settings := MetronComicScanSettings{Enabled: true, ScanComics: true, Schedule: "weekly", Weekdays: []string{"friday", "monday"}, StartTime: "03:15", DailyCallLimit: 12, MinIntervalSeconds: 20, IncompleteFields: []string{"publisher", "comicVineId"}}
+	settings := MetronComicScanSettings{
+		Enabled: true, ScanComics: true, ScanCharacters: true, ScanSeries: true, ScanArcs: true,
+		PullCharacterComics: true, PullSeriesComics: true, PullArcComics: true,
+		Schedule: "weekly", Weekdays: []string{"friday", "monday"}, StartTime: "03:15",
+		DailyCallLimit: 12, MinIntervalSeconds: 20,
+		IncompleteFields:          []string{"publisher", "comicVineId"},
+		CharacterIncompleteFields: []string{"description"},
+		SeriesIncompleteFields:    []string{"publisher"},
+		ArcIncompleteFields:       []string{"image"},
+		ResourceOrder:             []string{"arcs", "characters", "series", "comics"},
+	}
 	if err := validateMetronComicScanSettings(&settings); err != nil {
 		t.Fatal(err)
 	}
@@ -40,7 +50,11 @@ func TestMetronComicScanSettingsRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !got.Enabled || got.DailyCallLimit != 12 || got.MinIntervalSeconds != 20 || len(got.Weekdays) != 2 || len(got.IncompleteFields) != 2 {
+	if !got.Enabled || !got.ScanCharacters || !got.ScanSeries || !got.ScanArcs ||
+		!got.PullCharacterComics || !got.PullSeriesComics || !got.PullArcComics ||
+		got.DailyCallLimit != 12 || got.MinIntervalSeconds != 20 ||
+		len(got.Weekdays) != 2 || len(got.IncompleteFields) != 2 ||
+		len(got.ResourceOrder) != 4 || got.ResourceOrder[0] != "arcs" {
 		t.Fatalf("unexpected settings: %+v", got)
 	}
 }
@@ -57,6 +71,14 @@ func TestMetronComicScanLegacySettingsKeepDefaultIncompleteFields(t *testing.T) 
 	if len(settings.IncompleteFields) != len(metronComicIncompleteFields) {
 		t.Fatalf("legacy incomplete fields = %v; want defaults %v", settings.IncompleteFields, metronComicIncompleteFields)
 	}
+	if len(settings.CharacterIncompleteFields) != len(metronCharacterIncompleteFields) ||
+		len(settings.SeriesIncompleteFields) != len(metronSeriesIncompleteFields) ||
+		len(settings.ArcIncompleteFields) != len(metronArcIncompleteFields) {
+		t.Fatalf("legacy resource defaults were not preserved: %+v", settings)
+	}
+	if strings.Join(settings.ResourceOrder, ",") != strings.Join(metronMaintenanceResourceOrder, ",") {
+		t.Fatalf("legacy resource order = %v; want %v", settings.ResourceOrder, metronMaintenanceResourceOrder)
+	}
 }
 
 func TestMetronComicScanSettingsRequireKnownIncompleteFields(t *testing.T) {
@@ -70,6 +92,35 @@ func TestMetronComicScanSettingsRequireKnownIncompleteFields(t *testing.T) {
 	settings.IncompleteFields = append(settings.IncompleteFields, "unknown")
 	if err := validateMetronComicScanSettings(&settings); err == nil {
 		t.Fatal("unknown incomplete field returned nil error")
+	}
+}
+
+func TestMetronMaintenanceCanScanLinkedResourcesWithoutComics(t *testing.T) {
+	settings := defaultMetronComicScanSettings()
+	settings.ScanComics = false
+	settings.ScanCharacters = true
+	settings.CharacterIncompleteFields = []string{"description", "aliases"}
+	if err := validateMetronComicScanSettings(&settings); err != nil {
+		t.Fatalf("validate character-only maintenance: %v", err)
+	}
+
+	settings.CharacterIncompleteFields = nil
+	if err := validateMetronComicScanSettings(&settings); err == nil {
+		t.Fatal("enabled character maintenance accepted no incomplete fields")
+	}
+}
+
+func TestMetronMaintenanceResourceOrderIsNormalized(t *testing.T) {
+	order, err := normalizeMetronMaintenanceResourceOrder([]string{" ARCS ", "comics", "arcs"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"arcs", "comics", "characters", "series"}
+	if strings.Join(order, ",") != strings.Join(want, ",") {
+		t.Fatalf("order = %v; want %v", order, want)
+	}
+	if _, err := normalizeMetronMaintenanceResourceOrder([]string{"publishers"}); err == nil {
+		t.Fatal("unknown maintenance resource was accepted")
 	}
 }
 
@@ -234,6 +285,343 @@ func TestMetronComicScanUsesSelectedIncompleteFields(t *testing.T) {
 	}
 	if len(rows) != 2 || rows[0].MetronID.Int64 != 102 || rows[1].MetronID.Int64 != 103 {
 		t.Fatalf("selected rows = %+v; want Metron issues 102 and 103", rows)
+	}
+}
+
+func TestMetronMaintenanceSelectsIncompleteLinkedResourcesAndRespectsCooldown(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	now := time.Now().UTC()
+	recent := now.Add(-time.Hour).Format(time.RFC3339)
+	if _, err := db.Exec(`
+		INSERT INTO characters (id, name, description, image, metron_character_id)
+		VALUES (1, 'Missing aliases', 'Complete', '/character.jpg', 101);
+		INSERT INTO series (id, name, series_year, publisher, volume, year_end, issue_count, description, metron_series_id)
+		VALUES (1, 'Missing publisher', 2020, '', 2, 2024, 12, 'Complete', 201);
+		INSERT INTO arcs (id, name, description, image, metron_arc_id)
+		VALUES (1, 'Missing image', 'Complete', '', 301);
+		INSERT INTO metron_sync_states (resource_type, metron_id, fully_synced, synced_at)
+		VALUES ('series', 201, 1, ?);
+	`, recent); err != nil {
+		t.Fatalf("seed linked resources: %v", err)
+	}
+
+	settings := defaultMetronComicScanSettings()
+	settings.RecheckCooldownDays = 30
+	settings.CharacterIncompleteFields = []string{"aliases"}
+	settings.SeriesIncompleteFields = []string{"publisher"}
+	settings.ArcIncompleteFields = []string{"image"}
+
+	characters, err := selectIncompleteCharacters(context.Background(), db, settings, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(characters) != 1 || characters[0].MetronID != 101 {
+		t.Fatalf("characters = %+v; want Metron character 101", characters)
+	}
+	series, err := selectIncompleteSeries(context.Background(), db, settings, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(series) != 0 {
+		t.Fatalf("recently checked series = %+v; want none during cooldown", series)
+	}
+	arcs, err := selectIncompleteArcs(context.Background(), db, settings, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(arcs) != 1 || arcs[0].MetronID != 301 {
+		t.Fatalf("arcs = %+v; want Metron arc 301", arcs)
+	}
+
+	series, err = selectIncompleteSeries(context.Background(), db, settings, now.Add(31*24*time.Hour))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(series) != 1 || series[0].MetronID != 201 {
+		t.Fatalf("series after cooldown = %+v; want Metron series 201", series)
+	}
+}
+
+func TestMetronMaintenanceEnrichesLinkedResourceMetadataWithoutOverwritingLocalValues(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	ctx := testUserContext()
+	if _, err := db.Exec(`
+		INSERT INTO characters (id, name, description, image, metron_character_id)
+		VALUES (1, 'Local Character', '', '/keep-character.jpg', 101);
+		INSERT INTO series (id, name, series_year, publisher, volume, year_end, issue_count, description, metron_series_id)
+		VALUES (1, 'Local Series', 2020, 'Keep Publisher', 0, 0, 0, '', 201);
+		INSERT INTO arcs (id, name, description, image, metron_arc_id)
+		VALUES (1, 'Local Arc', '', '/keep-arc.jpg', 301);
+	`); err != nil {
+		t.Fatalf("seed linked resources: %v", err)
+	}
+
+	if err := enrichIncompleteCharacterFromMetron(ctx, db, nil, 1, metron.MetronCharacter{
+		ID: 101, Name: "Remote Character", Description: "Remote description",
+		Image: "/replace-character.jpg", Aliases: []string{"Hero"},
+	}); err != nil {
+		t.Fatalf("enrich character: %v", err)
+	}
+	if err := enrichIncompleteSeriesFromMetron(ctx, db, 1, metron.Series{
+		ID: 201, Name: "Remote Series", Publisher: "Replace Publisher", YearBegan: 2021,
+		Volume: 2, YearEnd: 2025, IssueCount: 24, Description: "Remote description",
+	}); err != nil {
+		t.Fatalf("enrich series: %v", err)
+	}
+	if err := enrichIncompleteArcFromMetron(ctx, db, 1, metron.MetronArc{
+		ID: 301, Name: "Remote Arc", Description: "Remote description", Image: "/replace-arc.jpg",
+	}); err != nil {
+		t.Fatalf("enrich arc: %v", err)
+	}
+
+	var character Character
+	if err := db.Get(&character, `SELECT * FROM characters WHERE id = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if character.Name != "Local Character" || character.Description != "Remote description" ||
+		character.Image != "/keep-character.jpg" {
+		t.Fatalf("character = %+v; want missing description only", character)
+	}
+	var aliases int
+	if err := db.Get(&aliases, `SELECT COUNT(*) FROM character_aliases WHERE character_id = 1 AND alias = 'Hero'`); err != nil || aliases != 1 {
+		t.Fatalf("character aliases = %d, err=%v; want Hero", aliases, err)
+	}
+
+	var gotSeries ComicSeries
+	if err := db.Get(&gotSeries, `SELECT * FROM series WHERE id = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if gotSeries.Name != "Local Series" || gotSeries.Publisher != "Keep Publisher" ||
+		gotSeries.SeriesYear != 2020 || gotSeries.Volume != 2 || gotSeries.YearEnd != 2025 ||
+		gotSeries.IssueCount != 24 || gotSeries.Description != "Remote description" {
+		t.Fatalf("series = %+v; missing metadata was not filled safely", gotSeries)
+	}
+
+	var arc Arc
+	if err := db.Get(&arc, `SELECT * FROM arcs WHERE id = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if arc.Name != "Local Arc" || arc.Description != "Remote description" || arc.Image != "/keep-arc.jpg" {
+		t.Fatalf("arc = %+v; want missing description only", arc)
+	}
+}
+
+func TestMetronMaintenanceProcessesResourcesInConfiguredOrder(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	if _, err := db.Exec(`
+		CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+		INSERT INTO comics (id, series, issue, publisher, metron_issue_id)
+		VALUES (1, 'Local Series', '1', '', 101);
+		INSERT INTO characters (id, name, description, image, metron_character_id)
+		VALUES (1, 'Local Character', '', '', 201);
+		INSERT INTO series (id, name, series_year, publisher, metron_series_id)
+		VALUES (1, 'Local Series', 2020, '', 301);
+		INSERT INTO arcs (id, name, description, image, metron_arc_id)
+		VALUES (1, 'Local Arc', '', '', 401);
+	`); err != nil {
+		t.Fatalf("seed maintenance resources: %v", err)
+	}
+
+	requests := []string{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.Path)
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/arc/401/":
+			_, _ = w.Write([]byte(`{"id":401,"name":"Remote Arc","desc":"Arc description"}`))
+		case "/series/301/":
+			_, _ = w.Write([]byte(`{"id":301,"name":"Remote Series","publisher":{"name":"Publisher"},"year_began":2020}`))
+		case "/character/201/":
+			_, _ = w.Write([]byte(`{"id":201,"name":"Remote Character","desc":"Character description"}`))
+		case "/issue/101/":
+			_, _ = w.Write([]byte(`{"id":101,"number":"1","series":{"name":"Local Series","year_began":2020,"publisher":{"name":"Publisher"}}}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	settings := defaultMetronComicScanSettings()
+	settings.ScanCharacters = true
+	settings.ScanSeries = true
+	settings.ScanArcs = true
+	settings.IncompleteFields = []string{"publisher"}
+	settings.CharacterIncompleteFields = []string{"description"}
+	settings.SeriesIncompleteFields = []string{"publisher"}
+	settings.ArcIncompleteFields = []string{"description"}
+	settings.ResourceOrder = []string{"arcs", "series", "characters", "comics"}
+	settings.DailyCallLimit = 10
+	settings.MinIntervalSeconds = 0
+
+	scanner := NewMetronComicScanner(db, metron.New(metron.Config{BaseURL: server.URL}), nil)
+	scanner.run(context.Background(), settings)
+
+	want := []string{"/arc/401/", "/series/301/", "/character/201/", "/issue/101/"}
+	if strings.Join(requests, ",") != strings.Join(want, ",") {
+		t.Fatalf("request order = %v; want %v", requests, want)
+	}
+}
+
+func TestMetronMaintenanceCanPullFullArcComicList(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	if _, err := db.Exec(`
+		CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+		INSERT INTO arcs (id, name, description, image, metron_arc_id)
+		VALUES (1, 'Local Arc', '', '', 301);
+	`); err != nil {
+		t.Fatalf("seed arc: %v", err)
+	}
+
+	requests := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests[r.URL.Path]++
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/arc/301/":
+			_, _ = w.Write([]byte(`{"id":301,"name":"Remote Arc","desc":"Remote description"}`))
+		case "/arc/301/issue_list/":
+			_, _ = w.Write([]byte(`{"results":[{"issue":{"id":401,"number":"1","series":{"id":501,"name":"Series","year_began":2026,"publisher":{"name":"Publisher"}}}}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	settings := defaultMetronComicScanSettings()
+	settings.ScanComics = false
+	settings.ScanArcs = true
+	settings.PullArcComics = true
+	settings.ArcIncompleteFields = []string{"description"}
+	settings.DailyCallLimit = 10
+	settings.MinIntervalSeconds = 0
+	settings.RecheckCooldownDays = 30
+
+	scanner := NewMetronComicScanner(db, metron.New(metron.Config{BaseURL: server.URL}), nil)
+	scanner.run(context.Background(), settings)
+
+	var description string
+	if err := db.Get(&description, `SELECT description FROM arcs WHERE id = 1`); err != nil {
+		t.Fatal(err)
+	}
+	if description != "Remote description" {
+		t.Fatalf("arc description = %q; want remote metadata", description)
+	}
+	var linked int
+	if err := db.Get(&linked, `
+		SELECT COUNT(*)
+		FROM arc_comics ac
+		JOIN comics c ON c.id = ac.comic_id
+		WHERE ac.arc_id = 1 AND c.metron_issue_id = 401
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if linked != 1 {
+		t.Fatalf("linked arc comics = %d; want one imported comic", linked)
+	}
+	if requests["/arc/301/"] != 1 || requests["/arc/301/issue_list/"] != 1 {
+		t.Fatalf("requests = %#v; want metadata and full comic list", requests)
+	}
+	usage := currentMetronComicScanUsage(context.Background(), db, time.Now())
+	if usage.Calls != 2 {
+		t.Fatalf("Metron calls = %d; want metadata plus comic list", usage.Calls)
+	}
+}
+
+func TestMetronMaintenanceMetadataOnlySkipsArcComicList(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	if _, err := db.Exec(`
+		CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+		INSERT INTO arcs (id, name, description, image, metron_arc_id)
+		VALUES (1, 'Local Arc', '', '', 301);
+	`); err != nil {
+		t.Fatalf("seed arc: %v", err)
+	}
+
+	requests := map[string]int{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests[r.URL.Path]++
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path == "/arc/301/" {
+			_, _ = w.Write([]byte(`{"id":301,"name":"Remote Arc","desc":"Remote description"}`))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	settings := defaultMetronComicScanSettings()
+	settings.ScanComics = false
+	settings.ScanArcs = true
+	settings.PullArcComics = false
+	settings.ArcIncompleteFields = []string{"description"}
+	settings.DailyCallLimit = 10
+	settings.MinIntervalSeconds = 0
+
+	scanner := NewMetronComicScanner(db, metron.New(metron.Config{BaseURL: server.URL}), nil)
+	scanner.run(context.Background(), settings)
+
+	if requests["/arc/301/"] != 1 || requests["/arc/301/issue_list/"] != 0 {
+		t.Fatalf("requests = %#v; metadata-only maintenance must not pull the comic list", requests)
+	}
+	var comics int
+	if err := db.Get(&comics, `SELECT COUNT(*) FROM comics`); err != nil {
+		t.Fatal(err)
+	}
+	if comics != 0 {
+		t.Fatalf("comics = %d; metadata-only maintenance imported comics", comics)
+	}
+	usage := currentMetronComicScanUsage(context.Background(), db, time.Now())
+	if usage.Calls != 1 {
+		t.Fatalf("Metron calls = %d; want metadata only", usage.Calls)
+	}
+}
+
+func TestMetronMaintenanceQuotaAppliesToEveryComicListPage(t *testing.T) {
+	db := newMetronImportTestDB(t)
+	if _, err := db.Exec(`
+		CREATE TABLE app_settings (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+		INSERT INTO arcs (id, name, description, image, metron_arc_id)
+		VALUES (1, 'Local Arc', '', '', 301);
+	`); err != nil {
+		t.Fatalf("seed arc: %v", err)
+	}
+
+	requests := map[string]int{}
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests[r.URL.String()]++
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.String() {
+		case "/arc/301/":
+			_, _ = w.Write([]byte(`{"id":301,"name":"Remote Arc","desc":"Remote description"}`))
+		case "/arc/301/issue_list/":
+			_, _ = w.Write([]byte(`{"count":2,"next":"` + server.URL + `/arc/301/issue_list/?page=2","results":[{"issue":{"id":401,"number":"1","series":{"name":"Series"}}}]}`))
+		case "/arc/301/issue_list/?page=2":
+			_, _ = w.Write([]byte(`{"count":2,"next":null,"results":[{"issue":{"id":402,"number":"2","series":{"name":"Series"}}}]}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	settings := defaultMetronComicScanSettings()
+	settings.ScanComics = false
+	settings.ScanArcs = true
+	settings.PullArcComics = true
+	settings.ArcIncompleteFields = []string{"description"}
+	settings.DailyCallLimit = 2
+	settings.MinIntervalSeconds = 0
+
+	scanner := NewMetronComicScanner(db, metron.New(metron.Config{BaseURL: server.URL}), nil)
+	scanner.run(context.Background(), settings)
+
+	if requests["/arc/301/"] != 1 || requests["/arc/301/issue_list/"] != 1 ||
+		requests["/arc/301/issue_list/?page=2"] != 0 {
+		t.Fatalf("requests = %#v; quota should stop before the second list page", requests)
+	}
+	status := scanner.snapshot(context.Background())
+	if status.StopReason != "daily quota used" || status.CallsUsedToday != 2 {
+		t.Fatalf("status = %+v; want exhausted two-call quota", status)
 	}
 }
 

--- a/backend/internal/metron/arcs.go
+++ b/backend/internal/metron/arcs.go
@@ -79,3 +79,32 @@ func (c *Client) GetArcIssues(ctx context.Context, id int) ([]Issue, error) {
 	}
 	return issues, nil
 }
+
+func (c *Client) EachArcIssuePageWithRequest(ctx context.Context, id int, beforeRequest func() error, handle func([]Issue, int) error) error {
+	next := fmt.Sprintf("/arc/%d/issue_list/", id)
+	var values url.Values
+	for next != "" {
+		if beforeRequest != nil {
+			if err := beforeRequest(); err != nil {
+				return err
+			}
+		}
+		page, err := c.getListPage(ctx, next, values)
+		if err != nil {
+			return err
+		}
+		issues := make([]Issue, 0, len(page.results))
+		for _, raw := range page.results {
+			if issue := object(raw, "issue"); len(issue) > 0 {
+				raw = issue
+			}
+			issues = append(issues, issueFromMap(raw))
+		}
+		if err := handle(issues, page.count); err != nil {
+			return err
+		}
+		next = page.next
+		values = nil
+	}
+	return nil
+}

--- a/backend/internal/metron/characters.go
+++ b/backend/internal/metron/characters.go
@@ -59,9 +59,18 @@ func (c *Client) GetCharacterIssues(ctx context.Context, id int) ([]Issue, error
 }
 
 func (c *Client) EachCharacterIssuePage(ctx context.Context, id int, handle func([]Issue, int) error) error {
+	return c.EachCharacterIssuePageWithRequest(ctx, id, nil, handle)
+}
+
+func (c *Client) EachCharacterIssuePageWithRequest(ctx context.Context, id int, beforeRequest func() error, handle func([]Issue, int) error) error {
 	next := fmt.Sprintf("/character/%d/issue_list/", id)
 	var values url.Values
 	for next != "" {
+		if beforeRequest != nil {
+			if err := beforeRequest(); err != nil {
+				return err
+			}
+		}
 		page, err := c.getListPage(ctx, next, values)
 		if err != nil {
 			return err

--- a/backend/internal/metron/series.go
+++ b/backend/internal/metron/series.go
@@ -66,3 +66,29 @@ func (c *Client) GetSeriesIssues(ctx context.Context, id int) ([]Issue, error) {
 	}
 	return issues, nil
 }
+
+func (c *Client) EachSeriesIssuePageWithRequest(ctx context.Context, id int, beforeRequest func() error, handle func([]Issue, int) error) error {
+	next := fmt.Sprintf("/series/%d/issue_list/", id)
+	var values url.Values
+	for next != "" {
+		if beforeRequest != nil {
+			if err := beforeRequest(); err != nil {
+				return err
+			}
+		}
+		page, err := c.getListPage(ctx, next, values)
+		if err != nil {
+			return err
+		}
+		issues := make([]Issue, 0, len(page.results))
+		for _, raw := range page.results {
+			issues = append(issues, issueFromMap(raw))
+		}
+		if err := handle(issues, page.count); err != nil {
+			return err
+		}
+		next = page.next
+		values = nil
+	}
+	return nil
+}

--- a/ui/src/features/settings/components/MetronSchedulingSettings.vue
+++ b/ui/src/features/settings/components/MetronSchedulingSettings.vue
@@ -31,14 +31,55 @@ const incompleteFieldOptions = [
   { value: 'coverDate', label: 'Cover date' },
   { value: 'description', label: 'Description' },
 ]
+const characterIncompleteFieldOptions = [
+  { value: 'description', label: 'Description' },
+  { value: 'image', label: 'Image' },
+  { value: 'aliases', label: 'Aliases' },
+]
+const seriesIncompleteFieldOptions = [
+  { value: 'publisher', label: 'Publisher' },
+  { value: 'seriesYear', label: 'Start year' },
+  { value: 'volume', label: 'Volume' },
+  { value: 'yearEnd', label: 'End year' },
+  { value: 'issueCount', label: 'Issue count' },
+  { value: 'description', label: 'Description' },
+]
+const arcIncompleteFieldOptions = [
+  { value: 'description', label: 'Description' },
+  { value: 'image', label: 'Image' },
+]
+const maintenanceResourceOptions = [
+  { value: 'comics', label: 'Comics' },
+  { value: 'characters', label: 'Characters' },
+  { value: 'series', label: 'Series' },
+  { value: 'arcs', label: 'Arcs' },
+]
 
 watch(
   () => props.metronComicScan?.settings,
   (settings) => {
     Object.assign(draft, settings || {})
-    if (!Array.isArray(draft.incompleteFields)) {
-      draft.incompleteFields = incompleteFieldOptions.map((option) => option.value)
+    const fieldDefaults = [
+      ['incompleteFields', incompleteFieldOptions],
+      ['characterIncompleteFields', characterIncompleteFieldOptions],
+      ['seriesIncompleteFields', seriesIncompleteFieldOptions],
+      ['arcIncompleteFields', arcIncompleteFieldOptions],
+    ]
+    for (const [field, options] of fieldDefaults) {
+      if (!Array.isArray(draft[field])) {
+        draft[field] = options.map((option) => option.value)
+      }
     }
+    const knownResources = new Set(maintenanceResourceOptions.map((option) => option.value))
+    const resourceOrder = Array.isArray(draft.resourceOrder)
+      ? draft.resourceOrder.filter((resource, index, values) => {
+          return knownResources.has(resource) && values.indexOf(resource) === index
+        })
+      : []
+    for (const option of maintenanceResourceOptions) {
+      if (!resourceOrder.includes(option.value)) resourceOrder.push(option.value)
+    }
+    draft.resourceOrder = resourceOrder
   },
   { immediate: true },
 )
@@ -56,17 +97,72 @@ function toggleWeekday(day, checked) {
   draft.weekdays = [...selected]
 }
 
-function toggleIncompleteField(field, checked) {
-  const selected = new Set(draft.incompleteFields || [])
+function toggleIncompleteField(group, field, checked) {
+  const selected = new Set(draft[group] || [])
   if (checked) selected.add(field)
   else selected.delete(field)
-  draft.incompleteFields = [...selected]
+  draft[group] = [...selected]
+}
+
+function moveMaintenanceResource(index, direction) {
+  const target = index + direction
+  if (target < 0 || target >= draft.resourceOrder.length) return
+  const order = [...draft.resourceOrder]
+  const selected = order[index]
+  order[index] = order[target]
+  order[target] = selected
+  draft.resourceOrder = order
+}
+
+function maintenanceResourceLabel(resource) {
+  return maintenanceResourceOptions.find((option) => option.value === resource)?.label || resource
+}
+
+function maintenanceResourceEnabled(resource) {
+  return Boolean(
+    {
+      comics: draft.scanComics,
+      characters: draft.scanCharacters,
+      series: draft.scanSeries,
+      arcs: draft.scanArcs,
+    }[resource],
+  )
+}
+
+function maintenanceResourcePullDescription(resource) {
+  if (!maintenanceResourceEnabled(resource)) return 'Disabled — skipped'
+  if (resource === 'comics') return 'Missing issue metadata'
+  const pullsFullList = {
+    characters: draft.pullCharacterComics,
+    series: draft.pullSeriesComics,
+    arcs: draft.pullArcComics,
+  }[resource]
+  return pullsFullList ? 'Metadata, then full comic list' : 'Metadata only'
+}
+
+function maintenanceSettingsValid() {
+  const groups = [
+    [draft.scanComics, draft.incompleteFields],
+    [draft.scanCharacters, draft.characterIncompleteFields],
+    [draft.scanSeries, draft.seriesIncompleteFields],
+    [draft.scanArcs, draft.arcIncompleteFields],
+  ]
+  return (
+    groups.some(([enabled]) => enabled) &&
+    groups.every(([enabled, fields]) => !enabled || fields?.length)
+  )
 }
 
 function comicScanPayload() {
   return {
     enabled: Boolean(draft.enabled),
-    scanComics: true,
+    scanComics: Boolean(draft.scanComics),
+    scanCharacters: Boolean(draft.scanCharacters),
+    scanSeries: Boolean(draft.scanSeries),
+    scanArcs: Boolean(draft.scanArcs),
+    pullCharacterComics: Boolean(draft.pullCharacterComics),
+    pullSeriesComics: Boolean(draft.pullSeriesComics),
+    pullArcComics: Boolean(draft.pullArcComics),
     schedule: draft.schedule || 'daily',
     weekdays: draft.schedule === 'weekly' ? draft.weekdays || [] : [],
     startTime: draft.startTime || '02:00',
@@ -74,6 +170,10 @@ function comicScanPayload() {
     minIntervalSeconds: Math.max(0, Number(draft.minIntervalSeconds) || 0),
     recheckCooldownDays: Math.max(0, Number(draft.recheckCooldownDays) || 0),
     incompleteFields: draft.incompleteFields || [],
+    characterIncompleteFields: draft.characterIncompleteFields || [],
+    seriesIncompleteFields: draft.seriesIncompleteFields || [],
+    arcIncompleteFields: draft.arcIncompleteFields || [],
+    resourceOrder: draft.resourceOrder || maintenanceResourceOptions.map((option) => option.value),
   }
 }
 
@@ -270,10 +370,10 @@ function startComicDiscovery() {
           <p class="eyebrow mt-0 mb-1.5 text-eyebrow text-xs font-bold uppercase">
             Metron maintenance
           </p>
-          <h3>Incomplete comic data</h3>
+          <h3>Incomplete Metron data</h3>
           <p class="muted block text-muted">
-            Choose which missing fields make a comic incomplete. Issue responses also create missing
-            arc and character links without extra detail calls.
+            Fill missing metadata for comics, characters, series, and arcs. For linked resource
+            types, choose whether maintenance should also pull their complete comic lists.
           </p>
         </div>
         <label class="compact-toggle metron-scan-toggle">
@@ -282,19 +382,218 @@ function startComicDiscovery() {
         </label>
       </header>
 
-      <fieldset class="permission-scopes metron-incomplete-fields">
-        <legend>Consider a comic incomplete when it has no</legend>
-        <label v-for="option in incompleteFieldOptions" :key="option.value">
-          <input
-            type="checkbox"
-            :checked="(draft.incompleteFields || []).includes(option.value)"
-            @change="toggleIncompleteField(option.value, $event.target.checked)"
-          />
-          <span>{{ option.label }}</span>
-        </label>
-      </fieldset>
-      <p v-if="!(draft.incompleteFields || []).length" class="access-note">
-        Select at least one field before saving or running this scan.
+      <section class="metron-maintenance-order" aria-labelledby="metron-maintenance-order-title">
+        <header>
+          <div>
+            <h4 id="metron-maintenance-order-title">Pull order</h4>
+            <p class="muted block text-muted">
+              Move resource types into the priority order used by every scheduled or manual run.
+            </p>
+          </div>
+        </header>
+        <ol>
+          <li
+            v-for="(resource, index) in draft.resourceOrder || []"
+            :key="resource"
+            :class="{ 'is-disabled': !maintenanceResourceEnabled(resource) }"
+          >
+            <span class="metron-order-position">{{ index + 1 }}</span>
+            <span class="metron-order-copy">
+              <strong>{{ maintenanceResourceLabel(resource) }}</strong>
+              <small>{{ maintenanceResourcePullDescription(resource) }}</small>
+            </span>
+            <span class="metron-order-actions">
+              <BaseButton
+                variant="neutral"
+                size="compact"
+                :disabled="index === 0"
+                :aria-label="`Move ${maintenanceResourceLabel(resource)} earlier`"
+                @click="moveMaintenanceResource(index, -1)"
+              >
+                Move up
+              </BaseButton>
+              <BaseButton
+                variant="neutral"
+                size="compact"
+                :disabled="index === draft.resourceOrder.length - 1"
+                :aria-label="`Move ${maintenanceResourceLabel(resource)} later`"
+                @click="moveMaintenanceResource(index, 1)"
+              >
+                Move down
+              </BaseButton>
+            </span>
+          </li>
+        </ol>
+        <div class="metron-maintenance-order-help">
+          <strong>How the order works</strong>
+          <ul>
+            <li>
+              At the start of a run, ComicHero finds all eligible incomplete records. Disabled
+              resource types and types with no eligible records are skipped.
+            </li>
+            <li>
+              Resource types run from top to bottom. Within each type, existing records are pulled
+              by local ID, oldest IDs first.
+            </li>
+            <li>
+              Comics pull issue metadata. Characters, series, and arcs pull metadata first; when
+              “full comic list” is selected, that record’s paginated comic list is pulled
+              immediately afterward before moving to the next record.
+            </li>
+            <li>
+              Each metadata request and comic-list page uses the shared call budget and request
+              interval. If the budget runs out, later records and resource types wait for the next
+              run. Successfully checked records observe the re-check cooldown.
+            </li>
+            <li>
+              The eligible queues are a start-of-run snapshot, so comics newly imported from a full
+              list are considered by incomplete-comic maintenance on the next run.
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <div class="metron-maintenance-resources">
+        <section class="metron-maintenance-resource">
+          <header>
+            <label class="compact-toggle">
+              <input v-model="draft.scanComics" type="checkbox" />
+              <span>Comics</span>
+            </label>
+          </header>
+          <fieldset v-if="draft.scanComics" class="permission-scopes metron-incomplete-fields">
+            <legend>Incomplete when missing</legend>
+            <label v-for="option in incompleteFieldOptions" :key="option.value">
+              <input
+                type="checkbox"
+                :checked="(draft.incompleteFields || []).includes(option.value)"
+                @change="
+                  toggleIncompleteField('incompleteFields', option.value, $event.target.checked)
+                "
+              />
+              <span>{{ option.label }}</span>
+            </label>
+          </fieldset>
+          <p v-if="draft.scanComics && !(draft.incompleteFields || []).length" class="access-note">
+            Select at least one comic field.
+          </p>
+        </section>
+
+        <section class="metron-maintenance-resource">
+          <header>
+            <label class="compact-toggle">
+              <input v-model="draft.scanCharacters" type="checkbox" />
+              <span>Characters</span>
+            </label>
+            <label v-if="draft.scanCharacters" class="metron-resource-depth">
+              <span>Pull</span>
+              <BaseSelect v-model="draft.pullCharacterComics">
+                <option :value="false">Metadata only</option>
+                <option :value="true">Metadata + full comic list</option>
+              </BaseSelect>
+            </label>
+          </header>
+          <fieldset v-if="draft.scanCharacters" class="permission-scopes metron-incomplete-fields">
+            <legend>Incomplete when missing</legend>
+            <label v-for="option in characterIncompleteFieldOptions" :key="option.value">
+              <input
+                type="checkbox"
+                :checked="(draft.characterIncompleteFields || []).includes(option.value)"
+                @change="
+                  toggleIncompleteField(
+                    'characterIncompleteFields',
+                    option.value,
+                    $event.target.checked,
+                  )
+                "
+              />
+              <span>{{ option.label }}</span>
+            </label>
+          </fieldset>
+          <p
+            v-if="draft.scanCharacters && !(draft.characterIncompleteFields || []).length"
+            class="access-note"
+          >
+            Select at least one character field.
+          </p>
+        </section>
+
+        <section class="metron-maintenance-resource">
+          <header>
+            <label class="compact-toggle">
+              <input v-model="draft.scanSeries" type="checkbox" />
+              <span>Series</span>
+            </label>
+            <label v-if="draft.scanSeries" class="metron-resource-depth">
+              <span>Pull</span>
+              <BaseSelect v-model="draft.pullSeriesComics">
+                <option :value="false">Metadata only</option>
+                <option :value="true">Metadata + full comic list</option>
+              </BaseSelect>
+            </label>
+          </header>
+          <fieldset v-if="draft.scanSeries" class="permission-scopes metron-incomplete-fields">
+            <legend>Incomplete when missing</legend>
+            <label v-for="option in seriesIncompleteFieldOptions" :key="option.value">
+              <input
+                type="checkbox"
+                :checked="(draft.seriesIncompleteFields || []).includes(option.value)"
+                @change="
+                  toggleIncompleteField(
+                    'seriesIncompleteFields',
+                    option.value,
+                    $event.target.checked,
+                  )
+                "
+              />
+              <span>{{ option.label }}</span>
+            </label>
+          </fieldset>
+          <p
+            v-if="draft.scanSeries && !(draft.seriesIncompleteFields || []).length"
+            class="access-note"
+          >
+            Select at least one series field.
+          </p>
+        </section>
+
+        <section class="metron-maintenance-resource">
+          <header>
+            <label class="compact-toggle">
+              <input v-model="draft.scanArcs" type="checkbox" />
+              <span>Arcs</span>
+            </label>
+            <label v-if="draft.scanArcs" class="metron-resource-depth">
+              <span>Pull</span>
+              <BaseSelect v-model="draft.pullArcComics">
+                <option :value="false">Metadata only</option>
+                <option :value="true">Metadata + full comic list</option>
+              </BaseSelect>
+            </label>
+          </header>
+          <fieldset v-if="draft.scanArcs" class="permission-scopes metron-incomplete-fields">
+            <legend>Incomplete when missing</legend>
+            <label v-for="option in arcIncompleteFieldOptions" :key="option.value">
+              <input
+                type="checkbox"
+                :checked="(draft.arcIncompleteFields || []).includes(option.value)"
+                @change="
+                  toggleIncompleteField('arcIncompleteFields', option.value, $event.target.checked)
+                "
+              />
+              <span>{{ option.label }}</span>
+            </label>
+          </fieldset>
+          <p v-if="draft.scanArcs && !(draft.arcIncompleteFields || []).length" class="access-note">
+            Select at least one arc field.
+          </p>
+        </section>
+      </div>
+      <p
+        v-if="!draft.scanComics && !draft.scanCharacters && !draft.scanSeries && !draft.scanArcs"
+        class="access-note"
+      >
+        Select at least one data type before saving or running maintenance.
       </p>
 
       <div class="metron-scan-fields">
@@ -341,10 +640,10 @@ function startComicDiscovery() {
         </label>
       </div>
       <p class="muted metron-scan-hint block text-muted">
-        Some issues have no publisher, cover date, or synopsis on Metron itself, so they can stay
-        "incomplete" no matter how often they're checked. The cooldown skips a comic for this many
-        days after it was last checked, so those rows stop using up the whole daily call budget. Set
-        to 0 to recheck everything every run.
+        Some records have fields that are also blank on Metron, so they can stay "incomplete" after
+        a check. The cooldown prevents those records from consuming the daily call budget on every
+        run. Full comic lists use additional Metron calls and import missing comics with list
+        metadata. Set the cooldown to 0 to recheck everything every run.
       </p>
 
       <fieldset v-if="draft.schedule === 'weekly'" class="permission-scopes">
@@ -366,6 +665,9 @@ function startComicDiscovery() {
         </div>
         <div v-if="metronComicScan.running">
           <strong>{{ metronComicScan.updated }}</strong>
+          <span v-if="metronComicScan.currentResource">
+            Now pulling {{ maintenanceResourceLabel(metronComicScan.currentResource) }}
+          </span>
           <span
             >updated ({{ metronComicScan.failed }} failed) from
             {{ metronComicScan.scanned }} scanned</span
@@ -387,7 +689,7 @@ function startComicDiscovery() {
         <BaseButton
           variant="primary"
           size="large"
-          :disabled="saving || !(draft.incompleteFields || []).length"
+          :disabled="saving || !maintenanceSettingsValid()"
           @click="save"
         >
           {{ saving ? 'Saving...' : 'Save settings' }}
@@ -396,7 +698,7 @@ function startComicDiscovery() {
           v-if="!metronComicScan.running"
           variant="neutral"
           size="large"
-          :disabled="saving || !draft.enabled || !(draft.incompleteFields || []).length"
+          :disabled="saving || !draft.enabled || !maintenanceSettingsValid()"
           @click="startComicScan"
         >
           {{ saving ? 'Saving and starting...' : 'Scan now' }}
@@ -478,5 +780,78 @@ function startComicDiscovery() {
 .permission-scopes.metron-discovery-types,
 .permission-scopes.metron-incomplete-fields {
   @apply border-0 p-0 m-0 grid grid-cols-[repeat(auto-fit,minmax(126px,1fr))] gap-2 min-w-0 disabled:opacity-55 down-mobile:grid-cols-1;
+}
+
+.metron-maintenance-resources {
+  @apply grid gap-3;
+}
+
+.metron-maintenance-order {
+  @apply grid gap-4 rounded-lg border border-line bg-surface p-4;
+}
+
+.metron-maintenance-order h4,
+.metron-maintenance-order p {
+  @apply m-0;
+}
+
+.metron-maintenance-order > ol {
+  @apply m-0 grid list-none gap-2 p-0;
+}
+
+.metron-maintenance-order > ol > li {
+  @apply grid grid-cols-[2rem_minmax(0,1fr)_auto] items-center gap-3 rounded border border-line bg-surface-soft p-3 down-mobile:grid-cols-[2rem_minmax(0,1fr)];
+}
+
+.metron-maintenance-order > ol > li.is-disabled {
+  @apply opacity-60;
+}
+
+.metron-order-position {
+  @apply inline-flex size-8 items-center justify-center rounded-full bg-primary-soft text-sm font-black text-control;
+}
+
+.metron-order-copy {
+  @apply grid gap-0.5;
+}
+
+.metron-order-copy small {
+  @apply text-xs font-bold text-muted;
+}
+
+.metron-order-actions {
+  @apply flex gap-2 down-mobile:col-span-2 down-mobile:pl-11;
+}
+
+.metron-maintenance-order-help {
+  @apply rounded border border-line bg-surface-soft p-3 text-sm text-muted;
+}
+
+.metron-maintenance-order-help > strong {
+  @apply text-ink;
+}
+
+.metron-maintenance-order-help ul {
+  @apply mb-0 mt-2 grid gap-1.5 pl-5;
+}
+
+.metron-maintenance-resource {
+  @apply grid gap-3 rounded-lg border border-line bg-surface p-4;
+}
+
+.metron-maintenance-resource > header {
+  @apply flex items-center justify-between gap-4 down-mobile:items-stretch down-mobile:flex-col;
+}
+
+.metron-maintenance-resource .compact-toggle {
+  @apply inline-flex min-h-10 items-center gap-2 font-extrabold text-label;
+}
+
+.metron-resource-depth {
+  @apply flex min-w-72 items-center gap-2 text-sm font-extrabold text-muted down-mobile:min-w-0 down-mobile:items-stretch down-mobile:flex-col;
+}
+
+.metron-resource-depth select {
+  @apply min-w-56 down-mobile:w-full;
 }
 </style>


### PR DESCRIPTION
## Summary
- extend incomplete-data maintenance to characters, series, and arcs
- add metadata-only or full comic-list pulls, with per-page quota enforcement
- add configurable resource pull order and live current-resource status

## Verification
- go test ./...
- npm test
- npm run lint
- npm run format -- --check
- npm run build